### PR TITLE
Clarify XD0051

### DIFF
--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -1976,7 +1976,8 @@ XPath expression in an AVT or TVT can not be evaluated.</error>
 <para>
 <error code="D0051">It is a <glossterm>dynamic error</glossterm> if the XPath 
 expression in an AVT or TVT evaluates to something to other than a sequence 
-containing atomic values or nodes.</error>
+containing atomic values or nodes.</error> Function, array and map items are
+explicitly excluded here because they do not have a string representation.
 </para>
     
 <section xml:id="attribute-value-templates">


### PR DESCRIPTION
Clarify D0051 by explicitly naming function, maps and arrays and giving a reason.