### PR TITLE
Fix references to 1.1

### DIFF
--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -8,8 +8,8 @@
                class="ed"
                version="5.0-extension w3c-xproc">
   <info>
-    <title>XProc 1.1: Standard Step Library</title>
-    <w3c-shortname>xproc20-steps</w3c-shortname>
+    <title>XProc 3.0: Standard Step Library</title>
+    <w3c-shortname>xproc30-steps</w3c-shortname>
     <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
 
     <bibliorelation role="x-no-errata" type="references"
@@ -17,124 +17,36 @@
     <bibliorelation role="x-no-translations" type="references"
                     xlink:href="http://www.w3.org/2003/03/Translations/byTechnology?technology=xproc">translations</bibliorelation>
 
-    <bibliorelation type="isformatof" xlink:href="steps11.xml">XML</bibliorelation>
-<!--
-    <bibliorelation type="isformatof" xlink:href="changelog.html">ChangeLog</bibliorelation>
--->
-
-<!--
-    <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2010/PR-xproc-20100309/"/>
-    <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2010/WD-xproc-20100105/"/>
-    <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2009/CR-xproc-20090528/"/>
--->
-    <!--
-    <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2008/CR-xproc-20081126/"/>
-    <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2008/WD-xproc-20080814/"/>
-      <bibliorelation type="replaces" xlink:href="http://www.w3.org/TR/2007/WD-xproc-20071129/"/>
-      <bibliorelation type="replaces"
-		xlink:href="http://www.w3.org/TR/2007/WD-xproc-20070920/"/>
-<bibliorelation type="replaces"
-		xlink:href="http://www.w3.org/TR/2007/WD-xproc-20070706/"/>
-<bibliorelation type="replaces"
-		xlink:href="http://www.w3.org/TR/2007/WD-xproc-20070405/"/>
-<bibliorelation type="replaces"
-		xlink:href="http://www.w3.org/TR/2006/WD-xproc-20061117/"/>
--->
-    <authorgroup>
-      <author>
-        <personname>Norman Walsh</personname>
-        <affiliation>
-          <orgname>MarkLogic Corporation</orgname>
-        </affiliation>
-        <email>norman.walsh@marklogic.com</email>
-      </author>
-      <author>
-        <personname>Alex Milowski</personname>
-        <affiliation>
-          <orgname>Invited expert</orgname>
-        </affiliation>
-        <email>alex@milowski.org</email>
-      </author>
-      <author>
-        <personname>Henry S. Thompson</personname>
-        <affiliation>
-          <orgname>University of Edinburgh</orgname>
-        </affiliation>
-        <email>ht@inf.ed.ac.uk</email>
-      </author>
-    </authorgroup>
+    <bibliorelation type="isformatof" xlink:href="steps30.xml">XML</bibliorelation>
+<authorgroup>
+  <author>
+    <personname>Achim Berndzen</personname>
+  </author>
+  <author>
+    <personname>Gerrit Imsieke</personname>
+  </author>
+  <author>
+    <personname>Norman Walsh</personname>
+  </author>
+</authorgroup>
 
 <abstract>
 <para>This specification describes the standard step vocabulary of
-<citetitle>XProc 1.1: An XML Pipeline Language</citetitle>.</para>
+<citetitle>XProc 3.0: An XML Pipeline Language</citetitle>.</para>
 </abstract>
 
 <legalnotice role="status">
 
 <para><emphasis>This section describes the status of this document at
 the time of its publication. Other documents may supersede this
-document. A list of current W3C publications and the latest revision
-of this technical report can be found in the
-<link xlink:href="http://www.w3.org/TR/">W3C technical reports index</link> at
-http://www.w3.org/TR/.</emphasis></para>
+document.</emphasis></para>
 
