### PR TITLE
Fix step errors

### DIFF
--- a/src/main/xml/steps/steps/cast-content-type.xml
+++ b/src/main/xml/steps/steps/cast-content-type.xml
@@ -11,7 +11,7 @@ of its input.</para>
 </p:declare-step>
 
 <para>The input document is transformed from one media type to another.
-<error code="C1002">It is a <glossterm>dynamic
+<error code="C0070">It is a <glossterm>dynamic
 error</glossterm> if the supplied <option>content-type</option> is not
 a valid media type of the form
 “<literal><replaceable>type</replaceable>/<replaceable>subtype</replaceable>+<replaceable>ext</replaceable></literal>”.</error></para>
@@ -42,13 +42,13 @@ a <tag>c:data</tag> document. The resulting document will
 have the specified media type and a <glossterm>representation</glossterm> that
 is the content of the <tag>c:data</tag> element after decoding the base64
 encoded content.</para>
-<para><error code="C1004">It is a <glossterm>dynamic
+<para><error code="C0072">It is a <glossterm>dynamic
 error</glossterm> if the <tag>c:data</tag> contains content is not
 a valid base64 string.</error></para>
-<para><error code="C1005">It is a <glossterm>dynamic
+<para><error code="C0073">It is a <glossterm>dynamic
 error</glossterm> if the <tag>c:data</tag> element does not have
 a <tag class="attribute">content-type</tag> attribute.</error></para>
-<para><error code="C1006">It is a <glossterm>dynamic
+<para><error code="C0074">It is a <glossterm>dynamic
 error</glossterm> if the <option>content-type</option> is supplied and is
 not the same as the <tag class="attribute">content-type</tag> specified on
 the <tag>c:data</tag> element.</error>
@@ -60,13 +60,13 @@ the input document is not a <tag>c:data</tag> document is
 <listitem>
 <para><impl>What happens when one non-XML media type is cast to another
 non-XML media type is <glossterm>implementation-defined</glossterm>.</impl>
-<error code="C1003">It is a <glossterm>dynamic
+<error code="C0071">It is a <glossterm>dynamic
 error</glossterm> if the <tag>p:cast-content-type</tag> step
 cannot perform the requested cast.</error></para>
 </listitem>
 </itemizedlist>
 
-<para><error code="C1007">In all cases except when the input document
+<para><error code="C075">In all cases except when the input document
 is a <tag>c:data</tag> element, it is a <glossterm>dynamic
 error</glossterm> if the <option>content-type</option> is not supplied.</error>
 </para>

--- a/src/main/xml/steps/steps/set-properties.xml
+++ b/src/main/xml/steps/steps/set-properties.xml
@@ -22,7 +22,7 @@ option is true, then the supplied properties are added to the existing
 properties. If it is false, the document’s properties are replaced by
 the new set.</para>
 
-<para><error code="C1001">It is a <glossterm>dynamic
+<para><error code="C0069">It is a <glossterm>dynamic
 error</glossterm> if the <option>properties</option> map contains
 a key equal to the string “<literal>content-type</literal>”.</error>
 </para>


### PR DESCRIPTION
When I remapped dynamic and static errors, I accidentally missed step errors.

I've fixed that in the wiki and this PR fixes the few C10xx errors that had been created.
