### PR TITLE
Fix #167 again

### DIFF
--- a/langspec/schemas/xproc.rnc
+++ b/langspec/schemas/xproc.rnc
@@ -181,7 +181,7 @@ Input =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|(Document|Inline)+)? & (Documentation|PipeInfo)*)|AnyElement)
+      ( ( (\Empty | (Document|Inline)*) & (Documentation|PipeInfo)* ) | AnyElement* )
    }
 
 [
@@ -195,7 +195,7 @@ WithInput =
       common.attributes,
       inline.attributes,
       use-when.attr?,
-      (((\Empty|(Pipe|Document|Inline)+)? & (Documentation|PipeInfo)*)|AnyElement)
+      ( ( (\Empty | (Document|Inline)*) & (Documentation|PipeInfo)* ) | AnyElement* )
    }
 
 # ============================================================

--- a/langspec/schemas/xproc.rng
+++ b/langspec/schemas/xproc.rng
@@ -305,17 +305,15 @@
       </optional>
       <choice>
         <interleave>
-          <optional>
-            <choice>
-              <ref name="Empty"/>
-              <oneOrMore>
-                <choice>
-                  <ref name="Document"/>
-                  <ref name="Inline"/>
-                </choice>
-              </oneOrMore>
-            </choice>
-          </optional>
+          <choice>
+            <ref name="Empty"/>
+            <zeroOrMore>
+              <choice>
+                <ref name="Document"/>
+                <ref name="Inline"/>
+              </choice>
+            </zeroOrMore>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Documentation"/>
@@ -323,7 +321,9 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="AnyElement"/>
+        <zeroOrMore>
+          <ref name="AnyElement"/>
+        </zeroOrMore>
       </choice>
     </element>
   </define>
@@ -342,18 +342,15 @@
       </optional>
       <choice>
         <interleave>
-          <optional>
-            <choice>
-              <ref name="Empty"/>
-              <oneOrMore>
-                <choice>
-                  <ref name="Pipe"/>
-                  <ref name="Document"/>
-                  <ref name="Inline"/>
-                </choice>
-              </oneOrMore>
-            </choice>
-          </optional>
+          <choice>
+            <ref name="Empty"/>
+            <zeroOrMore>
+              <choice>
+                <ref name="Document"/>
+                <ref name="Inline"/>
+              </choice>
+            </zeroOrMore>
+          </choice>
           <zeroOrMore>
             <choice>
               <ref name="Documentation"/>
@@ -361,7 +358,9 @@
             </choice>
           </zeroOrMore>
         </interleave>
-        <ref name="AnyElement"/>
+        <zeroOrMore>
+          <ref name="AnyElement"/>
+        </zeroOrMore>
       </choice>
     </element>
   </define>


### PR DESCRIPTION
An input (or with-input) can contain:

  p:empty

or

  any number of p:document or p:inline elements

or

  any number of other elements

In the p:empty/p:document/p:inline case, you can mix in any number of p:documentation and p:pipeinfo elements.