-<para>Publication as a First Public Working Draft does not imply
-endorsement by the W3C Membership. This is a draft document and may be
-updated, replaced or obsoleted by other documents at any time. It is
-inappropriate to cite this document as other than work in
-progress.</para>
-
-<para><!--This document is an editor's draft without normative standing.
--->This document is a
-product of the
-<link xlink:href="http://www.w3.org/XML/Processing/" >XML Processing Model
-Working Group</link>
-as part of the W3C
-<link xlink:href="http://www.w3.org/XML/Activity">XML Activity</link>.
-This draft is a first attempt to address some of the requirements of
-<biblioref linkend="use-cases"/>. It is in many ways substantially incomplete.
-The Working Group is publishing it in order to establish an intended direction
-and to provide an official opportunity for comment.
-</para>
-
-<para>Please report errors in this document by
-<link xlink:href="https://github.com/xproc/specification/issues">raising
-issues</link> on the
-<link xlink:href="https://github.com/xproc/specification">specification
-repository</link>.
-Alternatively, you may report errors in this document to the public
-mailing list
-<link xlink:href="mailto:public-xml-processing-model-comments@w3.org"
->public-xml-processing-model-comments@w3.org</link> (public
-<link xlink:href="http://lists.w3.org/Archives/Public/public-xml-processing-model-comments/"
->archives</link> are available).</para>
-
-<!--
-<para>There is an
-<link xlink:href="http://www.w3.org/XML/XProc/2010/02/ir.html">Implementation
-Report for XProc 1.0</link>. It documents the performance of implementations
-against the
-<link xlink:href="http://tests.xproc.org/">XProc 1.0 Test Suite</link>.
-At this time, there are no such reports for XProc 2.0.
-</para>
--->
-
-<para>This document was produced by a group operating under the <link
-xlink:href="http://www.w3.org/Consortium/Patent-Policy-20040205/">5
-February 2004 W3C Patent Policy</link>. W3C maintains a <link
-xlink:href="http://www.w3.org/2004/01/pp-impl/38398/status">public
-list of any patent disclosures</link> made in connection with the
-deliverables of the group; that page also includes instructions for
-disclosing a patent. An individual who has actual knowledge of a
-patent which the individual believes contains <link
-xlink:href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
-Claim(s)</link> must disclose the information in accordance with <link
-xlink:href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-6 of the W3C Patent Policy</link>.</para>
-
-<para>This document is governed by the
-<link xml:id="w3c_process_revision" xlink:href="http://www.w3.org/2005/10/Process-20051014/">14 October 2005 W3C Process Document</link>.</para>
+<para>This document is derived from
+<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
+An XML Pipeline Language</link> published by the W3C. See also
+<xref linkend="credits"/>.</para>
 </legalnotice>
+
 </info>
 
 <section xml:id="introduction">
@@ -3840,5 +3752,19 @@ specification.</para>
 
 <xi:include href="errors.xml"/>
 <xi:include href="error-codes.xml"/>
+
+<appendix xml:id="credits">
+<title>Credits</title>
+
+<para>This document is derived from
+<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
+An XML Pipeline Language</link> published by the W3C. It was developed
+by the <citetitle>XML Processing Model Working Group</citetitle> and edited by
+Norman Walsh, Alex Miłowski, and Henry Thompson.</para>
+
+<para>The editors of this specification extend their gratitude to everyone
+who contributed to this document and all of the versions that came before it.</para>
+</appendix>
+
 <xi:include href="references.xml"/>
 </specification>

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -556,11 +556,11 @@ that set.</error>
           intermediate results produced by steps in the pipeline have base URIs. <impl>Whether (and
             when and how) or not the intermediate results that pass between steps are ever written
             to a filesystem is <glossterm>implementation-dependent</glossterm>.</impl></para>
-        <para><impl>In Version 2.0 of XProc, how (or if) implementers provide local resolution
+        <para><impl>In Version 3.0 of XProc, how (or if) implementers provide local resolution
             mechanisms and how (or if) they provide access to intermediate results by URI is
               <glossterm>implementation-defined</glossterm>.</impl>
         </para>
-        <para>Version 2.0 of XProc does not require implementations to guarantee that multiple
+        <para>Version 3.0 of XProc does not require implementations to guarantee that multiple
           attempts to dereference the same URI always produce consistent results.</para>
         <note xml:id="note-unsatisfying">
           <para>On the one hand, this is a somewhat unsatisfying state of affairs because it leaves
