### PR TITLE
Attempt to fix Issue #239

### DIFF
--- a/src/main/schema/xproc.rnc
+++ b/src/main/schema/xproc.rnc
@@ -392,6 +392,7 @@ DeclareStep =
       name.ncname.attr?,
       attribute type { xsd:QName }?,
       decl.attributes,
+      attribute visibility { xsd:boolean }?,
       common.attributes,
       use-when.attr?,
       (Input|Output|Option|Documentation|PipeInfo)*,

--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -4970,7 +4970,7 @@ visible to an importing pipeline. If <tag class="attribute">visibility</tag> is 
 <literal>false</literal>, the step type is only visible inside the <tag>p:library</tag> 
 but not visible to any pipeline importing the <tag>p:library</tag>. If the 
 <tag class="attribute">visibility</tag> attribute is missing, <literal>true</literal> 
-is assumed. If the <tag>p:declare-step</tag> is not a child of a <tag>p:library/tag> the 
+is assumed. If the <tag>p:declare-step</tag> is not a child of a <tag>p:library</tag> the 
 attribute is ignored.</para>
 
 <para>For a description of <tag class="attribute">psvi-required</tag>,

--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -4964,6 +4964,15 @@ has no ancestors in the XProc namespace, then it <rfc2119>must</rfc2119>
 have a <tag class="attribute">version</tag> attribute.
 See <xref linkend="versioning-considerations"/>.</para>
 
+<para>If the <tag>p:declare-step</tag> is a child of a <tag>p:library</tag> the
+<tag class="attribute">visibility</tag> attribute controls whether the step is 
+visible to an importing pipeline. If <tag class="attribute">visibility</tag> is set to
+<literal>false</literal>, the step type is only visible inside the <tag>p:library</tag> 
+but not visible to any pipeline importing the <tag>p:library</tag>. If the 
+<tag class="attribute">visibility</tag> attribute is missing, <literal>true</literal> 
+is assumed. If the <tag>p:declare-step</tag> is not a child of a <tag>p:library/tag> the 
+attribute is ignored.</para>
+
 <para>For a description of <tag class="attribute">psvi-required</tag>,
 see <xref linkend="psvi-support" />. For <tag
 class="attribute">xpath-version</tag>, see <xref


### PR DESCRIPTION
Let's see if I can do something not controversial today:
I introduced attribute "visibility" on p:declare-step and add the prose to explain its use.

Deviating from my original proposal I made it an xs:boolean for two reasons:

1. Doing so, we do not need to have another error which is raised when a wrong value is used for the attribute.

1. I could not figure out how to do this in RNC.

If you like the original proposal better, I will be happy to change the prose if someone changes the rnc (or tells me how to do ("public" | "private").
