### PR TITLE
Relaxed signature checking

### DIFF
--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -3161,59 +3161,75 @@ on the output.</para>
           step is a copy of the input document with a horizontal rule as the first child of each
           selected <code>h:div</code>.</para>
       </section></section>
-    <section xml:id="p.choose"><title>p:choose</title><para>A choose is specified by the
-          <tag>p:choose</tag> element. It is a <glossterm>multi-container step</glossterm> that
-        selects exactly one of a list of alternative <glossterm baseform="subpipeline"
-          >subpipelines</glossterm> based on the evaluation of XPath expressions.</para>
+
+<section xml:id="p.choose">
+<title>p:choose</title>
+
+<para>A choose is specified by the <tag>p:choose</tag> element. It is
+a <glossterm>multi-container step</glossterm> that selects exactly one
+of a list of alternative <glossterm baseform="subpipeline"
+>subpipelines</glossterm> based on the evaluation of XPath
+expressions.</para>
+
       <e:rng-pattern name="Choose"/>
-      <para>A <tag>p:choose</tag> contains an arbitrary number of alternative
-          <glossterm baseform="subpipeline">subpipelines</glossterm>, exactly one of which will be
-        evaluated. <error code="S0074">It is a <glossterm>static error</glossterm> if a <tag>p:choose</tag>
-        has neither a <tag>p:when</tag> nor a <tag>p:otherwise</tag>.</error></para>
+
+<para>A <tag>p:choose</tag> contains an arbitrary number of
+alternative <glossterm
+baseform="subpipeline">subpipelines</glossterm>, exactly one of which
+will be evaluated. <error code="S0074">It is a <glossterm>static
+error</glossterm> if a <tag>p:choose</tag> has neither a
+<tag>p:when</tag> nor a <tag>p:otherwise</tag>.</error></para>
+
 <para>The list of alternative subpipelines consists of zero or more
-        subpipelines guarded by an XPath expression, followed optionally by a single default
-        subpipeline.</para>
+subpipelines guarded by an XPath expression, followed optionally by a
+single default subpipeline.</para>
+
 <para>The <tag>p:choose</tag> considers each subpipeline in turn and
-        selects the first (and only the first) subpipeline for which the guard expression evaluates
-        to true in its context. If there are no subpipelines for which the expression evaluates to
-        true, the default subpipeline, if it was specified, is selected.</para>
-<para>After a
-          <glossterm>subpipeline</glossterm> is selected, it is evaluated as if only it had been
-        present.</para>
-<para>The outputs of the <tag>p:choose</tag> are taken from the outputs of
-        the selected <glossterm>subpipeline</glossterm>. The <tag>p:choose</tag> has the same number
-        of outputs as the selected subpipeline with the same names. If the selected subpipeline has
-        a <glossterm>primary output port</glossterm>, the port with the same name on the
-          <tag>p:choose</tag> is also a primary output port.</para>
-<para>In order to ensure that the
-        output of the <tag>p:choose</tag> is consistent irrespective of the
-          <glossterm>subpipeline</glossterm> chosen, each <glossterm>subpipeline</glossterm> must
-        declare the same number of outputs with the same names. If any of the subpipelines specifies
-        a <glossterm>primary output port</glossterm>, each subpipeline must specify exactly the same
-        output as primary. <error code="S0007">It is a <glossterm>static error</glossterm> if two
-            <glossterm baseform="subpipeline">subpipelines</glossterm> in a <tag>p:choose</tag>
-          declare different outputs.</error></para>
-<para>As a convenience to authors, it is not an
-        error if some subpipelines declare outputs that can produce sequences and some do not. Each
-        output of the <tag>p:choose</tag> is declared to produce a sequence if that output is
-        declared to produce a sequence in any of its subpipelines.</para>
-<para><error code="D0004"
-          >It is a <glossterm>dynamic error</glossterm> if no <glossterm>subpipeline</glossterm> is
-          selected by the <tag>p:choose</tag> and no default is provided.</error></para>
+selects the first (and only the first) subpipeline for which the guard
+expression evaluates to true in its context. If there are no
+subpipelines for which the expression evaluates to true, the default
+subpipeline, if it was specified, is selected.</para>
+
+<para>After a <glossterm>subpipeline</glossterm> is selected, it is
+evaluated as if only it had been present.</para>
+
+<para>The outputs of the <tag>p:choose</tag> are taken from the
+outputs of the selected <glossterm>subpipeline</glossterm>. The
+<tag>p:choose</tag> has the same number of outputs as the selected
+subpipeline with the same names. If the selected subpipeline has a
+<glossterm>primary output port</glossterm>, the port with the same
+name on the <tag>p:choose</tag> is also a primary output port.</para>
+
+<para>In order to ensure that the output of the <tag>p:choose</tag> is
+consistent irrespective of the <glossterm>subpipeline</glossterm>
+chosen, each <glossterm>subpipeline</glossterm> must declare the same
+number of outputs with the same names. If any of the subpipelines
+specifies a <glossterm>primary output port</glossterm>, each
+subpipeline must specify exactly the same output as primary. <error
+code="S0007">It is a <glossterm>static error</glossterm> if two
+<glossterm baseform="subpipeline">subpipelines</glossterm> in a
+<tag>p:choose</tag> declare different outputs.</error></para>
+
+<para>As a convenience to authors, it is not an error if some
+subpipelines declare outputs that can produce sequences and some do
+not. Each output of the <tag>p:choose</tag> is declared to produce a
+sequence if that output is declared to produce a sequence in any of
+its subpipelines.</para>
+
+<para><error code="D0004">It is a <glossterm>dynamic
+error</glossterm> if no <glossterm>subpipeline</glossterm> is selected
+by the <tag>p:choose</tag> and no default is provided.</error></para>
 
 <para>The <tag>p:choose</tag> can specify the context node against
 which the XPath expressions that occur on each branch are evaluated.
 The context node is specified as a <glossterm>connection</glossterm>
