### PR TITLE
Fix issue 136 by removing p:pipeline from the spec

### DIFF
--- a/src/main/schema/xproc.rnc
+++ b/src/main/schema/xproc.rnc
@@ -117,7 +117,7 @@ decl.attributes = psvi-required.attr?,
 
 # ============================================================
 
-start = Pipeline | Library | DeclareStep
+start = Library | DeclareStep
  | VocabParam | VocabParamSet | VocabResult | VocabHttpRequest
  | VocabHeader | VocabMultipart | VocabBody | VocabHttpResponse | VocabQuery
  | VocabLine | VocabData | VocabDirectory | Errors | StandardStep
@@ -132,7 +132,7 @@ Library =
       decl.attributes,
       common.attributes,
       use-when.attr?,
-      (Import|DeclareStep|Pipeline|Documentation|PipeInfo)*
+      (Import|DeclareStep|Documentation|PipeInfo)*
    }
 
 [
@@ -144,21 +144,6 @@ Import =
       use-when.attr?,
       href.attr,
       (Documentation|PipeInfo)*
-   }
-
-[
-   sa:class = "language-construct"
-]
-Pipeline =
-   element pipeline {
-      name.ncname.attr?,
-      attribute type { xsd:QName }?,
-      common.attributes,
-      use-when.attr?,
-      decl.attributes,
-      (Input|Output|Option|Documentation|PipeInfo)*,
-      (DeclareStep|Pipeline|Import|Documentation|PipeInfo)*,
-      Subpipeline
    }
 
 [
@@ -413,7 +398,7 @@ DeclareStep =
       common.attributes,
       use-when.attr?,
       (Input|Output|Option|Documentation|PipeInfo)*,
-      ((DeclareStep|Pipeline|Import|Documentation|PipeInfo)*,Subpipeline)?
+      ((DeclareStep|Import|Documentation|PipeInfo)*,Subpipeline)?
    }
 
 # ============================================================

--- a/src/main/xml/steps/examples/doctemp-1.xml
+++ b/src/main/xml/steps/examples/doctemp-1.xml
@@ -1,15 +1,15 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:c="http://www.w3.org/ns/xproc-step"
-            name="main" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="username" required="true"/>
 <p:option name="password" required="true"/>
 
 <p:identity>
-  <p:input port="source">
-    <p:inline>
-      <c:request method="POST"/>
-    </p:inline>
-  </p:input>
+  <p:with-input port="source">
+    <c:request method="POST"/>
+  </p:with-input>
 </p:identity>
 
 <p:add-attribute match="/c:request" attribute-name="href">
@@ -27,11 +27,11 @@
 </p:add-attribute>
 
 <p:insert position="first-child" match="/c:request">
-  <p:input port="insertion" select="/doc/request">
+  <p:with-input port="insertion" select="/doc/request">
     <p:pipe step="main" port="source"/>
-  </p:input>
+  </p:with-input>
 </p:insert>
 
 <p:unwrap match="/c:request/request"/>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/steps/examples/doctemp-2.xml
+++ b/src/main/xml/steps/examples/doctemp-2.xml
@@ -1,26 +1,30 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:c="http://www.w3.org/ns/xproc-step"
-            name="main" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="username" required="true"/>
 <p:option name="password" required="true"/>
+
+<!-- FIXME: this exmaple doesn't work anymore -->
 
 <p:in-scope-names name="vars"/>
 
 <p:template>
-  <p:input port="template">
+  <p:with-input port="template">
     <p:inline>
       <c:request method="POST" href="{/doc/request/@uri}"
                  username="{$username}" password="{$password}">
         { /doc/request/node() }
       </c:request>
     </p:inline>
-  </p:input>
-  <p:input port="source">
-    <p:pipe step="main" port="source"/>
-  </p:input>
+  </p:with-input>
+  <p:with-input port="source" pipe="main@source"/>
+  <!--
   <p:input port="parameters">
     <p:pipe step="vars" port="result"/>
   </p:input>
+  -->
 </p:template>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/steps/examples/exec-as1.xml
+++ b/src/main/xml/steps/examples/exec-as1.xml
@@ -1,5 +1,8 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:exec command="someCommand" args="arg1 arg2 arg3"/>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/steps/examples/exec-as2.xml
+++ b/src/main/xml/steps/examples/exec-as2.xml
@@ -1,6 +1,9 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:exec command="someCommand" args="arg1,arg2,arg3"
 	arg-separator=","/>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/steps/examples/xquery.xml
+++ b/src/main/xml/steps/examples/xquery.xml
@@ -1,17 +1,16 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:xinclude/>
 
 <p:validate-with-xml-schema name="validate">
-  <p:input port="schema">
-    <p:document href="http://example.com/path/to/schema.xsd"/>
-  </p:input>
+  <p:with-input port="schema" href="http://example.com/path/to/schema.xsd"/>
 </p:validate-with-xml-schema>
 
 <p:xquery>
-   <p:input port="query">
-      <p:data href="countp.xq" />
-   </p:input>
+   <p:with-input port="query" href="countp.xq"/>
 </p:xquery>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/steps/schemas.xml
+++ b/src/main/xml/steps/schemas.xml
@@ -2,9 +2,9 @@
 <locatingRules xmlns="http://thaiopensource.com/ns/locating-rules/1.0">
 
   <namespace ns="http://www.w3.org/ns/xproc"
-	     uri="../schemas/xproc.rnc"/>
+	     uri="../../schema/xproc.rnc"/>
 
   <namespace ns="http://docbook.org/ns/docbook"
-	     uri="../../schema/dbspec.rnc"/>
+	     uri="../../../../schema/dbspec.rnc"/>
 
 </locatingRules>

--- a/src/main/xml/xproc/examples/choose.xml
+++ b/src/main/xml/xproc/examples/choose.xml
@@ -1,19 +1,18 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:choose name="version">
   <p:when test="/*[@version = 2]">
     <p:validate-with-xml-schema>
-      <p:input port="schema">
-	<p:document href="v2schema.xsd"/>
-      </p:input>
+      <p:with-input port="schema" href="v2schema.xsd"/>
     </p:validate-with-xml-schema>
   </p:when>
 
   <p:when test="/*[@version = 1]">
     <p:validate-with-xml-schema>
-      <p:input port="schema">
-	<p:document href="v1schema.xsd"/>
-      </p:input>
+      <p:with-input port="schema" href="v1schema.xsd"/>
     </p:validate-with-xml-schema>
   </p:when>
 
@@ -23,13 +22,13 @@
 
   <p:otherwise>
     <p:error code="NOVERSION">
-      <p:input port="source">
+      <p:with-input port="source">
 	<p:inline>
 	  <message>Required version attribute missing.</message>
 	</p:inline>
-      </p:input>
+      </p:with-input>
     </p:error>
   </p:otherwise>
 </p:choose>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/doctemp-1.xml
