### PR TITLE
Fix content model issues with p:inline

### DIFF
--- a/langspec/schemas/xproc.rnc
+++ b/langspec/schemas/xproc.rnc
@@ -181,7 +181,7 @@ Input =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|(Document|Inline)+)? & (Documentation|PipeInfo)*)|Any)
+      (((\Empty|(Document|Inline)+)? & (Documentation|PipeInfo)*)|AnyElement)
    }
 
 [
@@ -195,7 +195,7 @@ WithInput =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|Any)
+      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|AnyElement)
    }
 
 # ============================================================
@@ -226,7 +226,7 @@ OutputConnection =
       inline.attributes,
       use-when.attr?,
       serialization.attr?,
-      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|Any)
+      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|AnyElement)
    }
 
 [
@@ -270,7 +270,7 @@ Inline =
       document-properties.attr?,
       attribute encoding { text }?,
       use-when.attr?,
-      Any
+      Any*
    }
 
 [
@@ -328,7 +328,7 @@ WithOptionSelect =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)|Any)
+      (((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)|AnyElement)
    }
 
 [
@@ -350,7 +350,7 @@ VariableSelect =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)|Any)
+      (((\Empty|Pipe|Document|Inline)? & (Namespaces|Documentation|PipeInfo)*)|AnyElement)
    }
 
 [
@@ -579,7 +579,7 @@ Documentation =
 [
    sa:model = "any-well-formed-content"
 ]
-DocContent = (text | Any)
+DocContent = Any
 
 # ============================================================
 [
@@ -607,10 +607,19 @@ extension.attr =
 [
    sa:model = "anyElement"
 ]
-Any =
+AnyElement =
    element * {
-      (_any.attr | text | Any)*
+      (_any.attr | text | AnyElement)*
    }
+
+[
+   sa:model = "anyNode"
+]
+Any =
+   (element * {
+       (_any.attr | Any)*
+    }
+   | text)
 
 # ============================================================
 
@@ -772,7 +781,7 @@ Error =
       attribute line { xsd:integer }?,
       attribute column { xsd:integer }?,
       attribute offset { xsd:integer }?,
-      (text|Any)*
+      Any*
    }
 
 Charset = text

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -325,7 +325,7 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="Any"/>
+        <ref name="AnyElement"/>
       </choice>
     </element>
   </define>
@@ -363,7 +363,7 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="Any"/>
+        <ref name="AnyElement"/>
       </choice>
     </element>
   </define>
@@ -434,7 +434,7 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="Any"/>
+        <ref name="AnyElement"/>
       </choice>
     </element>
   </define>
@@ -507,7 +507,9 @@
       <optional>
         <ref name="use-when.attr"/>
       </optional>
-      <ref name="Any"/>
+      <zeroOrMore>
+        <ref name="Any"/>
+      </zeroOrMore>
     </element>
   </define>
   <define name="Empty" sa:class="language-construct">
@@ -601,7 +603,7 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="Any"/>
+        <ref name="AnyElement"/>
       </choice>
     </element>
   </define>
@@ -642,7 +644,7 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="Any"/>
+        <ref name="AnyElement"/>
       </choice>
     </element>
   </define>
@@ -1121,10 +1123,7 @@
     </element>
   </define>
   <define name="DocContent" sa:model="any-well-formed-content">
-    <choice>
-      <text/>
-      <ref name="Any"/>
-    </choice>
+    <ref name="Any"/>
   </define>
   <!-- ============================================================ -->
   <define name="PipeInfo" sa:ignore="yes" sa:class="language-construct">
@@ -1164,17 +1163,31 @@
       </anyName>
     </attribute>
   </define>
-  <define name="Any" sa:model="anyElement">
+  <define name="AnyElement" sa:model="anyElement">
     <element>
       <anyName/>
       <zeroOrMore>
         <choice>
           <ref name="_any.attr"/>
           <text/>
-          <ref name="Any"/>
+          <ref name="AnyElement"/>
         </choice>
       </zeroOrMore>
     </element>
+  </define>
+  <define name="Any" sa:model="anyNode">
+    <choice>
+      <element>
+        <anyName/>
+        <zeroOrMore>
+          <choice>
+            <ref name="_any.attr"/>
+            <ref name="Any"/>
+          </choice>
+        </zeroOrMore>
+      </element>
+      <text/>
+    </choice>
   </define>
   <!-- ============================================================ -->
   <define name="VocabParam" sa:class="step-vocabulary">
@@ -1399,10 +1412,7 @@
         </attribute>
       </optional>
       <zeroOrMore>
-        <choice>
-          <text/>
-          <ref name="Any"/>
-        </choice>
+        <ref name="Any"/>
       </zeroOrMore>
     </element>
   </define>

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4729,14 +4729,18 @@ step.</error>
 
 <e:rng-pattern name="Inline"/>
 
-<para>The <tag class="attribute">document-properties</tag> attribute can 
-  be used to set the <glossterm>document properties</glossterm> of the provided document. The document's 
-  content type is determined by the value of the "content-type" key in the provided map.
-  If no attribute <tag class="attribute">document-properties</tag> is provided or the provided map does not
-  contain a "content-type" key, the value "<literal>application/xml</literal>" is assumed.
+<para>The <tag class="attribute">document-properties</tag> attribute
+can be used to set the <glossterm>document properties</glossterm> of
+the provided document. The document's content type is determined by
+the value of the "content-type" key in the provided map. If no
+attribute <tag class="attribute">document-properties</tag> is provided
+or the provided map does not contain a "content-type" key, the value
+"<literal>application/xml</literal>" is assumed.
 </para>
+
 <para>How the content of a <tag>p:inline</tag> element is interpreted
-depends on the document's content type and the <tag class="attribute">encoding</tag> attribute.
+depends on the document's content type and the <tag
+class="attribute">encoding</tag> attribute.
 </para>
 
 <!--

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4957,10 +4957,10 @@ effect.)</para>
 <section xml:id="implicit-inlines">
 <title>Implicit inlines</title>
 