-in the <tag>p:with-input</tag>. If no explicit connection is
-provided,
-the <glossterm>default readable port</glossterm> is used.
-If the context node is connected
-to <tag>p:empty</tag>, or is unconnected and the <glossterm>default
-readable port</glossterm> is undefined, the context
-item is undefined.
-<error code="D0005">It is a <glossterm>dynamic error</glossterm> if
-more than one document appears on the connection for this input
-port.</error>
+in the <tag>p:with-input</tag>. If no explicit connection is provided,
+the <glossterm>default readable port</glossterm> is used. If the
+context node is connected to <tag>p:empty</tag>, or is unconnected and
+the <glossterm>default readable port</glossterm> is undefined, the
+context item is undefined. <error code="D0005">It is a
+<glossterm>dynamic error</glossterm> if more than one document appears
+on the connection for this input port.</error>
 </para>
 
 <para>Each conditional <glossterm>subpipeline</glossterm> is

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -3203,9 +3203,7 @@ subpipelines.</para>
 subpipelines where one declares output ports “A” and “B” and the other
 declares output ports “B” and “C”. The outputs available from the
 <tag>p:choose</tag> are “A”, “B”, and “C”. No documents appear on any
-outputs not declared in the subpipline actually selected.
-<tag>p:choose</tag> has the same number of outputs as the selected
-subpipeline with the same names.</para>
+outputs not declared in the subpipline actually selected.</para>
 
 <para>In order to maintain consistency with respect to the
 <glossterm>default readable port</glossterm>, if any subpipeline has a
@@ -3378,23 +3376,28 @@ recovery subpipeline are the outputs of the <tag>p:try</tag> step. If
 the recovery subpipeline is evaluated and a step within that
 subpipeline fails, the <tag>p:try</tag> fails.</para>
 
-<para>The outputs of the <tag>p:try</tag> are taken from the outputs
-of the initial subpipeline or the recovery subpipeline if an error
-occurred in the initial subpipeline. The <tag>p:try</tag> has the same
-number of outputs as the selected subpipeline with the same names. If
-the selected subpipeline has a <glossterm>primary output
-port</glossterm>, the port with the same name on the <tag>p:try</tag>
-is also a primary output port.</para>
+<para>The outputs of the <tag>p:try</tag> are taken from the
+outputs of the initial <glossterm>subpipeline</glossterm> or the recovery
+subpipline if an error occurred in the initial subpipeline. The
+outputs <emphasis>available</emphasis> from the <tag>p:try</tag>
+are union of all of the outputs declared in any of its alternative
+subpipelines.</para>
 