+++ b/src/main/xml/xproc/examples/doctemp-1.xml
@@ -1,15 +1,17 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:c="http://www.w3.org/ns/xproc-step"
-            name="main" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="username" required="true"/>
 <p:option name="password" required="true"/>
 
 <p:identity>
-  <p:input port="source">
+  <p:with-input port="source">
     <p:inline>
       <c:request method="POST"/>
     </p:inline>
-  </p:input>
+  </p:with-input>
 </p:identity>
 
 <p:add-attribute match="/c:request" attribute-name="href">
@@ -27,11 +29,11 @@
 </p:add-attribute>
 
 <p:insert position="first-child" match="/c:request">
-  <p:input port="insertion" select="/doc/request">
+  <p:with-input port="insertion" select="/doc/request">
     <p:pipe step="main" port="source"/>
-  </p:input>
+  </p:with-input>
 </p:insert>
 
 <p:unwrap match="/c:request/request"/>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/doctemp-2.xml
+++ b/src/main/xml/xproc/examples/doctemp-2.xml
@@ -1,26 +1,24 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:c="http://www.w3.org/ns/xproc-step"
-            name="main" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="username" required="true"/>
 <p:option name="password" required="true"/>
 
 <p:in-scope-names name="vars"/>
 
 <p:template>
-  <p:input port="template">
+  <p:with-input port="template">
     <p:inline>
       <c:request method="POST" href="{/doc/request/@uri}"
                  username="{$username}" password="{$password}">
         { /doc/request/node() }
       </c:request>
     </p:inline>
-  </p:input>
-  <p:input port="source">
-    <p:pipe step="main" port="source"/>
-  </p:input>
-  <p:input port="parameters">
-    <p:pipe step="vars" port="result"/>
-  </p:input>
+  </p:with-input>
+  <p:with-input port="source" pipe="main@source"/>
+  <p:with-input port="parameters" pipe="vars"/>
 </p:template>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/doctemp-3.xml
+++ b/src/main/xml/xproc/examples/doctemp-3.xml
@@ -1,5 +1,5 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
-                name="main" version="1.0">
+                name="main" version="3.0">
 <p:output port="result">
   <p:pipe step="vars" port="result"/>
 </p:output>

--- a/src/main/xml/xproc/examples/exclude-pfx.xml
+++ b/src/main/xml/xproc/examples/exclude-pfx.xml
@@ -1,17 +1,18 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
-  <p:output port="result"/>
-  <p:serialization port="result" indent="true"/>
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:c="http://www.w3.org/ns/xproc-step"
+                version="3.0">
+  <p:output port="result" serialization="map { 'indent': true() }"/>
 
   <p:identity xmlns:a="http://example.com/a"
               xmlns:b="http://example.com/b"
               xmlns:c="http://example.com/c">
-    <p:input port="source">
+    <p:with-input port="source">
       <p:inline exclude-inline-prefixes="a b">
         <doc>
           <b:part/>
         </doc>
       </p:inline>
-    </p:input>
+    </p:with-input>
   </p:identity>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/fig1-abbr.xml
+++ b/src/main/xml/xproc/examples/fig1-abbr.xml
@@ -1,13 +1,15 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-	    name="xinclude-and-validate"
-	    version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+	        name="xinclude-and-validate"
+	        version="3.0">
+  <p:input port="source" primary="true"/>
   <p:input port="schemas" sequence="true"/>
+  <p:output port="result"/>
 
   <p:xinclude/>
 
   <p:validate-with-xml-schema>
-    <p:input port="schema">
+    <p:with-input port="schema">
       <p:pipe step="xinclude-and-validate" port="schemas"/>
-    </p:input>
+    </p:with-input>
   </p:validate-with-xml-schema>
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/fig1.xml
+++ b/src/main/xml/xproc/examples/fig1.xml
@@ -1,6 +1,6 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
 		name="xinclude-and-validate"
-		version="1.0">
+		version="3.0">
   <p:input port="source" primary="true"/>
   <p:input port="schemas" sequence="true"/>
   <p:output port="result">
@@ -8,17 +8,17 @@
   </p:output>
 
   <p:xinclude name="included">
-    <p:input port="source">
+    <p:with-input port="source">
       <p:pipe step="xinclude-and-validate" port="source"/>
-    </p:input>
+    </p:with-input>
   </p:xinclude>
 
   <p:validate-with-xml-schema name="validated">
-    <p:input port="source">
+    <p:with-input port="source">
       <p:pipe step="included" port="result"/>
-    </p:input>
-    <p:input port="schema">
+    </p:with-input>
+    <p:with-input port="schema">
       <p:pipe step="xinclude-and-validate" port="schemas"/>
-    </p:input>
+    </p:with-input>
   </p:validate-with-xml-schema>
 </p:declare-step>

--- a/src/main/xml/xproc/examples/fig2.xml
+++ b/src/main/xml/xproc/examples/fig2.xml
@@ -1,26 +1,25 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+		name="xinclude-and-validate"
+		version="3.0">
+  <p:input port="source"/>
+  <p:input port="schemas" sequence="true"/>
+  <p:output port="result"/>
 
   <p:choose>
     <p:when test="/*[@version &lt; 2.0]">
       <p:validate-with-xml-schema>
-	<p:input port="schema">
-	  <p:document href="v1schema.xsd"/>
-	</p:input>
+	<p:with-input port="schema" href="v1schema.xsd"/>
       </p:validate-with-xml-schema>
     </p:when>
 
     <p:otherwise>
       <p:validate-with-xml-schema>
-	<p:input port="schema">
-	  <p:document href="v2schema.xsd"/>
-	</p:input>
+	<p:with-input port="schema" href="v2schema.xsd"/>
       </p:validate-with-xml-schema>
     </p:otherwise>
   </p:choose>
 
   <p:xslt>
-    <p:input port="stylesheet">
-      <p:document href="stylesheet.xsl"/>
-    </p:input>
+    <p:with-input port="stylesheet" href="stylesheet.xsl"/>
   </p:xslt>
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/for-each.xml
+++ b/src/main/xml/xproc/examples/for-each.xml
@@ -1,7 +1,10 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:for-each name="chapters">
-  <p:input select="//chapter"/>
+  <p:with-input select="//chapter"/>
   <p:output port="html-results">
     <p:pipe step="make-html" port="result"/>
   </p:output>
@@ -10,19 +13,13 @@
   </p:output>
 
   <p:xslt name="make-html">
-    <p:input port="stylesheet">
-      <p:document href="http://example.com/xsl/html.xsl"/>
-    </p:input>
+    <p:with-input port="stylesheet" href="http://example.com/xsl/html.xsl"/>
   </p:xslt>
 
   <p:xslt name="make-fo">
