### PR TITLE
Attempt to fix Issue #254

### DIFF
--- a/src/main/schema/xproc.rnc
+++ b/src/main/schema/xproc.rnc
@@ -217,7 +217,6 @@ OutputConnection =
       serialization.attr?,
       [ sa:avt = "true" ]
          href.attr?,
-      [ sa:avt = "true" ]
          pipe.attr?,
       common.attributes,
       inline.attributes,
@@ -327,7 +326,6 @@ WithOptionSelect =
         collection.attr?,
       [ sa:avt = "true" ]
          href.attr?,
-      [ sa:avt = "true" ]
          pipe.attr?,
       common.attributes,
       inline.attributes,
@@ -354,7 +352,6 @@ VariableSelect =
          collection.attr?,
       [ sa:avt = "true" ]
          href.attr?,
-      [ sa:avt = "true" ]
          pipe.attr?,
       common.attributes,
       inline.attributes,

--- a/src/main/schema/xproc.rnc
+++ b/src/main/schema/xproc.rnc
@@ -181,7 +181,6 @@ WithInput =
       select.attr?,
       [ sa:avt = "true" ]
          href.attr?,
-      [ sa:avt = "true" ]
          pipe.attr?,
       common.attributes,
       inline.attributes,


### PR DESCRIPTION
Removed AVT-mark for p:pipe on p:with-input, p:output, p:variable and p:with-option