### PR TITLE
Removing legacy text

### DIFF
--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -4663,8 +4663,6 @@ default value.</error></para>
 the <tag class="attribute">select</tag> expression makes reference to
 the context node, size, or position.</error></para>
 
-<para>Regardless of the implicit type of the expression, the value is
-an <type>xs:untypedAtomic</type>.</para>
 </section>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
Just removing a para (for 1.0 specs) saying that an option is always a p:untyped-atomic.