-    <p:input port="source">
-      <p:pipe step="chapters" port="current"/>
-    </p:input>
-    <p:input port="stylesheet">
-      <p:document href="http://example.com/xsl/fo.xsl"/>
-    </p:input>
+    <p:with-input port="source" pipe="chapters@current"/>
+    <p:with-input port="stylesheet" href="http://example.com/xsl/fo.xsl"/>
   </p:xslt>
 </p:for-each>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/group.xml
+++ b/src/main/xml/xproc/examples/group.xml
@@ -1,4 +1,7 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:group>
   <p:variable name="db-key"
@@ -8,28 +11,22 @@
     <p:when test="/config/output = 'fo'">
       <p:xslt>
 	<p:with-option name="parameters" select="map {'key': $db-key }"/>
-	<p:input port="stylesheet">
-	  <p:document href="fo.xsl"/>
-	</p:input>
+	<p:with-input port="stylesheet" href="fo.xsl"/>
       </p:xslt>
     </p:when>
     <p:when test="/config/output = 'svg'">
       <p:xslt>
 	<p:with-option name="parameters" select="map {'key': $db-key }"/>
-	<p:input port="stylesheet">
-	  <p:document href="svg.xsl"/>
-	</p:input>
+	<p:with-input port="stylesheet" href="svg.xsl"/>
       </p:xslt>
     </p:when>
     <p:otherwise>
       <p:xslt>
 	<p:with-option name="parameters" select="map {'key': $db-key }"/>
-	<p:input port="stylesheet">
-	  <p:document href="html.xsl"/>
-	</p:input>
+	<p:with-input port="stylesheet" href="html.xsl"/>
       </p:xslt>
     </p:otherwise>
   </p:choose>
 </p:group>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/identity.xml
+++ b/src/main/xml/xproc/examples/identity.xml
@@ -1,11 +1,11 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
 
 <p:output port="result"/>
 
 <p:identity name="otherstep">
-  <p:input port="source">
+  <p:with-input port="source">
     <p:document href="http://example.com/input.xml"/>
-  </p:input>
+  </p:with-input>
 </p:identity>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/input-doc.xml
+++ b/src/main/xml/xproc/examples/input-doc.xml
@@ -1,10 +1,10 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
 <p:output port="result"/>
 <p:identity name="irrelevant">
 
-<p:input port="source">
+<p:with-input port="source">
   <p:document href="http://example.org/input.html"/>
-</p:input>
+</p:with-input>
 
 </p:identity>
 </p:declare-step>

--- a/src/main/xml/xproc/examples/input-port.xml
+++ b/src/main/xml/xproc/examples/input-port.xml
@@ -1,15 +1,15 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
 <p:output port="result"/>
 <p:identity name="origin">
-<p:input port="source">
+<p:with-input port="source">
   <p:document href="http://example.org/input.html"/>
-</p:input>
+</p:with-input>
 </p:identity>
 <p:identity name="irrelevant">
 
-<p:input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
+<p:with-input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
   <p:pipe step="origin" port="result"/>
-</p:input>
+</p:with-input>
 
 </p:identity>
 </p:declare-step>

--- a/src/main/xml/xproc/examples/input-select.xml
+++ b/src/main/xml/xproc/examples/input-select.xml
@@ -1,10 +1,10 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"  version="3.0">
 <p:output port="result"/>
 <p:identity>
 
-<p:input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
+<p:with-input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
   <p:document href="http://example.org/input.html"/>
-</p:input>
+</p:with-input>
 
 </p:identity>
 </p:declare-step>

--- a/src/main/xml/xproc/examples/opns-2.xml
+++ b/src/main/xml/xproc/examples/opns-2.xml
@@ -1,12 +1,13 @@
-<p:pipeline type="ex:delete-in-div"
-	    version="1.0"
-	    xmlns:p="http://www.w3.org/ns/xproc"
-	    xmlns:ex="http://example.org/ns/ex"
-	    xmlns:h="http://www.w3.org/1999/xhtml">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+	        xmlns:ex="http://example.org/ns/ex"
+	        xmlns:h="http://www.w3.org/1999/xhtml"
+                type="ex:delete-in-div" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="divchild" required="true"/>
 
 <p:delete>
   <p:with-option name="match" select="concat('h:div/',$divchild)"/>
 </p:delete>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/opns-4.xml
+++ b/src/main/xml/xproc/examples/opns-4.xml
@@ -1,8 +1,9 @@
-<p:pipeline type="ex:delete-in-div"
-	    version="1.0"
-	    xmlns:p="http://www.w3.org/ns/xproc"
-	    xmlns:ex="http://example.org/ns/ex"
-	    xmlns:h="http://www.w3.org/1999/xhtml">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+	        xmlns:ex="http://example.org/ns/ex"
+	        xmlns:h="http://www.w3.org/1999/xhtml"
+                type="ex:delete-in-div" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="divchild" required="true"/>
 
 <p:delete>
@@ -11,4 +12,4 @@
   </p:with-option>
 </p:delete>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/opns-5.xml
+++ b/src/main/xml/xproc/examples/opns-5.xml
@@ -1,8 +1,9 @@
-<p:pipeline type="ex:delete-in-div"
-	    version="1.0"
-            xmlns:p="http://www.w3.org/ns/xproc"
-            xmlns:ex="http://example.org/ns/ex"
-            xmlns:h="http://www.w3.org/1999/xhtml">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:ex="http://example.org/ns/ex"
+                xmlns:h="http://www.w3.org/1999/xhtml"
+                type="ex:delete-in-div" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 <p:option name="divchild" required="true"/>
 
 <p:delete>
@@ -12,4 +13,4 @@
   </p:with-option>
 </p:delete>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/par1.xml
+++ b/src/main/xml/xproc/examples/par1.xml
@@ -1,24 +1,19 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-	    version="1.0"
-	    name="main">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
   <p:xslt name="generate-stylesheet">
-    <p:input port="source">
-      <p:document href="someURI"/>
-    </p:input>
-    <p:input port="stylesheet">
-      <p:document href="someOtherURI"/>
-    </p:input>
+    <p:with-input port="source" href="someURI"/>
+    <p:with-input port="stylesheet" href="someOtherURI"/>
   </p:xslt>
 
   <p:store name="save-xslt" href="gen-style.xsl"/>
 
   <p:xslt name="style">
-    <p:input port="source">
+    <p:with-input port="source">
       <p:pipe step="main" port="source"/>
-    </p:input>
-    <p:input port="stylesheet">
-      <p:document href="gen-style.xsl"/>
-    </p:input>
+    </p:with-input>
+    <p:with-input port="stylesheet" href="gen-style.xsl"/>
   </p:xslt>
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/par1b.xml
+++ b/src/main/xml/xproc/examples/par1b.xml
@@ -1,24 +1,21 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-	    version="1.0"
-	    name="main">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
   <p:xslt name="generate-stylesheet">
