### PR TITLE
Attempt to fix issue 177

### DIFF
--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -4322,7 +4322,7 @@ has not declared an option with that name.</error>
 is operating in
 <link linkend="vers-forwcomp">forwards-compatible mode</link>.)</para>
 
-<para><error code="S0004">It is a <glossterm>static error</glossterm>
+<para><error code="S0080">It is a <glossterm>static error</glossterm>
 to include more than one <tag>p:with-option</tag> with the same option
 name as part of the same step invocation.</error></para>
 


### PR DESCRIPTION
Split up double use of XS0004 (option declared twice and option bound twice) into XS0004 (declaration) and XS0080 (binding).