### PR TITLE
Removed unnecessary section

### DIFF
--- a/src/main/xml/xproc/xproc.xml
+++ b/src/main/xml/xproc/xproc.xml
@@ -3851,22 +3851,6 @@ if <tag>p:document</tag>, <tag>p:pipe</tag>, or <tag>p:inline</tag> appear among
 the children of <tag>p:input</tag>.</error></para>
 </listitem>
 </varlistentry>
-<varlistentry><term><tag class="attribute">pipe</tag></term>
-<listitem>
-<para>The <tag class="attribute">pipe</tag> attribute is a shortcut for one or
-more <tag>p:pipe</tag> children. The attribute value <rfc2119>must</rfc2119> be
-space-separated list of step/port pairs of the form
-“<replaceable>step-name</replaceable>@<replaceable>port-name</replaceable>”.
-If “@port-name” is omitted, the connection is to the primary output port of
-the step named “step-name”. If the “step-name” is omitted, the connection is
-to the specified port on the same step as the step associated with the
-current default readable port.</para>
-<para><error code="S0082">If
-<tag class="attribute">pipe</tag> is specified, it is a <glossterm>static error</glossterm>
-if <tag>p:document</tag>, <tag>p:pipe</tag>, or <tag>p:inline</tag> appear among
-the children of <tag>p:input</tag>.</error></para>
-</listitem>
-</varlistentry>
 <varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
 <listitem>
 <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline


### PR DESCRIPTION
"@pipe" is not allowed on p:input, so we do not need to explain it.