-    <p:input port="source">
-      <p:document href="someURI"/>
-    </p:input>
-    <p:input port="stylesheet">
-      <p:document href="someOtherURI"/>
-    </p:input>
+    <p:with-input port="source" href="someURI"/>
+    <p:with-input port="stylesheet" href="someOtherURI"/>
   </p:xslt>
 
   <p:store name="save-xslt" href="gen-style.xsl"/>
 
   <p:xslt name="style">
-    <p:input port="source">
+    <p:with-input port="source">
       <p:pipe step="main" port="source"/>
-    </p:input>
-    <p:input port="stylesheet">
+    </p:with-input>
+    <p:with-input port="stylesheet">
       <p:pipe step="generate-stylesheet" port="result"/>
-    </p:input>
+    </p:with-input>
   </p:xslt>
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/param-conn-1.xml
+++ b/src/main/xml/xproc/examples/param-conn-1.xml
@@ -1,11 +1,11 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
 <p:input port="source"/>
 <p:output port="result"/>
 
 <p:xslt>
-  <p:input port="stylesheet">
+  <p:with-input port="stylesheet">
     <p:document href="http://example.com/stylesheets/doc.xsl"/>
-  </p:input>
+  </p:with-input>
 </p:xslt>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/param-conn-2.xml
+++ b/src/main/xml/xproc/examples/param-conn-2.xml
@@ -1,12 +1,11 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
 <p:input port="source"/>
 <p:output port="result"/>
 
-<p:xslt>
-  <p:input port="stylesheet">
+<p:xslt parameters="map { 'mode': 'debug' }">
+  <p:with-input port="stylesheet">
     <p:document href="http://example.com/stylesheets/doc.xsl"/>
-  </p:input>
-  <p:with-param name="mode" select="'debug'"/>
+  </p:with-input>
 </p:xslt>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/param-conn-3.xml
+++ b/src/main/xml/xproc/examples/param-conn-3.xml
@@ -1,11 +1,12 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
-<p:xslt>
-  <p:input port="stylesheet">
+<p:xslt parameters="map { 'mode': 'debug' }">
+  <p:with-input port="stylesheet">
     <p:document href="http://example.com/stylesheets/doc.xsl"/>
-  </p:input>
-  <p:with-param name="mode" select="'debug'"/>
+  </p:with-input>
 </p:xslt>
 
-</p:pipeline>
-
+</p:declare-step>

--- a/src/main/xml/xproc/examples/parameter.xml
+++ b/src/main/xml/xproc/examples/parameter.xml
@@ -1,18 +1,15 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-	    version="1.0"
-	    name="main">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+	        name="main" version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
-<p:xslt>
-  <p:input port="source">
+<p:xslt parameters="map { 'output-type': 'html' }">
+  <p:with-input port="source">
     <p:pipe step="main" port="source"/>
-  </p:input>
-  <p:input port="stylesheet">
+  </p:with-input>
+  <p:with-input port="stylesheet">
     <p:document href="http://example.com/stylesheets/doc.xsl"/>
-  </p:input>
-  <p:with-param name="output-type" select="'html'"/>
-  <p:input port="parameters">
-    <p:pipe step="main" port="parameters"/>
-  </p:input>
+  </p:with-input>
 </p:xslt>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/pipeline-library.xml
+++ b/src/main/xml/xproc/examples/pipeline-library.xml
@@ -1,6 +1,6 @@
 <p:library xmlns:p="http://www.w3.org/ns/xproc"
 	   xmlns:px="http://example.org/ns/pipelines"
-	   version="1.0">
+	   version="3.0">
 
 <p:import href="ancillary-library.xml"/>
 <p:import href="other-pipeline.xml"/>

--- a/src/main/xml/xproc/examples/pipeline.xml
+++ b/src/main/xml/xproc/examples/pipeline.xml
@@ -1,17 +1,21 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:xinclude/>
 
 <p:validate-with-xml-schema>
-  <p:input port="schema">
+  <p:with-input port="schema">
     <p:document href="http://example.com/path/to/schema.xsd"/>
-  </p:input>
+  </p:with-input>
 </p:validate-with-xml-schema>
 
 <p:xslt>
-  <p:input port="stylesheet">
+  <p:with-input port="stylesheet">
     <p:document href="http://example.com/path/to/stylesheet.xsl"/>
-  </p:input>
+  </p:with-input>
 </p:xslt>
 
-</p:pipeline>
+</p:declare-step>
+

--- a/src/main/xml/xproc/examples/simple-default.xml
+++ b/src/main/xml/xproc/examples/simple-default.xml
@@ -1,9 +1,10 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:xslt>
-  <p:input port="stylesheet">
-    <p:document href="docbook.xsl"/>
-  </p:input>
+  <p:with-input port="stylesheet" href="docbook.xsl"/>
 </p:xslt>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/simple-explicit.xml
+++ b/src/main/xml/xproc/examples/simple-explicit.xml
@@ -1,4 +1,4 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" version="3.0">
 <p:input port="source"/>
 <p:output port="result">
   <p:pipe step="transform" port="result"/>
@@ -6,12 +6,10 @@
 <p:option name="parameters"/>
 
 <p:xslt name="transform" parameters="{$parameters}">
-  <p:input port="source">
+  <p:with-input port="source">
     <p:pipe step="main" port="source"/>
-  </p:input>
-  <p:input port="stylesheet">
-    <p:document href="docbook.xsl"/>
-  </p:input>
+  </p:with-input>
+  <p:with-input port="stylesheet" href="docbook.xsl"/>
 </p:xslt>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/trycatch.xml
+++ b/src/main/xml/xproc/examples/trycatch.xml
@@ -1,27 +1,27 @@
 <p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
 		xmlns:c="http://www.w3.org/ns/xproc/results"
-		version="1.0">
+		version="3.0">
 <p:output port="result"/>
 
 <p:try>
   <p:group>
     <p:http-request>
-      <p:input port="source">
+      <p:with-input port="source">
 	<p:inline>
 	  <c:request method="post" href="http://example.com/form-action">
 	    <c:body content-type="application/x-www-form-urlencoded">name=W3C&amp;spec=XProc</c:body>
 	  </c:request>
 	</p:inline>
-      </p:input>
+      </p:with-input>
     </p:http-request>
   </p:group>
   <p:catch>
     <p:identity>
-      <p:input port="source">
+      <p:with-input port="source">
 	<p:inline>
 	  <c:error>HTTP Request Failed</c:error>
 	</p:inline>
-      </p:input>
+      </p:with-input>
     </p:identity>
   </p:catch>
 </p:try>

--- a/src/main/xml/xproc/examples/value-available.xml
+++ b/src/main/xml/xproc/examples/value-available.xml
@@ -1,6 +1,8 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-	    xmlns:ex="http://example.com/ns/example"
-	    version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+	        xmlns:ex="http://example.com/ns/example"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:declare-step type="ex:dir-list">
   <p:output port="result"/>
