### PR TITLE
Refactor cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,8 +242,8 @@ task steps30_xi1(dependsOn: ["setupDocBook", "legacy_make"], type: XMLCalabashTa
   outputs.file "build/,steps30.xml"
   input("source", "langspec/xproc30-steps/steps.xml")
   output("result", "build/,steps30.xml")
-  param("schema", "")
-  param("schematron", "")
+  option("schema", "schema/dbspec.rng")
+  option("schematron", "schema/docbook.sch")
   pipeline "style/validate.xpl"
 }
 

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -150,7 +150,7 @@ steps.</para>
 <xi:include href="steps/xsl-formatter.xml"/>
 </section>
 
-x
+<xi:include href="serialization-options.xml"/>
 </section>
 
 <xi:include href="errors.xml"/>

--- a/langspec/xproc30-steps/steps.xml
+++ b/langspec/xproc30-steps/steps.xml
@@ -93,39 +93,39 @@ compatible versions.</para>
 <para>This section describes standard steps that must be supported
 by any conforming processor.</para>
 
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/add-attribute.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/add-xml-base.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/cast-content-type.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/compare.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/count.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/delete.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/directory-list.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/error.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/escape-markup.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/filter.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/http-request.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/identity.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/insert.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/label-elements.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/load.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/make-absolute-uris.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/namespace-rename.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/pack.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/parameters.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/rename.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/replace.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/set-attributes.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/set-properties.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/sink.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/split-sequence.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/store.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/string-replace.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/unescape-markup.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/unwrap.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/wrap.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/wrap-sequence.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/xinclude.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/xslt.xml"/>
+<xi:include href="steps/add-attribute.xml"/>
+<xi:include href="steps/add-xml-base.xml"/>
+<xi:include href="steps/cast-content-type.xml"/>
+<xi:include href="steps/compare.xml"/>
+<xi:include href="steps/count.xml"/>
+<xi:include href="steps/delete.xml"/>
+<xi:include href="steps/directory-list.xml"/>
+<xi:include href="steps/error.xml"/>
+<xi:include href="steps/escape-markup.xml"/>
+<xi:include href="steps/filter.xml"/>
+<xi:include href="steps/http-request.xml"/>
+<xi:include href="steps/identity.xml"/>
+<xi:include href="steps/insert.xml"/>
+<xi:include href="steps/label-elements.xml"/>
+<xi:include href="steps/load.xml"/>
+<xi:include href="steps/make-absolute-uris.xml"/>
+<xi:include href="steps/namespace-rename.xml"/>
+<xi:include href="steps/pack.xml"/>
+<xi:include href="steps/parameters.xml"/>
+<xi:include href="steps/rename.xml"/>
+<xi:include href="steps/replace.xml"/>
+<xi:include href="steps/set-attributes.xml"/>
+<xi:include href="steps/set-properties.xml"/>
+<xi:include href="steps/sink.xml"/>
+<xi:include href="steps/split-sequence.xml"/>
+<xi:include href="steps/store.xml"/>
+<xi:include href="steps/string-replace.xml"/>
+<xi:include href="steps/unescape-markup.xml"/>
+<xi:include href="steps/unwrap.xml"/>
+<xi:include href="steps/wrap.xml"/>
+<xi:include href="steps/wrap-sequence.xml"/>
+<xi:include href="steps/xinclude.xml"/>
+<xi:include href="steps/xslt.xml"/>
 </section>
 
 <section xml:id="std-optional">
@@ -136,18 +136,18 @@ processor, they must conform to the semantics outlined here, but a
 conformant processor is not required to support all (or any) of these
 steps.</para>
 
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/exec.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/hash.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/in-scope-names.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/template.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/uuid.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/validate-with-relax-ng.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/validate-with-schematron.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/validate-with-xml-schema.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/www-form-urldecode.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/www-form-urlencode.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/xquery.xml"/>
-<xi:include xmlns:db="http://docbook.org/ns/docbook" href="steps/xsl-formatter.xml"/>
+<xi:include href="steps/exec.xml"/>
+<xi:include href="steps/hash.xml"/>
+<xi:include href="steps/in-scope-names.xml"/>
+<xi:include href="steps/template.xml"/>
+<xi:include href="steps/uuid.xml"/>
+<xi:include href="steps/validate-with-relax-ng.xml"/>
+<xi:include href="steps/validate-with-schematron.xml"/>
+<xi:include href="steps/validate-with-xml-schema.xml"/>
+<xi:include href="steps/www-form-urldecode.xml"/>
+<xi:include href="steps/www-form-urlencode.xml"/>
+<xi:include href="steps/xquery.xml"/>
+<xi:include href="steps/xsl-formatter.xml"/>
 </section>
 
 x


### PR DESCRIPTION
For reasons I don't recall, the steps document wasn't actually being validated.

As a consequence, the "x" I left myself at the point where the xi:include was needed to include the serialization options, went undetected and I never fixed that.

And there were some unnecessary namespace declarations.

All trivial fixes, I believe. 