### PR TITLE
Issue 310

### DIFF
--- a/src/main/schema/xproc.rnc
+++ b/src/main/schema/xproc.rnc
@@ -162,7 +162,8 @@ Input =
       primary.attr?,
       select.attr?,
       content-types.attr?,
-      href.attr?,
+      [ sa:avt = "true" ]
+         href.attr?,
       common.attributes,
       inline.attributes,
       use-when.attr?,

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5368,14 +5368,6 @@ comes from the <tag class="attribute">href</tag> attribute, the
 <tag class="attribute">parameters</tag> attribute.
 </para>
 
-<para>The attribute <tag class="attribute">href</tag> can be an attribute
-value template in all use cases except when the <tag>p:document</tag> appears
-as a child of <tag>p:input</tag>, because a static binding is required there.
-<error code="S0084">It is a <glossterm>static error</glossterm> if the attribute
-<tag class="attribute">href</tag> on a <tag>p:document</tag> within a <tag>p:input</tag>
-is an attribute value template.</error>
-</para>
-
 <para><error code="D0011">It is a <glossterm>dynamic error</glossterm>
 if the resource referenced by a <tag>p:document</tag> element does not
 exist, cannot be accessed, or has an XML content type and is not a


### PR DESCRIPTION
1. Remove par for p:document saying href is no avt, when p:document is child of p:input

1. Mark attribute href on p:input as avt