@@ -17,6 +19,7 @@
     </p:otherwise>
   </p:choose>
 </p:declare-step>
-    
+
 <ex:dir-list path=".."/>
-</p:pipeline>
+
+</p:declare-step>

--- a/src/main/xml/xproc/examples/viewport.xml
+++ b/src/main/xml/xproc/examples/viewport.xml
@@ -1,14 +1,15 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:viewport match="h:div[@class='chapter']"
             xmlns:h="http://www.w3.org/1999/xhtml">
   <p:insert position="first-child">
-    <p:input port="insertion">
-      <p:inline>
-        <hr xmlns="http://www.w3.org/1999/xhtml"/>
-      </p:inline>
-    </p:input>
+    <p:with-input port="insertion">
+      <hr xmlns="http://www.w3.org/1999/xhtml"/>
+    </p:with-input>
   </p:insert>
 </p:viewport>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/xinclude.xml
+++ b/src/main/xml/xproc/examples/xinclude.xml
@@ -1,10 +1,13 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" version="1.0">
-<!-- there's no otherstep so this isn't expected to work... -->
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
+<!-- there's no otherstep so this isn't expected to work... -->
 <p:xinclude name="expand">
-  <p:input port="source">
+  <p:with-input port="source">
     <p:pipe step="otherstep" port="result"/>
-  </p:input>
+  </p:with-input>
 </p:xinclude>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/xpathcontext.xml
+++ b/src/main/xml/xproc/examples/xpathcontext.xml
@@ -1,4 +1,5 @@
-<p:declare-step xmlns:p="http://www.w3.org/ns/xproc" xmlns:xp="x" type="xp:x" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:xp="x" type="xp:x" version="3.0">
 <p:output port="result" sequence="true"/>
 
 <p:variable name="home" select="'http://example.com/docs'"/>
@@ -8,7 +9,7 @@
 </p:load>
 
 <p:split-sequence name="select-chapters" test="@role='chapter'">
-  <p:input port="source" select="//section"/>
+  <p:with-input port="source" select="//section"/>
 </p:split-sequence>
 
 </p:declare-step>

--- a/src/main/xml/xproc/examples/xslt-empty.xml
+++ b/src/main/xml/xproc/examples/xslt-empty.xml
@@ -1,17 +1,21 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:xslt name="generate" version="2.0">
-  <p:input port="source">
+  <p:with-input port="source">
     <p:empty/>
-  </p:input>
-  <p:input port="stylesheet">
+  </p:with-input>
+  <p:with-input port="stylesheet">
     <p:inline>
       <xsl:stylesheet version="2.0">
         ...
       </xsl:stylesheet>
     </p:inline>
-  </p:input>
+  </p:with-input>
   <p:with-option name="template-name" select="'someName'"/>
 </p:xslt>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/examples/xslt.xml
+++ b/src/main/xml/xproc/examples/xslt.xml
@@ -1,13 +1,17 @@
-<p:pipeline xmlns:p="http://www.w3.org/ns/xproc" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="3.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
 <p:xslt name="xform">
-  <p:input port="stylesheet">
+  <p:with-input port="stylesheet">
     <p:inline>
       <xsl:stylesheet version="1.0">
         ...
       </xsl:stylesheet>
     </p:inline>
-  </p:input>
+  </p:with-input>
 </p:xslt>
 
-</p:pipeline>
+</p:declare-step>

--- a/src/main/xml/xproc/schemas.xml
+++ b/src/main/xml/xproc/schemas.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <locatingRules xmlns="http://thaiopensource.com/ns/locating-rules/1.0">
-  <uri resource="xproc.xml" uri="../../../schema/dbspec.rnc"/>
+  <uri resource="xproc.xml" uri="../../../../schema/dbspec.rnc"/>
 </locatingRules>

--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -106,45 +106,51 @@ document.</para>
       <title>A simple, linear XInclude/Validate pipeline</title>
       <programlisting language="xml"><xi:include href="examples/fig1.xml" parse="text"/></programlisting>
     </example>
-    <para>The example in <xref linkend="ex1"/> is very verbose. It makes all of the connections seen
-      in the figure explicit. In practice, pipelines do not have to be this verbose. XProc supports
-      defaults for many common cases:</para>
-    <itemizedlist>
-      <listitem>
-        <para>If you use <tag>p:pipeline</tag> instead of <tag>p:declare-step</tag>, the
-            “<port>source</port>” input port and “<port>result</port>” output port are implicitly
-          declared for you.</para>
-      </listitem>
-      <listitem>
-        <para>Where inputs and outputs are connected between sequential sibling steps, they do not
-          have to be made explicit.</para>
-      </listitem>
-    </itemizedlist>
-    <para>The same pipeline, using XProc defaults, is shown in <xref linkend="ex1-abbr"/>.</para>
-    <example xml:id="ex1-abbr">
-      <title>A simple, linear XInclude/Validate pipeline (simplified)</title>
-      <programlisting language="xml"><xi:include href="examples/fig1-abbr.xml" parse="text"/></programlisting>
-    </example>
-    <para><xref linkend="fig-style-proc"/> is a more complex example: it performs schema validation
-      with an appropriate schema and then styles the validated document.</para>
-    <figure xml:id="fig-style-proc">
-      <title>A validate and transform pipeline</title>
-      <mediaobject>
-        <alt>A validate and transform pipeline</alt>
-        <imageobject>
-          <imagedata fileref="graphics/sch-transform.png"/>
-        </imageobject>
-      </mediaobject>
-    </figure>
-    <para>The heart of this example is the conditional. The “choose” step evaluates an XPath
-      expression over a test document. Based on the result of that expression, one or another branch
-      is run. In this example, each branch consists of a single validate step.</para>
-    <example xml:id="ex2">
-      <title>A validate and transform pipeline</title>
-      <programlisting language="xml"><xi:include href="examples/fig2.xml" parse="text"/></programlisting>
-    </example>
-    <para>This example, like the preceding, relies on XProc defaults for simplicity. It is always
-      valid to write the fully explicit form if you prefer.</para>
+
+<para>The example in <xref linkend="ex1"/> is very verbose. It makes
+all of the connections seen in the figure explicit. In practice,
+pipelines do not have to be this verbose. By default, Where inputs and
+outputs are connected between sequential sibling steps, they do not
+have to be made explicit.</para>
+
+<para>The same pipeline, using XProc defaults, is shown in <xref
+linkend="ex1-abbr"/>.</para>
+
+<example xml:id="ex1-abbr">
+  <title>A simple, linear XInclude/Validate pipeline (simplified)</title>
+  <programlisting language="xml"><xi:include href="examples/fig1-abbr.xml" parse="text"/></programlisting>
+</example>
+
+<para><xref linkend="fig-style-proc"/> is a more complex example: it
+performs schema validation with an appropriate schema and then styles
+the validated document.</para>
+
+<figure xml:id="fig-style-proc">
+  <title>A validate and transform pipeline</title>
+  <mediaobject>
+    <alt>A validate and transform pipeline</alt>
+    <imageobject>
+      <imagedata fileref="graphics/sch-transform.png"/>
+    </imageobject>
+  </mediaobject>
+</figure>
+
+<para>The heart of this example is the conditional. The “choose” step
+evaluates an XPath expression over a test document. Based on the
+result of that expression, one or another branch is run. In this
+example, each branch consists of a single validate step.</para>
+
+<example xml:id="ex2">
+  <title>A validate and transform pipeline</title>
+  <programlisting language="xml"><xi:include href="examples/fig2.xml" parse="text"/></programlisting>
+</example>
+
+<para>This example, like the preceding, relies on XProc defaults for
+simplicity. It is always valid to write the fully explicit form if you
+prefer. This example also takes advantage of using the <tag class="attribute">href</tag>
+attribute directly on <tag>p:with-input</tag> as a shortcut for the
+<tag>p:document</tag> connection.</para>
+
     <para>The media type for pipeline documents is <literal>application/xml</literal>. Often,
       pipeline documents are identified by the extension <filename class="extension"
       >.xpl</filename>.</para>
