### PR TITLE
Attempt to restore the schema changes from PR 124

### DIFF
--- a/langspec/schemas/xproc.rnc
+++ b/langspec/schemas/xproc.rnc
@@ -426,11 +426,14 @@ Choose =
       common.attributes,
       use-when.attr?,
       ((Documentation|PipeInfo)*,
-         WithInput?,
-         Variable*,
-         (When|Documentation|PipeInfo)*,
-         Otherwise?,
-         (Documentation|PipeInfo)*)
+       WithInput?,
+
+       ((((Documentation|PipeInfo)*, When)+,
+         ((Documentation|PipeInfo)*, Otherwise)?)
+       | (((Documentation|PipeInfo)*, When)*,
+         ((Documentation|PipeInfo)*, Otherwise))),
+
+       (Documentation|PipeInfo)*)
    }
 
 [

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -793,19 +793,48 @@
         <optional>
           <ref name="WithInput"/>
         </optional>
-        <zeroOrMore>
-          <ref name="Variable"/>
-        </zeroOrMore>
-        <zeroOrMore>
-          <choice>
-            <ref name="When"/>
-            <ref name="Documentation"/>
-            <ref name="PipeInfo"/>
-          </choice>
-        </zeroOrMore>
-        <optional>
-          <ref name="Otherwise"/>
-        </optional>
+        <choice>
+          <group>
+            <oneOrMore>
+              <zeroOrMore>
+                <choice>
+                  <ref name="Documentation"/>
+                  <ref name="PipeInfo"/>
+                </choice>
+              </zeroOrMore>
+              <ref name="When"/>
+            </oneOrMore>
+            <optional>
+              <zeroOrMore>
+                <choice>
+                  <ref name="Documentation"/>
+                  <ref name="PipeInfo"/>
+                </choice>
+              </zeroOrMore>
+              <ref name="Otherwise"/>
+            </optional>
+          </group>
+          <group>
+            <zeroOrMore>
+              <zeroOrMore>
+                <choice>
+                  <ref name="Documentation"/>
+                  <ref name="PipeInfo"/>
+                </choice>
+              </zeroOrMore>
+              <ref name="When"/>
+            </zeroOrMore>
+            <group>
+              <zeroOrMore>
+                <choice>
+                  <ref name="Documentation"/>
+                  <ref name="PipeInfo"/>
+                </choice>
+              </zeroOrMore>
+              <ref name="Otherwise"/>
+            </group>
+          </group>
+        </choice>
         <zeroOrMore>
           <choice>
             <ref name="Documentation"/>


### PR DESCRIPTION
The schema changes from PR #124 were accidentally lost. This PR applies a slightly different set of changes to achieve the same purpose.

1. Now that we allow p;variable in between steps, I think it's a mistake to allow it inside p:choose as a sibling of p:when/p:otherwise. A user can simply put it before the choose if they want it to be available to all of the conditional branches.

2. I chose a slightly different content model that makes it clear that at least one of p:when or p:otherwise is required.

Hopefully this is seen as a friendly amendment to the original PR.
