### PR TITLE
Editorial cleanup to remove processing errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,14 +171,8 @@ task steps(dependsOn: [ "xproc_schemas", "spec_schemas",
                         "steps:specification", "steps_assets", "steps_src",
                         "steps_xpl" ],
            type: DocBookTask) {
-  inputs.file "steps/build/source.xml"
-  inputs.file "tools/xsl/docbook.xsl"
-  inputs.file "tools/xsl/dbspec.xsl"
-  inputs.file "tools/xsl/xprocns.xsl"
-  inputs.file "tools/xsl/ml-macro.xsl"
-  inputs.file "tools/xsl/rngsyntax.xsl"
-  inputs.file "tools/xpl/formatspec.xpl"
-  outputs.file "build/dist/steps/index.html"
+  inputs.files fileTree(dir: "tools/xsl/")
+  inputs.files fileTree(dir: "tools/xpl/")
   input("source", "steps/build/source.xml")
   output("result", "build/dist/steps/index.html")
 

--- a/overview/src/main/xml/specification.xml
+++ b/overview/src/main/xml/specification.xml
@@ -93,4 +93,17 @@ these steps. General features of atomic steps are described in
 </itemizedlist>
 </section>
 
+<appendix xml:id="credits">
+<title>Credits</title>
+
+<para>This document is derived from
+<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
+An XML Pipeline Language</link> published by the W3C. It was developed
+by the <citetitle>XML Processing Model Working Group</citetitle> and edited by
+Norman Walsh, Alex Miłowski, and Henry Thompson.</para>
+
+<para>The editors of this specification extend their gratitude to everyone
+who contributed to this document and all of the versions that came before it.</para>
+</appendix>
+
 </specification>

--- a/steps/build.gradle
+++ b/steps/build.gradle
@@ -19,55 +19,7 @@ import com.xmlcalabash.XMLCalabashTask
 import com.nwalsh.tasks.StripAmblesTask
 
 task xinclude(dependsOn: [ ":spec_schemas" ], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
-  inputs.file "src/main/xml/errors.xml"
-  inputs.file "src/main/xml/error-codes.xml"
-  inputs.file "src/main/xml/glob.xml"
-  inputs.file "src/main/xml/steps/add-attribute.xml"
-  inputs.file "src/main/xml/steps/add-xml-base.xml"
-  inputs.file "src/main/xml/steps/cast-content-type.xml"
-  inputs.file "src/main/xml/steps/compare.xml"
-  inputs.file "src/main/xml/steps/count.xml"
-  inputs.file "src/main/xml/steps/delete.xml"
-  inputs.file "src/main/xml/steps/directory-list.xml"
-  inputs.file "src/main/xml/steps/error.xml"
-  inputs.file "src/main/xml/steps/escape-markup.xml"
-  inputs.file "src/main/xml/steps/exec.xml"
-  inputs.file "src/main/xml/steps/filter.xml"
-  inputs.file "src/main/xml/steps/hash.xml"
-  inputs.file "src/main/xml/steps/http-request.xml"
-  inputs.file "src/main/xml/steps/identity.xml"
-  inputs.file "src/main/xml/steps/in-scope-names.xml"
-  inputs.file "src/main/xml/steps/insert.xml"
-  inputs.file "src/main/xml/steps/label-elements.xml"
-  inputs.file "src/main/xml/steps/load.xml"
-  inputs.file "src/main/xml/steps/make-absolute-uris.xml"
-  inputs.file "src/main/xml/steps/namespace-rename.xml"
-  inputs.file "src/main/xml/steps/pack.xml"
-  inputs.file "src/main/xml/steps/parameters.xml"
-  inputs.file "src/main/xml/steps/rename.xml"
-  inputs.file "src/main/xml/steps/replace.xml"
-  inputs.file "src/main/xml/steps/set-attributes.xml"
-  inputs.file "src/main/xml/steps/set-properties.xml"
-  inputs.file "src/main/xml/steps/sink.xml"
-  inputs.file "src/main/xml/steps/split-sequence.xml"
-  inputs.file "src/main/xml/steps/store.xml"
-  inputs.file "src/main/xml/steps/string-replace.xml"
-  inputs.file "src/main/xml/steps/unescape-markup.xml"
-  inputs.file "src/main/xml/steps/unwrap.xml"
-  inputs.file "src/main/xml/steps/uuid.xml"
-  inputs.file "src/main/xml/steps/wrap-sequence.xml"
-  inputs.file "src/main/xml/steps/wrap.xml"
-  inputs.file "src/main/xml/steps/www-form-urldecode.xml"
-  inputs.file "src/main/xml/steps/www-form-urlencode.xml"
-  inputs.file "src/main/xml/steps/xinclude.xml"
-  inputs.file "src/main/xml/steps/xquery.xml"
-  inputs.file "src/main/xml/steps/xsl-formatter.xml"
-  inputs.file "src/main/xml/steps/xslt.xml"
-  inputs.file "src/main/xml/steps/payloads/request_body.xml"
-  inputs.file "src/main/xml/steps/payloads/request_response.xml"
-  inputs.file "src/main/xml/steps/payloads/response_body.xml"
-  outputs.file "build/xinclude.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")
   pipeline "../tools/xpl/validate.xpl"
@@ -76,7 +28,8 @@ xinclude.doFirst {
   mkdir("build")
 }
 
-task source(dependsOn: ["glossary"], type: XMLCalabashTask) {
+task source(dependsOn: ["xinclude", "glossary"], type: XMLCalabashTask) {
+  inputs.files fileTree(dir: "src/main/xml/")
   inputs.file "../tools/xsl/masterbib.xsl"
   inputs.file "../src/main/xml/bibliography.xml"
   inputs.file "src/main/xml/specification.xml"
@@ -88,7 +41,8 @@ task source(dependsOn: ["glossary"], type: XMLCalabashTask) {
 }
 
 task glossary(dependsOn: ["xinclude"], type: XMLCalabashTask) {
-  inputs.file "build/xinclude.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
+  inputs.file "../src/main/xml/bibliography.xml"
   inputs.file "../tools/xpl/makeglossary.xpl"
   inputs.file "../tools/xsl/makeglossary.xsl"
   outputs.file "build/glossary.xml"

--- a/steps/src/main/xml/common-features.xml
+++ b/steps/src/main/xml/common-features.xml
@@ -66,9 +66,8 @@ input document unless the step's process explicitly sets an
 description explicitly states how the base URI is constructed.</para>
 </listitem>
 <listitem>
-<para>Each step describes how it modifies the
-<glossterm>document properties</glossterm> of the documents
-that flow through it.</para>
+<para>Each step describes how it modifies the document properties of
+the documents that flow through it.</para>
 <para>A great many steps indicate that they preserve some or all of
 the properties of the input document. It should be noted that in some
 cases the transformation performed by the step will violate the
@@ -80,8 +79,7 @@ properties with greater care in this case.
 </itemizedlist>
 
 <para>When a step uses an XPath to compute an option value, the XPath
-context is as defined in
-<olink targetdoc="../xproc/xproc.xml" targetptr="xpath-context"/>.</para>
+context is as defined in <biblioref linkend="xproc30"/>.</para>
 
 <para>When a step specifies a particular version of a technology,
 implementations <rfc2119>must</rfc2119> implement that

--- a/steps/src/main/xml/conformance.xml
+++ b/steps/src/main/xml/conformance.xml
@@ -1,0 +1,42 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xml:id="conformance">
+<title>Conformance</title>
+
+<para>Conformant processors <rfc2119>must</rfc2119> implement all of the features
+described in this specification except those that are explicitly identified
+as optional.</para>
+
+<para>Some aspects of processor behavior are not completely specified; those
+features are either <glossterm role='unwrapped'>implementation-dependent</glossterm> or
+<glossterm role='unwrapped'>implementation-defined</glossterm>.</para>
+
+<para><termdef xml:id="dt-implementation-dependent">An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role='unwrapped'>implementation-dependent</glossterm> features are performed.</termdef>
+</para>
+
+<para><termdef xml:id="dt-implementation-defined">An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role='unwrapped'>implementation-defined</glossterm> features are performed.</termdef>
+</para>
+
+<section xml:id="implementation-defined">
+<title>Implementation-defined features</title>
+
+<para>The following features are implementation-defined:</para>
+
+<?implementation-defined-features?>
+</section>
+
+<section xml:id="implementation-dependent">
+<title>Implementation-dependent features</title>
+
+<para>The following features are implementation-dependent:</para>
+
+<?implementation-dependent-features?>
+</section>
+</appendix>

--- a/steps/src/main/xml/error-codes.xml
+++ b/steps/src/main/xml/error-codes.xml
@@ -1,9 +1,0 @@
-<appendix xmlns="http://docbook.org/ns/docbook"
-	  xml:id="app.step-errors">
-<title>Step Errors</title>
-
-<para>The following <glossterm baseform="dynamic-error">dynamic errors</glossterm>
-can be raised by steps in this specification:</para>
-
-<?step-error-list?>
-</appendix>

--- a/steps/src/main/xml/errors.xml
+++ b/steps/src/main/xml/errors.xml
@@ -1,31 +1,25 @@
 <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">
-<title>Errors</title>
-    <para>Errors in a pipeline can be divided into two classes: static errors and dynamic
-      errors.</para>
-    <section xml:id="static-errors">
-      <title>Static Errors</title>
-      <para><termdef xml:id="dt-static-error">A <firstterm>static error</firstterm> is one which can
-          be detected before pipeline evaluation is even attempted.</termdef> Examples of static
-        errors include cycles and incorrect specification of inputs and outputs. </para>
-      <para>Static errors are fatal and must be detected before any steps are evaluated.</para>
-      <para>For a complete list of static errors, see <xref linkend="app.static-errors"/>.</para>
-    </section>
-    <section xml:id="dynamic-errors">
-      <title>Dynamic Errors</title>
-      <para>A <termdef xml:id="dt-dynamic-error">A <firstterm>dynamic error</firstterm> is one which
-          occurs while a pipeline is being evaluated.</termdef> Examples of dynamic errors include
-        references to URIs that cannot be resolved, steps which fail, and pipelines that exhaust the
-        capacity of an implementation (such as memory or disk space).</para>
-      <para>If a step fails due to a dynamic error, failure propagates upwards until either a
-          <tag>p:try</tag> is encountered or the entire pipeline fails. In other words, outside of a
-          <tag>p:try</tag>, step failure causes the entire pipeline to fail.</para>
-      <para>For a complete list of dynamic errors, see <xref linkend="app.dynamic-errors"/>.</para>
-    </section>
-    <section xml:id="step-errors">
-      <title>Step Errors</title>
-      <para>Several of the steps in the standard and option step library can generate dynamic
-        errors.</para>
-      <para>For a complete list of the dynamic errors raised by builtin pipeline steps, see <xref
-          linkend="app.step-errors"/>.</para>
-    </section>
-  </section>
+<title>Step Errors</title>
+
+<para>Several of the steps in the standard step library can generate
+<glossterm baseform="dynamic-error">dynamic errors</glossterm>.</para>
+
+<para>A <termdef xml:id="dt-dynamic-error">A <firstterm>dynamic
+error</firstterm> is one which occurs while a pipeline is being
+evaluated.</termdef> Examples of dynamic errors include references to
+URIs that cannot be resolved, steps which fail, and pipelines that
+exhaust the capacity of an implementation (such as memory or disk
+space).</para>
+
+<para>If a step fails due to a dynamic error, failure propagates
+upwards until either a <tag>p:try</tag> is encountered or the entire
+pipeline fails. In other words, outside of a <tag>p:try</tag>, step
+failure causes the entire pipeline to fail.</para>
+
+<para>The following errors can be raised by steps in this
+specification:</para>
+
+<?step-error-list level="none"?>
+
+</section>
+

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -124,7 +124,7 @@ steps.</para>
 </section>
 
 <xi:include href="errors.xml"/>
-<xi:include href="error-codes.xml"/>
+<xi:include href="conformance.xml"/>
 <xi:include href="glob.xml"/>
 <xi:include href="references.xml"/>
 

--- a/steps/src/main/xml/steps/add-attribute.xml
+++ b/steps/src/main/xml/steps/add-attribute.xml
@@ -67,7 +67,7 @@ or any other prefix that resolves to the namespace name
 added explicitly by this step, adding an attribute whose name is in a
 namespace for which there is no namespace declaration in scope on the
 matched element may result in a namespace binding being added by
-<olink targetdoc="../xproc/xproc.xml" targetptr="namespace-fixup"/>.</para>
+namespace fixup.</para>
 
 <para>If an attribute named
 <tag class="attribute">xml:base</tag> is added or changed, the base URI

--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -19,8 +19,7 @@ a valid media type of the form
 <itemizedlist>
 <listitem>
 <para>Casting from one XML media type to another simply changes the
-“<literal>content-type</literal>” <glossterm baseform="document properties">document
-property</glossterm>.
+“<literal>content-type</literal>” document property.
 </para>
 </listitem>
 <listitem xml:id="c.data">
@@ -39,7 +38,7 @@ representation of the non-XML content.</para>
 <para>Casting from an XML media type to a non-XML media type
 <rfc2119>must</rfc2119> support the case where the input document is
 a <tag>c:data</tag> document. The resulting document will
-have the specified media type and a <glossterm>representation</glossterm> that
+have the specified media type and a representation that
 is the content of the <tag>c:data</tag> element after decoding the base64
 encoded content.</para>
 <para><error code="C0072">It is a <glossterm>dynamic

--- a/steps/src/main/xml/steps/error.xml
+++ b/steps/src/main/xml/steps/error.xml
@@ -29,8 +29,8 @@ The error generated can be caught by a <tag>p:try</tag> just like any
 other dynamic error.</para>
 
 <para>For authoring convenience, the <tag>p:error</tag> step is
-declared with a single, primary output port. With respect to
-<glossterm baseform="connection">connections</glossterm>, this port behaves like
+declared with a single, primary output port. With respect to connections,
+this port behaves like
 any other output port even though nothing can ever
 appear on it since the step always fails.</para>
 

--- a/steps/src/main/xml/steps/exec.xml
+++ b/steps/src/main/xml/steps/exec.xml
@@ -96,8 +96,7 @@ If <option>source-is-xml</option> is true, the value of the
 <option>serialization</option> option is used to convert the input
 into serialized XML which is passed to the command, otherwise the
 XPath string-value of the document is passed. Serialization is
-described in
-<link linkend="serialization">Serialization</link>.</para>
+described in <biblioref linkend="xproc30"/>.</para>
 
 <para>The standard output of the command is read and returned on
 <port>result</port>; the standard error output is read and returned on

--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -17,8 +17,7 @@ including an entity body (content) for the request.</para>
 
 <para>The <option>serialization</option> option is provided to control the
 serialization of any content which is sent as part of the request.
-The effect of these options is as specified in
-<link linkend="serialization">Serialization</link>.
+The effect of these options is as specified in <biblioref linkend="xproc30"/>.
 See <link linkend="c.request_body"/> for a discussion of when serialization
 occurs in constructing a request.</para>
 
@@ -105,31 +104,44 @@ challenge contains an authentication method that isn't
 supported.</error> All implementations are required to support "Basic"
 and "Digest" authentication per <biblioref linkend="rfc2617"/>.</para>
 
-<para>The attribute <code>timeout</code> controls the time the XProc processor is 
-waiting for the request to be answered. If a value is given for <code>timeout</code> 
-it is taken as the number of seconds to wait for the response to be delivered. 
-If no response is received after that time, the request is terminated. 
-If <code>fail-on-timeout</code> is <literal>true</literal>, a <glossterm>dynamic 
-error</glossterm> is raised, if it is <literal>false</literal>, a 
-<code>c:response</code> document with <code>status=408</code> 
-is generated. If no value is given for fail-on-timeout, <literal>false</literal> is assumed. 
-If no value for <code>timeout</code> is given, <code>fail-on-timeout</code> is ignored.</para>
+<para>The attribute <code>timeout</code> controls the time the XProc processor is
+waiting for the request to be answered. If a value is given for <code>timeout</code>
+it is taken as the number of seconds to wait for the response to be delivered.
+If no response is received after that time, the request is terminated.</para>
 
-<para><error code="C0078">It is a <glossterm>dynamic error</glossterm> if <option>fail-on-timeout</option>
-is specified as <literal>true</literal> and a value is given for <option>timeout</option> and the
-http-request is not finished in the time specified by <option>timeout</option>.</error>
+<itemizedlist>
+<listitem>
+<para><error code="C0078">It is a <glossterm>dynamic error</glossterm>
+if <option>fail-on-timeout</option> is specified as
+<literal>true</literal> and a value is given for
+<option>timeout</option> and the <tag>p:http-request</tag> is not finished in the
+time specified by <option>timeout</option>.</error>
 </para>
+</listitem>
+<listitem>
+<para>If <code>fail-on-timeout</code> is <literal>false</literal>, a
+<code>c:response</code> document with <code>status=408</code> is
+generated.</para>
+</listitem>
+<listitem>
+<para>If no value is given for <code>fail-on-timeout</code>,
+<literal>false</literal> is assumed. If no value is given for
+<code>timeout</code>, <code>fail-on-timeout</code> is ignored.</para>
+</listitem>
+</itemizedlist>
 
 <note>
 <title>Note</title>
-<para>Please note the difference between option <code>p:timeout</code> on <code>p:http-request</code> and 
-the attribute <code>timeout</code> in combination with <code>fail-on-timeout="true"</code> on <code>c:request</code>. If 
-the step does not finish in the set time, <code>D0053</code> is raised. If the request does not finish in time and 
-fail-on-timeout is true, <code>C0078</code> is raised. The actual times after which a timeout is detected may also 
-differ slightly.
+<para>Please note the difference between option <code>p:timeout</code>
+on <code>p:http-request</code> and the attribute <code>timeout</code>
+in combination with <code>fail-on-timeout="true"</code> on
+<code>c:request</code>. If the step does not finish in the set time,
+<code>D0053</code> is raised. If the request does not finish in time
+and fail-on-timeout is true, <code>C0078</code> is raised. The actual
+times after which a timeout is detected may also differ slightly.
 </para>
 </note>
-  
+
   <para>The <code>c:header</code> element specifies a
 header name and value, either for inclusion in a request, or as received in a response.</para>
 

--- a/steps/src/main/xml/steps/make-absolute-uris.xml
+++ b/steps/src/main/xml/steps/make-absolute-uris.xml
@@ -23,7 +23,7 @@ nodes.</error></para>
 as an IRI reference. If it is relative, it is made absolute against
 the base URI of the element on which it is specified
 (<tag>p:with-option</tag> or <tag>p:make-absolute-uris</tag> in the case of
-a <olink targetdoc="../xproc/xproc.xml" targetptr="option-shortcut">syntactic shortcut</olink>
+a syntactic shortcut
 value).</para>
 
 <para>For every element or attribute in the input document which

--- a/steps/src/main/xml/steps/set-attributes.xml
+++ b/steps/src/main/xml/steps/set-attributes.xml
@@ -33,8 +33,7 @@ If no elements match, the step will not change any elements.</para>
 <para>This step must not copy namespace declarations.  If the attributes
 copied from the <port>attributes</port> use namespaces, prefixes, or
 prefixes bound to different namespaces, the document produced on the
-<port>result</port> output port will require
-<olink targetdoc="../xproc/xproc.xml" targetptr="namespace-fixup"/>.</para>
+<port>result</port> output port will require namespace fixup.</para>
 
 <para>If an attribute named
 <tag class="attribute">xml:base</tag> is added or changed, the base URI

--- a/steps/src/main/xml/steps/set-properties.xml
+++ b/steps/src/main/xml/steps/set-properties.xml
@@ -1,8 +1,8 @@
 <section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.set-properties">
 <title>p:set-properties</title>
 
-<para>The <tag>p:set-properties</tag> step sets <glossterm>document
-properties</glossterm> on the source document.</para>
+<para>The <tag>p:set-properties</tag> step sets document
+properties on the source document.</para>
 
 <p:declare-step type="p:set-properties">
    <p:input port="source" content-types="*/*"/>
@@ -11,7 +11,7 @@ properties</glossterm> on the source document.</para>
    <p:option name="merge" default="false()" as="xs:boolean"/>
 </p:declare-step>
 
- <para>The <glossterm>document properties</glossterm> of the document
+ <para>The document properties of the document
 on the <port>source</port> port are augmented with the values specified
 in the <option>properties</option> option. The document produced on
 the <port>result</port> port has the same representation but the

--- a/steps/src/main/xml/steps/split-sequence.xml
+++ b/steps/src/main/xml/steps/split-sequence.xml
@@ -29,7 +29,7 @@ documents (which may be empty) to the <port>matched</port> port.
 All other documents are written to the <port>not-matched</port> port,
 irrespective of whether or not they match.</para>
 
-<para>The <olink targetdoc="../xproc/xproc.xml" targetptr="xpath-context">XPath context</olink> for the
+<para>The XPath context for the
 <option>test</option> option changes over time. For each document that
 appears on the <code>source</code> port, the expression is evaluated
 with that document as the context document. The context position

--- a/steps/src/main/xml/steps/store.xml
+++ b/steps/src/main/xml/steps/store.xml
@@ -16,7 +16,7 @@ location of the stored document.</para>
 <rfc2119>must</rfc2119> be an <type>anyURI</type>. If it is relative,
 it is made absolute against the base URI of the element on which it is
 specified (<tag>p:with-option</tag> or <tag>p:store</tag> in the case
-of a <olink targetdoc="../xproc/xproc.xml" targetptr="option-shortcut">syntactic shortcut</olink>
+of a syntactic shortcut
 value).</para>
 
 <para>The step attempts to store the XML document to the specified
@@ -30,7 +30,7 @@ document stored by the step.</para>
 
 <para>The <option>serialization</option> option is provided to control the
 serialization of content when it is stored. Serialization is described in
-<link linkend="serialization">Serialization</link>.</para>
+<biblioref linkend="xproc30"/>.</para>
 
 <section>
 <title>Document properties</title>

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -36,9 +36,8 @@ option.</para>
 
 <para>The <option>group-adjacent</option> option can be used to group
 adjacent documents.
-The
-<olink targetdoc="../xproc/xproc.xml" targetptr="xpath-context">XPath
-context</olink> for the
+The XPath context
+for the
 <option>group-adjacent</option> option changes over time. For each document that
 appears on the <code>source</code> port, the expression is evaluated
 with that document as the context document. The context position

--- a/steps/src/main/xml/steps/xsl-formatter.xml
+++ b/steps/src/main/xml/steps/xsl-formatter.xml
@@ -18,8 +18,7 @@ port.</para>
 <rfc2119>must</rfc2119> be an <type>anyURI</type>. If it is relative,
 it is made absolute against the base URI of the element on which it is
 specified (<tag>p:with-option</tag> or <tag>p:xsl-formatter</tag> in the
-case of a <olink targetdoc="../xproc/xproc.xml" targetptr="option-shortcut">syntactic shortcut</olink>
-value).</para>
+case of a syntactic shortcut value).</para>
 
 <para>The content-type of the output is controlled by the
 <option>content-type</option> option. This option specifies a media

--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -28,7 +28,7 @@ option <rfc2119>must</rfc2119> be a <type>QName</type>.</para>
 option <rfc2119>must</rfc2119> be an <type>anyURI</type>. If it is
 relative, it is made absolute against the base URI of the element on
 which it is specified (<tag>p:with-option</tag> or <tag>p:xslt</tag> in the
-case of a <olink targetdoc="../xproc/xproc.xml" targetptr="option-shortcut">syntactic shortcut</olink>
+case of a syntactic shortcut
 value).</para>
 
 <para>If the step specifies a <option>version</option>, then that version
@@ -96,8 +96,7 @@ option is specified.</para>
 
 
 <para>The static and initial dynamic contexts of the XSLT processor
-are the contexts defined in
-<olink targetdoc="../xproc/xproc.xml" targetptr="step-xpath-context-20"/>
+are the contexts defined in the step XPath context
 with the following adjustments.</para>
 
 <para>The dynamic context is augmented as follows:</para>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -521,8 +521,21 @@
 </xsl:template>
 
 <xsl:template match="processing-instruction('step-error-list')">
+  <xsl:variable name="level" as="xs:string?" select="f:pi(., 'level')"/>
+
   <div id="step-error-summary">
-    <h5>Step Errors</h5>
+    <xsl:choose>
+      <xsl:when test="$level = 'none'"/>
+      <xsl:when test="empty($level)">
+        <h5>Step Errors</h5>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:element namespace="http://www.w3.org/1999/xhtml"
+                     name="{QName('', $level)}">
+          <xsl:text>Step Errors</xsl:text>
+        </xsl:element>
+      </xsl:otherwise>
+    </xsl:choose>
     <dl class="errs">
       <xsl:call-template name="format-error-list">
 	<xsl:with-param name="errors" select="//db:error[starts-with(@code,'C')]"/>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -49,8 +49,7 @@ document.</emphasis></para>
 
 <para>This document is derived from
 <link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
-An XML Pipeline Language</link> published by the W3C. See also
-<xref linkend="credits"/>.</para>
+An XML Pipeline Language</link> published by the W3C.</para>
 </legalnotice>
 </info>
 
@@ -5541,19 +5540,6 @@ output</emphasis> on that port. </para>
   </appendix>
   <xi:include href="parallel.xml"/>
   <xi:include href="mediatype.xml"/>
-
-<appendix xml:id="credits">
-<title>Credits</title>
-
-<para>This document is derived from
-<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
-An XML Pipeline Language</link> published by the W3C. It was developed
-by the <citetitle>XML Processing Model Working Group</citetitle> and edited by
-Norman Walsh, Alex Miłowski, and Henry Thompson.</para>
-
-<para>The editors of this specification extend their gratitude to everyone
-who contributed to this document and all of the versions that came before it.</para>
-</appendix>
 
 <appendix xml:id="changelog">
 <title>Change Log</title>


### PR DESCRIPTION
There's still a ways to go, but this is a stab at it.

For most of the linking errors, I just removed the links. With one or two specs, they were nice. With seven or eight or more, I think their small utility doesn't justify the large maintenance cost.