@@ -274,7 +280,7 @@ one input with respect to some set of XML Schemas, etc.</para>
           elements) of the step's highest ancestor element within the pipeline document or library
           which contains it, “<replaceable>n</replaceable>” is the position of the next-highest
           ancestor, and so on, including both steps and non-step wrappers. For example, consider the
-          pipeline in <xref linkend="ex2"/>. The <tag>p:pipeline</tag> step has no name, so it gets
+          pipeline in <xref linkend="ex2"/>. The <tag>p:declare-step</tag> step has no name, so it gets
           the default name “<literal>!1</literal>”; the <tag>p:choose</tag> gets the name
             “<literal>!1.1</literal>”; the first <tag>p:when</tag> gets the name
             “<literal>!1.1.1</literal>”; the <tag>p:otherwise</tag> gets the name
@@ -1855,7 +1861,7 @@ non-XML document.</para>
           >psvi-required</tag> attribute:</para>
       <itemizedlist>
         <listitem>
-          <para>On a <tag>p:pipeline</tag> or <tag>p:declare-step</tag>, <tag class="attribute"
+          <para>On a <tag>p:declare-step</tag>, <tag class="attribute"
               >psvi-required</tag> indicates whether or not the declared step requires PSVI support.
               <error code="D0022">It is a <glossterm>dynamic error</glossterm> if a processor that
               does not support PSVI annotations attempts to invoke a step which asserts that they
@@ -1863,8 +1869,7 @@ non-XML document.</para>
         </listitem>
         <listitem>
           <para>On a <tag>p:library</tag>, the <tag class="attribute">psvi-required</tag> attribute
-            provides a default value for all of its <tag>p:pipeline</tag> and
-              <tag>p:declare-step</tag>
+            provides a default value for all of its <tag>p:declare-step</tag>
             <emphasis>children</emphasis> that do not specify a value themselves.</para>
         </listitem>
       </itemizedlist>
@@ -2136,7 +2141,7 @@ name</link>. The value may be any XDM value.</termdef>
 for which a particular pipeline was authored by setting the
 <tag class="attribute">version</tag> attribute. The
 <tag class="attribute">version</tag> attribute can be specified on
-<tag>p:declare-step</tag>, <tag>p:pipeline</tag>, or <tag>p:library</tag>.
+<tag>p:declare-step</tag> or <tag>p:library</tag>.
 If specified, the value of
 the <tag class="attribute">version</tag> attribute <rfc2119>must</rfc2119> be a
 <type>xs:decimal</type>. <error code="S0063">It is a
@@ -2246,8 +2251,10 @@ encounter the following step:</para>
           <para>Suppose that XProc version 3.0 changes the definition of the <tag>p:xslt</tag> step
             so that it has an additional output port, <code>messages</code>. Then consider the
             following pipeline: </para>
-          <programlisting language="xml"><![CDATA[<p:pipeline xmlns:p="http://www.w3.org/ns/xproc"
-            version="2.0">
+          <programlisting language="xml"><![CDATA[<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                version="99.0">
+<p:input port="source"/>
+<p:output port="result"/>
 
   <p:xslt name="style">
     <p:with-input port="stylesheet">
@@ -2262,9 +2269,9 @@ encounter the following step:</para>
       <p:pipe step="style" port="messages"/>
     </p:with-input>
   </p:count>
-</p:pipeline>]]></programlisting>
+</p:declare-step>]]></programlisting>
 
-<para>When run by a "2.0" or later processor, it will count the
+<para>When run by a "99.0" or later processor, it will count the
 documents that appear on the <code>messages</code> port. When run by a
 “1.0” processor in forwards-compatible mode, the binding to the
 “<port>messages</port>” port is not a static error.
@@ -2368,22 +2375,20 @@ they are <firstterm>visible</firstterm> to each other.
       <para>The scope of the names of the step types is the pipeline in which they are declared,
         including any declarations imported from libraries via <tag>p:import</tag>. Nested pipelines
         inherit the step types in scope for their parent.</para>
-      <para>In other words, the step types that are in scope in a <tag>p:pipeline</tag> or
-          <tag>p:declare-step</tag> are:</para>
+      <para>In other words, the step types that are in scope in a <tag>p:declare-step</tag> are:</para>
       <itemizedlist>
         <listitem>
-          <para>The standard, built-in types (<tag>p:pipeline</tag>, <tag>p:choose</tag>, etc.).
+          <para>The standard, built-in types (<tag>p:declare-step</tag>, <tag>p:choose</tag>, etc.).
           </para>
         </listitem>
         <listitem>
           <para>Any implementation-provided types. </para>
         </listitem>
         <listitem>
-          <para>Any step types declared in the pipeline (the <tag>p:pipeline</tag> and
-              <tag>p:declare-step</tag> children of the pipeline element). </para>
+          <para>Any step types declared in the <tag>p:declare-step</tag> children of the pipeline element. </para>
         </listitem>
         <listitem>
-          <para>The types of any <tag>p:pipeline</tag>s or <tag>p:declare-step</tag>s that are
+          <para>The types of any <tag>p:declare-step</tag>s that are
             imported. </para>
         </listitem>
         <listitem>
@@ -2391,7 +2396,7 @@ they are <firstterm>visible</firstterm> to each other.
           </para>
         </listitem>
         <listitem>
-          <para>Any step types that are in scope for the pipeline's parent <tag>p:pipeline</tag> or
+          <para>Any step types that are in scope for the pipeline's parent
               <tag>p:declare-step</tag>, if it has one. </para>
         </listitem>
         <listitem>
