### PR TITLE
Make signature of p:store more explicit

### DIFF
--- a/steps/src/main/xml/steps/store.xml
+++ b/steps/src/main/xml/steps/store.xml
@@ -7,7 +7,7 @@ location of the stored document.</para>
 
 <p:declare-step type="p:store">
   <p:input port="source" content-types="*/*"/>
-  <p:output port="result" content-types="application/xml"/>
+  <p:output port="result" content-types="application/xml" primary="true"/>
   <p:option name="href" required="true" as="xs:anyURI"/>
   <p:option name="serialization" as="map(xs:string,xs:anyAtomicValue)"/>
 </p:declare-step>


### PR DESCRIPTION
After some question already raised I think its better to flag output port "result" explicit as primary="true" to mark the difference to XProc 1.0
And, to be honest, is also a test the new system ;-))