### PR TITLE
Make maps and arrays expressions

### DIFF
--- a/src/main/xml/steps/steps.xml
+++ b/src/main/xml/steps/steps.xml
@@ -93,7 +93,7 @@ these steps may be found in
   </listitem>
 </itemizedlist>
 
-<para>Options values are often expressed using <link
+<para>Option values are often expressed using <link
 linkend="option-shortcut">the shortcut syntax</link>. In these cases,
 the option shortcuts are generally treated as <link
 linkend="value-templates">value templates</link>. However, for options

--- a/src/main/xml/steps/steps.xml
+++ b/src/main/xml/steps/steps.xml
@@ -93,6 +93,18 @@ these steps may be found in
   </listitem>
 </itemizedlist>
 
+<para>Options values are often expressed using <link
+linkend="option-shortcut">the shortcut syntax</link>. In these cases,
+the option shortcuts are generally treated as <link
+linkend="value-templates">value templates</link>. However, for options
+of type <code>map()</code> or <code>array()</code>, an expression is
+<emphasis>required</emphasis> (there is no non-expression string which
+can ever be a legal value for a map or array). Given that every value
+entered this way will have to be a value template, and consequently
+every curly brace contained within the expression will have to be
+escaped, values of type map or array are defined to be expressions
+directly.</para>
+
 <para>Some aspects of documents are generally unchanged by steps:</para>
 
 <itemizedlist>


### PR DESCRIPTION
This PR attempts to implement @xml-project 's suggestion that we make map and array shortcuts into expressions directly. (As opposed to my question about making the option named `parameters` special.)

I'm still unsure about how users will feel, but I think this implements the change.

Close #197 