@@ -2123,7 +2123,7 @@ encounter the following step:</para>
 <para>The processor will simply ignore the “<port>ancillary</port>” port.
 </para>
 
-          <para>Suppose that XProc version 2.0 changes the definition of the <tag>p:xslt</tag> step
+          <para>Suppose that XProc version 3.0 changes the definition of the <tag>p:xslt</tag> step
             so that it has an additional output port, <code>messages</code>. Then consider the
             following pipeline: </para>
           <programlisting language="xml"><![CDATA[<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -6,32 +6,26 @@
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>
-<title>XProc 1.1: An XML Pipeline Language</title>
-<w3c-shortname>xproc11</w3c-shortname>
+<title>XProc 3.0: An XML Pipeline Language</title>
+<w3c-shortname>xproc30</w3c-shortname>
 <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
 
-<bibliorelation type="isformatof" xlink:href="xproc11.xml">XML</bibliorelation>
+<bibliorelation type="isformatof" xlink:href="xproc30.xml">XML</bibliorelation>
 
 <authorgroup>
   <author>
+    <personname>Achim Berndzen</personname>
+  </author>
+  <author>
+    <personname>Gerrit Imsieke</personname>
+  </author>
+  <author>
     <personname>Norman Walsh</personname>
-    <email>ndw@nwalsh.com</email>
-  </author>
-  <author>
-    <personname>Alex Milowski</personname>
-    <email>alex@milowski.org</email>
-  </author>
-  <author>
-    <personname>Henry S. Thompson</personname>
-    <affiliation>
-      <orgname>University of Edinburgh</orgname>
-    </affiliation>
-    <email>ht@inf.ed.ac.uk</email>
   </author>
 </authorgroup>
 <abstract>
 <para>This specification describes the syntax and semantics of
-<citetitle>XProc 1.1: An XML Pipeline Language</citetitle>, a language for
+<citetitle>XProc 3.0: An XML Pipeline Language</citetitle>, a language for
 describing operations to be performed on documents.</para>
 
 <para>An XML Pipeline specifies a sequence of operations to be
@@ -51,8 +45,8 @@ document.</emphasis></para>
 
 <para>This document is derived from
 <link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
-An XML Pipeline Language</link> published by the W3C … @@FIXME: what more
-do we need to say?</para>
+An XML Pipeline Language</link> published by the W3C. See also
+<xref linkend="credits"/>.</para>
 </legalnotice>
 </info>
 
@@ -4818,6 +4812,19 @@ output</emphasis> on that port. </para>
   </appendix>
   <xi:include href="parallel.xml"/>
   <xi:include href="mediatype.xml"/>
+
+<appendix xml:id="credits">
+<title>Credits</title>
+
+<para>This document is derived from
+<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
+An XML Pipeline Language</link> published by the W3C. It was developed
+by the <citetitle>XML Processing Model Working Group</citetitle> and edited by
+Norman Walsh, Alex Miłowski, and Henry Thompson.</para>
+
+<para>The editors of this specification extend their gratitude to everyone
+who contributed to this document and all of the versions that came before it.</para>
+</appendix>
 
 <appendix xml:id="changelog">
 <title>Change Log</title>

--- a/style/docbook.xsl
+++ b/style/docbook.xsl
@@ -331,7 +331,7 @@
       </p>
     </xsl:if>
 
-<p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+<p class="copyright">Copyright © 2016 FIXME:</p>
 
     <hr/>
 

--- a/style/docbook.xsl
+++ b/style/docbook.xsl
@@ -279,7 +279,7 @@
           </a>
         </dd>
         <dd>
-          <a href="http://github.com/xproc/1.1-specification/issues">
+          <a href="http://github.com/xproc/3.0-specification/issues">
             <xsl:text>Report an issue</xsl:text>
           </a>
         </dd>


### PR DESCRIPTION
This PR fixes several references to "1.1" from the prose of the specification.

It also attempts to address editorial credits.