@@ -2401,18 +2406,18 @@ they are <firstterm>visible</firstterm> to each other.
       <para>The step types that are in scope in a <tag>p:library</tag> are:</para>
       <itemizedlist>
         <listitem>
-          <para>The standard, built-in types (<tag>p:pipeline</tag>, <tag>p:choose</tag>, etc.).
+          <para>The standard, built-in types (<tag>p:declare-step</tag>, <tag>p:choose</tag>, etc.).
           </para>
         </listitem>
         <listitem>
           <para>Any implementation-provided types. </para>
         </listitem>
         <listitem>
-          <para>Any step types declared in the library (the <tag>p:pipeline</tag> and
+          <para>Any step types declared in the library (the
               <tag>p:declare-step</tag> children of the <tag>p:library</tag> element). </para>
         </listitem>
         <listitem>
-          <para>The types of <tag>p:pipeline</tag>s or <tag>p:declare-step</tag>s that are imported
+          <para>The types of <tag>p:declare-step</tag>s that are imported
             into the library. </para>
         </listitem>
         <listitem>
@@ -2838,7 +2843,7 @@ the summaries:</para><itemizedlist>
       <itemizedlist>
         <listitem>
           <para><error code="S0059">It is a <glossterm>static error</glossterm> if the pipeline
-              element is not <tag>p:pipeline</tag>, <tag>p:declare-step</tag>, or
+              element is not <tag>p:declare-step</tag> or
                 <tag>p:library</tag>.</error>
           </para>
         </listitem>
@@ -2965,63 +2970,44 @@ colon.</error></para>
 </listitem>
 </itemizedlist>
 
-<section xml:id="p.pipeline"><title>p:pipeline</title><para>A <tag>p:pipeline</tag> declares a
-        pipeline that can be evaluated by an XProc processor. It encapsulates the behavior of a
-          <glossterm>subpipeline</glossterm>. Its children declare inputs, outputs, and options that
-        the pipeline exposes and identify the steps in its subpipeline. (A <tag>p:pipeline</tag> is
-        a simplified form of <link linkend="p.declare-step">step declaration</link>.)
-        </para>
+<section xml:id="pipelines">
+<title>Pipelines</title>
 
-<para>All <tag>p:pipeline</tag> pipelines have an implicit
-<glossterm>primary input port</glossterm> named “<port>source</port>”
-and an implicit <glossterm>primary output
-port</glossterm> named “<port>result</port>”. Any input or output
-ports that the <tag>p:pipeline</tag> declares explicitly are
-<emphasis>in addition</emphasis> to those ports and may not be
-declared primary.</para>
+<para>The document element of a pipeline document is
+<tag>p:declare-step</tag> which declares a pipeline that can be
+evaluated by an XProc processor.</para>
 
-      <e:rng-pattern name="Pipeline"/>
-      <para>Viewed from the outside, a <tag>p:pipeline</tag> is a black box which performs some
-        calculation on its inputs and produces its outputs. From the pipeline author's perspective,
-        the computation performed by the pipeline is described in terms of <glossterm>contained
-          steps</glossterm> which read the pipeline's inputs and produce the pipeline's
-        outputs.</para>
+<para>It encapsulates the behavior of a
+<glossterm>subpipeline</glossterm>. Its children declare inputs,
+outputs, and options that the pipeline exposes and identify the steps
+in its subpipeline.
+</para>
 
-<para>The <tag class="attribute">version</tag> attribute identifies the version
-of XProc for which this pipeline was authored. If the <tag>p:pipeline</tag>
-has no ancestors in the XProc namespace, then it <rfc2119>must</rfc2119>
-have a <tag class="attribute">version</tag> attribute.
-See <xref linkend="versioning-considerations"/>.</para>
+<para>Viewed from the outside, a <tag>p:declare-step</tag> is a black
+box which performs some calculation on its inputs and produces its
+outputs. From the pipeline author's perspective, the computation
+performed by the pipeline is described in terms of
+<glossterm>contained steps</glossterm> which read the pipeline's
+inputs and produce the pipeline's outputs.</para>
 
-<para>If a pipeline does not have a <tag class="attribute">type</tag>
-then that pipeline cannot be invoked as a step.</para>
+<para>A <tag>p:declare-step</tag> element can also be nested inside
+other <tag>p:declare-step</tag> or <tag>p:library</tag> elements in
+which case it simply declares a pipeline that will be run
+elsewhere.</para>
 
-<para>The <tag>p:pipeline</tag> element is just a simplified form of
-step declaration. A document that reads:</para>
+<para>For more details, see <xref linkend="p.declare-step"/>.</para>
 
-<programlisting language="xml">&lt;p:pipeline <replaceable>some-attributes</replaceable>&gt;
-  <replaceable>some-content</replaceable>
-&lt;/p:pipeline&gt;</programlisting>
-
-<para>can be interpreted as if it read:</para>
-
-<programlisting language="xml">&lt;p:declare-step <replaceable>some-attributes</replaceable>&gt;
-  &lt;p:input port='source' primary='true'/&gt;
-  &lt;p:output port='result' primary='true'/&gt;
-  <replaceable>some-content</replaceable>
-&lt;/p:declare-step&gt;</programlisting>
-
-<para>See
-          <tag>p:declare-step</tag> for more details.</para><section xml:id="example-pipeline"
-        role="tocsuppress">
-        <title>Example</title>
-        <para>A pipeline might accept a document as input; perform XInclude, validation, and
-          transformation; and produce the transformed document as its output.</para>
-        <example xml:id="ex.p.pipeline">
-          <title>A Sample Pipeline Document</title>
-          <programlisting language="xml"><xi:include href="examples/pipeline.txt" parse="text"/></programlisting>
-        </example>
-      </section></section>
+<section xml:id="example-pipeline"
+         role="tocsuppress">
+<title>Example</title>
+<para>A pipeline might accept a document as input; perform XInclude, validation, and
+transformation; and produce the transformed document as its output.</para>
+<example xml:id="ex.p.pipeline">
+  <title>A Sample Pipeline Document</title>
+  <programlisting language="xml"><xi:include href="examples/pipeline.txt" parse="text"/></programlisting>
+</example>
+</section>
+</section>
 
 <section xml:id="p.for-each">
 <title>p:for-each</title>
@@ -3995,13 +3981,13 @@ see <tag>p:inline</tag>.</para>
 <para>A default connection does not satisfy the requirement that a
 primary input port is automatically connected by the processor, nor is
 it used when no default readable port is defined. In other words, a
-<tag>p:declare-step</tag> or a <tag>p:pipeline</tag> can define
+<tag>p:declare-step</tag> can define
 defaults for all of its inputs, whether they are primary or not, but
 defining a default for a primary input usually has no effect. It's
 never used by an atomic step since the step, when it's called, will
 always connect the primary input port to the default readable port (or
 cause a static error). The only case where it has value is on a
-<tag>p:pipeline</tag> when that pipeline is invoked directly by the
+<tag>p:declare-step</tag> when that pipeline is invoked directly by the
 processor. In that case, the processor <rfc2119>must</rfc2119> use the
 default connection if no external connection is provided for the
 port.</para>
@@ -4560,8 +4546,7 @@ node for the expression that defines the value of the variable.</error>
 
 <para>A <tag>p:option</tag> declares an option and may associate a
 default value with it. The <tag>p:option</tag> tag can only be used in
-a <tag>p:declare-step</tag> or a <tag>p:pipeline</tag> (which is a
-syntactic abbreviation for a step declaration).</para>
+a <tag>p:declare-step</tag>.</para>
 
 <para>The name of the option <rfc2119>must</rfc2119> be an EQName. If it
 does not contain a prefix then it is in no namespace. <error
@@ -4885,10 +4870,14 @@ option or variable are used.</para>
         </para></section>
     </section>
     <!-- ============================================================ -->
-    <section xml:id="p.declare-step"><title>p:declare-step</title><para>A <tag>p:declare-step</tag>
-        provides the type and <glossterm>signature</glossterm> of an <glossterm>atomic
-          step</glossterm> or pipeline. It declares the inputs, outputs, and options for all steps
-        of that type.</para>
+
+<section xml:id="p.declare-step">
+<title>p:declare-step</title>
+
+<para>A <tag>p:declare-step</tag> provides the type and
+<glossterm>signature</glossterm> of an <glossterm>atomic
+step</glossterm> or pipeline. It declares the inputs, outputs, and
+options for all steps of that type.</para>
 
       <e:rng-pattern name="DeclareStep"/>
 
@@ -5006,7 +4995,7 @@ See <xref linkend="versioning-considerations"/>.</para>
 
 <note xml:id="note-step-decl">
         <para>The steps declared in a pipeline library are referred to by their type. It is not an
-          error to put a <tag>p:pipeline</tag> or <tag>p:declare-step</tag> without a <tag
+          error to put a <tag>p:declare-step</tag> without a <tag
             class="attribute">type</tag> in a <tag>p:library</tag>, but there is no standard
           mechanism for instantiating it or referring to it. It is effectively invisible.</para>
       </note><para>Libraries can import pipelines and/or other libraries.
@@ -5021,8 +5010,8 @@ See also <xref linkend="handling-imports"
         available to the current pipeline. </para>
 <para><error code="S0052">It is a
             <glossterm>static error</glossterm> if the URI of a <tag>p:import</tag> cannot be
-          retrieved or if, once retrieved, it does not point to a <tag>p:library</tag>,
-            <tag>p:declare-step</tag>, or <tag>p:pipeline</tag>.</error>
+          retrieved or if, once retrieved, it does not point to a <tag>p:library</tag> or
+            <tag>p:declare-step</tag>.</error>
         <error code="S0053">It is a <glossterm>static error</glossterm> to import a single pipeline
           if that pipeline does not have a <tag class="attribute">type</tag>.</error>
       </para>
@@ -5238,8 +5227,7 @@ as defined below, are removed:</para>
                   </listitem>
                   <listitem>
                       <para>A namespace URI designated by using an <tag class="attribute"
-                          >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag>,
-                          <tag>p:pipeline</tag>, or <tag>p:library</tag> is also excluded. (In other words, the
+                          >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag> or <tag>p:library</tag> is also excluded. (In other words, the
                           effect of several <tag class="attribute">exclude-inline-prefixes</tag> attributes among
                           the ancestors of <tag>p:inline</tag> is cumulative.)</para>
                   </listitem>
@@ -5499,7 +5487,7 @@ output</emphasis> on that port. </para>
       as follows:</para>
     <variablelist>
       <varlistentry>
-        <term>p:pipeline, p:declare-step</term>
+        <term>p:declare-step</term>
         <listitem>
           <para>A singleton bag containing the <code>type</code> of the element</para>
         </listitem>
@@ -5548,19 +5536,19 @@ output</emphasis> on that port. </para>
           exports</glossterm> of its children, against the background of a singleton set containing
           <emphasis>DU</emphasis> as the initial <emphasis>Visited</emphasis> set, contains any
         duplicates.</error></para>
-    <para>Given a non-top-level <code>p:pipeline</code> or <code>p:declare-step</code> element,
+    <para>Given a non-top-level <code>p:declare-step</code> element,
         <error code="S0036">it is a <glossterm>static error</glossterm> if the
           <glossterm>bag-merger</glossterm> of the <glossterm>step type exports</glossterm> of its
         parent with the <glossterm>step type exports</glossterm> of its children, against the
         background of a copy of the <emphasis>Visited</emphasis> set of its parent as the initial
           <emphasis>Visited</emphasis> set, contains any duplicates.</error></para>
     <para>The phrase "a copy of the <emphasis>Visited</emphasis> set" in the preceding paragraph is
-      meant to indicate that checking of non-top-level <code>p:pipeline</code> or
+      meant to indicate that checking of non-top-level
         <code>p:declare-step</code> elements does <emphasis>not</emphasis> have a persistent impact
       on the checking of its parent. The contrast is that whereas changes to
         <emphasis>Visited</emphasis> pass both up <emphasis>and</emphasis> down through
         <code>p:import</code>, they pass only <emphasis>down</emphasis> through
-        <emphasis>p:pipeline</emphasis> and <emphasis>p:declare-step</emphasis>.</para>
+        <emphasis>p:declare-step</emphasis>.</para>
     <para><termdef xml:id="dt-bag-merger">The <firstterm>bag-merger</firstterm> of two or more bags
         (where a bag is an unordered list or, equivalently, something like a set except that it may
         contain duplicates) is a bag constructed by starting with an empty bag and adding each


### PR DESCRIPTION
Several things in here:

1. I updated the schema so there isn't a `p:pipeline` element anymore
2. I fixed the examples, not simply removing `p:pipeline` but also taking care of translating `p:input` into `p:with-input` and other changes. They're schema valid now, but not necessarily correct :-)
3. I updated the prose of the XProc spec. I struggled with what to do with the section that used to be about `p:pipeline`. Replacing it with the section on `p:declare-step` doesn't seem like a perfect solution because readers are going to come to this pipeline section first and there's *a lot* of detail in the `p:declare-step` section. In the end, I just sort of generalized the prose and left it.
4. I fixed some issues in ancillary files related to editing in Emacs. Meh. I should probably take those out of the repo at some point.

At some point, I'm going to print the spec out and do a wholistic once-through with a red pen. Hopefully we can smooth out rough edges like this at that time.

This PR is my attempt to close #136 

