### PR TITLE
Attempt to fix issue 153

### DIFF
--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -2774,6 +2774,10 @@ attribute">extension attributes</glossterm>.</error>
           </para>
         </listitem>
         <listitem>
+          <para><errpr code="S0077">It is a <glossterm>static error</glossterm> if the value on an 
+            attribute of an XProc element does not satisfy the type required for that attribute.
+        </listitem>
+        <listitem>
           <para><error code="D0028">It is a <glossterm>dynamic error</glossterm> if any attribute
               value does not satisfy the type required for that attribute.</error></para>
         </listitem>

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -2776,6 +2776,7 @@ attribute">extension attributes</glossterm>.</error>
         <listitem>
           <para><errpr code="S0077">It is a <glossterm>static error</glossterm> if the value on an 
             attribute of an XProc element does not satisfy the type required for that attribute.
+          </para>
         </listitem>
         <listitem>
           <para><error code="D0028">It is a <glossterm>dynamic error</glossterm> if any attribute

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -2774,8 +2774,8 @@ attribute">extension attributes</glossterm>.</error>
           </para>
         </listitem>
         <listitem>
-          <para><errpr code="S0077">It is a <glossterm>static error</glossterm> if the value on an 
-            attribute of an XProc element does not satisfy the type required for that attribute.
+          <para><error code="S0077">It is a <glossterm>static error</glossterm> if the value on an 
+            attribute of an XProc element does not satisfy the type required for that attribute.</error>
           </para>
         </listitem>
         <listitem>


### PR DESCRIPTION
Introducing a new static error XS0077 for cases, where the value of an attribute of an XProc element does not satisfy the required type, e.g.
&lt;p:input port="prefix:name" /> (NC-Name required) or
&lt;p:inline expand-text='5' /> (boolean required).

We did not have such an error code in XProc 1.0 but I think we should have it in XProc 3.0. May be we could then remove XS0063 (@version must be a decimal).