### PR TITLE
Proposal for p:terminate-after issue #78

### DIFF
--- a/src/main/xml/steps/steps.xml
+++ b/src/main/xml/steps/steps.xml
@@ -144,6 +144,37 @@ version or a subsequent version that is backwards compatible with that
 version. At user-option, they may implement other non-backwards
 compatible versions.</para>
 
+<section xml:id="common-options">
+<title>Common options</title>
+<para>All XProc steps <rfc2119>must</rfc2119> accept the option 
+<option>p:terminate-after</option>. As a debugging tool this option can be used 
+to tell the XProc processor that a step with such an option should be terminated 
+if its execution does take more time than expected. The value of the 
+<option>p:terminate-after</option> option must be a <type>xs:positiveInteger</type>. 
+It is interpreted as the maximal number of seconds the step is expected to run. The 
+measurement of time starts after all bindings for input ports and all options are evaluated. 
+If the XProc processor realizes a longer runtime, it should terminate the execution of the step 
+as soon as possible, do cleanup to ensure proper execution of other steps in 
+the pipeline and then raise a dynamic error.</para>
+
+<para><error code="D0053">It is a <glossterm>dynamic error</glossterm> if a step runs 
+longer than its terminate-after value.</error> <impl>It is
+<glossterm>implementation-defined</glossterm> whether a processor supports
+timeouts, and if it does, how precisely and precisely how the
+execution time of a step is measured.</impl>
+</para>
+
+<note>
+<title>Note</title>
+<para>Note that the name of this option is <option>p:terminate-after</option>
+even on steps in the XProc namespace. This limits the extent to which the
+option restricts the space of available option names for steps.
+(If the option name wasn’t in a namespace, then no step could have an option
+named “<literal>terminate-after</literal>” which seems unreasonable.)
+</para>
+</note>
+</section>
+
 <section xml:id="std-required">
 <title>Required Steps</title>
 


### PR DESCRIPTION
Counter proposal to resolve issue #78. For semantic reasons I changed "p:timeout" to "p:terminate-after". I will propose to add an option named "timeout" on p:http-request. Having "p:timeout" (a common option) and "timeout" seems to be to error-prone.

@gimsieke @ndw
Due to the previous discussion I propose that we should have a consensus on this before merging.
 