-<para>As an authoring convenience, if a single element node,
-optionally preceded and/or followed by whitespace, in any namespace other
-than the XProc namespace, occurs where a <tag>p:inline</tag> is
-allowed, it is treated as if it was enclosed within a
+<para>As an authoring convenience, if one or more element nodes,
+optionally preceded and/or followed by whitespace, in any namespace
+other than the XProc namespace, occurs where a <tag>p:inline</tag> is
+allowed, each is treated as if it was enclosed within a
 <tag>p:inline</tag> element (with no attributes). Any preceding or
 following whitespace is discarded.</para>
 
@@ -4969,6 +4969,7 @@ following whitespace is discarded.</para>
 <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline1">
     <p:with-input port="source">
         <para xmlns="http://docbook.org/ns/docbook">Some text</para>
+        <para xmlns="http://docbook.org/ns/docbook">Some other text</para>
     </p:with-input>
 </p:identity>]]></programlisting>
 
@@ -4977,12 +4978,18 @@ following whitespace is discarded.</para>
 <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline2">
     <p:with-input port="source">
         <p:inline><para xmlns="http://docbook.org/ns/docbook">Some text</para></p:inline>
+        <p:inline><para xmlns="http://docbook.org/ns/docbook">Some other text</para></p:inline>
     </p:with-input>
 </p:identity>]]></programlisting>
 
 <para>An explicit <tag>p:inline</tag> is required if the author
 wants to include top level comments, processing instructions, or whitespace,
 or if the document element is in the XProc namespace.</para>
+
+<para><error code="S00xx">It is a <glossterm>static error</glossterm>
+if comments or processing instructions occur as siblings of an element node
+that would be treated as an implicit inline.</error>
+</para>
 </section>
 </section>
 


### PR DESCRIPTION
This PR closes #167 and #168 by both allowing multiple elements in p:inline and allowing text node content in p:inline.
