### PR TITLE
Attempt to fix issue 208

### DIFF
--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -1967,7 +1967,12 @@ unescaped right curly bracket occurs outside of an expression.
 brackets in a value template, when interpreted as an XPath expression,
 contains errors. The error is signaled using the appropriate
 XPath error code.</para>
-
+  
+<para>
+<error code="D0050">It is a dynamic error if the XPath expression in an 
+AVT or TVT can not be evaluated.</error>
+</para>
+    
 <section xml:id="attribute-value-templates">
 <title>Attribute Value Templates</title>
 

--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -1969,8 +1969,8 @@ contains errors. The error is signaled using the appropriate
 XPath error code.</para>
   
 <para>
-<error code="D0050">It is a dynamic error if the XPath expression in an 
-AVT or TVT can not be evaluated.</error>
+<error code="D0050">It is a <glossterm>dynamic error</glossterm> if the 
+XPath expression in an AVT or TVT can not be evaluated.</error>
 </para>
     
 <section xml:id="attribute-value-templates">


### PR DESCRIPTION
Added dynamic error D0050 for errors in the dynamic evaluation of XPath expressions in AVTs or TVTs.

Close #208 