-<para>In order to ensure that the output of the <tag>p:try</tag> is
-consistent irrespective of whether the initial subpipeline provides
-its output or the recovery subpipeline does, both subpipelines must
-declare the same number of outputs with the same names. If either of
-the subpipelines specifies a <glossterm>primary output
-port</glossterm>, both subpipelines must specify exactly the same
-output as primary. <error code="S0009">It is a <glossterm>static
-error</glossterm> if the <tag>p:group</tag> and <tag>p:catch</tag>
-subpipelines declare different outputs.</error></para>
+<para>Consider a <tag>p:try</tag> that has an initial
+subpipeline that declares output ports “A” and “B” and a recovery
+subpipeline that
+declares output ports “B” and “C”. The outputs available from the
+<tag>p:try</tag> are “A”, “B”, and “C”. No documents appear on any
+outputs not declared in the subpipeline whose results are actually
+returned.</para>
+
+<para>In order to maintain consistency with respect to the
+<glossterm>default readable port</glossterm>, if any subpipeline has a
+<glossterm>primary output port</glossterm>, even implicitly, then
+<emphasis>every</emphasis> subpipline must have exactly the same
+primary output port. In some cases, this may require making the implicit
+primary output explicit in order to assure that it has the same name.
+</para>
 
 <para>As a convenience to authors, it is not an error if an output
 port can produce a sequence in the initial subpipeline but not in the

--- a/langspec/xproc30/xproc.xml
+++ b/langspec/xproc30/xproc.xml
@@ -3195,20 +3195,25 @@ evaluated as if only it had been present.</para>
 
 <para>The outputs of the <tag>p:choose</tag> are taken from the
 outputs of the selected <glossterm>subpipeline</glossterm>. The
-<tag>p:choose</tag> has the same number of outputs as the selected
-subpipeline with the same names. If the selected subpipeline has a
-<glossterm>primary output port</glossterm>, the port with the same
-name on the <tag>p:choose</tag> is also a primary output port.</para>
+outputs <emphasis>available</emphasis> from the <tag>p:choose</tag>
+are union of all of the outputs declared in any of its alternative
+subpipelines.</para>
 
-<para>In order to ensure that the output of the <tag>p:choose</tag> is
-consistent irrespective of the <glossterm>subpipeline</glossterm>
-chosen, each <glossterm>subpipeline</glossterm> must declare the same
-number of outputs with the same names. If any of the subpipelines
-specifies a <glossterm>primary output port</glossterm>, each
-subpipeline must specify exactly the same output as primary. <error
-code="S0007">It is a <glossterm>static error</glossterm> if two
-<glossterm baseform="subpipeline">subpipelines</glossterm> in a
-<tag>p:choose</tag> declare different outputs.</error></para>
+<para>Consider a <tag>p:choose</tag> that has two alternative
+subpipelines where one declares output ports “A” and “B” and the other
+declares output ports “B” and “C”. The outputs available from the
+<tag>p:choose</tag> are “A”, “B”, and “C”. No documents appear on any
+outputs not declared in the subpipline actually selected.
+<tag>p:choose</tag> has the same number of outputs as the selected
+subpipeline with the same names.</para>
+
+<para>In order to maintain consistency with respect to the
+<glossterm>default readable port</glossterm>, if any subpipeline has a
+<glossterm>primary output port</glossterm>, even implicitly, then
+<emphasis>every</emphasis> subpipline must have exactly the same
+primary output port. In some cases, this may require making the implicit
+primary output explicit in order to assure that it has the same name.
+</para>
 
 <para>As a convenience to authors, it is not an error if some
 subpipelines declare outputs that can produce sequences and some do


### PR DESCRIPTION
Here's my first attempt to close #134 

I think a more general statement might be in order eventually, but I think this patch fixes the two places where we explicitly call out the matches.
