### PR TITLE
Fix #327 by adding support for xspecref

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,41 +42,10 @@ apply plugin: 'groovy'
 import org.docbook.DocBookTask
 import com.xmlcalabash.XMLCalabashTask
 
-// ================================================================================
+// ======================================================================
 
 task allspecs() {
   // dependencies are added by the specs
-}
-
-task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
-                        "xproc:specification", "xproc_assets", "xproc_src" ],
-             type: DocBookTask) {
-  inputs.files fileTree(dir: "tools/xsl/")
-  inputs.files fileTree(dir: "tools/xpl/")
-  input("source", "xproc/build/source.xml")
-  output("result", "build/dist/xproc/index.html")
-
-  param("schemaext.schema", new File("build/schema/dbspec.rng"))
-  option("style", new File("tools/xsl/xproc-specs.xsl"))
-  pipeline "tools/xpl/formatspec.xpl"
-}
-allspecs.dependsOn "xproc"
-
-task xproc_assets(dependsOn: [ "xproc_web_assets" ], type: Copy) {
-  from "xproc/build/graphics"
-  into "build/dist/xproc/graphics/"
-}
-
-task xproc_web_assets(type: Copy) {
-  from "src/main/resources"
-  into "build/dist/xproc/"
-}
-
-task xproc_src(dependsOn: ["xproc:source"], type: Copy) {
-  from "xproc/build/"
-  into "build/dist/xproc/"
-  include "source.xml"
-  rename ("source.xml", "specification.xml")
 }
 
 // ======================================================================
@@ -109,12 +78,46 @@ task overview_src(dependsOn: ["overview:source"], type: Copy) {
   rename ("source.xml", "specification.xml")
 }
 
+// ================================================================================
+
+task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
+                        "xproc:specification", "xproc_assets", "xproc_src" ],
+             type: DocBookTask) {
+  inputs.files fileTree(dir: "tools/xsl/")
+  inputs.files fileTree(dir: "tools/xpl/")
+  input("source", "xproc/build/source.xml")
+  output("result", "build/dist/xproc/index.html")
+
+  param("schemaext.schema", new File("build/schema/dbspec.rng"))
+  option("style", new File("tools/xsl/xproc-specs.xsl"))
+  pipeline "tools/xpl/formatspec.xpl"
+}
+allspecs.dependsOn "xproc"
+overview.dependsOn "xproc"
+
+task xproc_assets(dependsOn: [ "xproc_web_assets" ], type: Copy) {
+  from "xproc/build/graphics"
+  into "build/dist/xproc/graphics/"
+}
+
+task xproc_web_assets(type: Copy) {
+  from "src/main/resources"
+  into "build/dist/xproc/"
+}
+
+task xproc_src(dependsOn: ["xproc:source"], type: Copy) {
+  from "xproc/build/"
+  into "build/dist/xproc/"
+  include "source.xml"
+  rename ("source.xml", "specification.xml")
+}
+
 // ======================================================================
 // steps-intro
 
 task steps_intro(dependsOn: [ "xproc_schemas", "spec_schemas",
-                                "steps-intro:specification", "steps_intro_assets",
-                                "steps_intro_src" ],
+                              "steps-intro:specification", "steps_intro_assets",
+                              "steps_intro_src" ],
                  type: DocBookTask) {
   inputs.files fileTree(dir: "tools/xsl/")
   inputs.files fileTree(dir: "tools/xpl/")
@@ -126,6 +129,7 @@ task steps_intro(dependsOn: [ "xproc_schemas", "spec_schemas",
   pipeline "tools/xpl/formatspec.xpl"
 }
 allspecs.dependsOn "steps_intro"
+overview.dependsOn "steps_intro"
 
 task steps_intro_assets(type: Copy) {
   from "src/main/resources"
@@ -142,7 +146,7 @@ task steps_intro_src(dependsOn: ["steps-intro:source"], type: Copy) {
 // ======================================================================
 // steps
 
-task steps(dependsOn: [ "xproc_schemas", "spec_schemas",
+task steps(dependsOn: [ "xproc", "xproc_schemas", "spec_schemas",
                         "steps:specification", "steps_assets", "steps_src",
                         "steps_xpl" ],
            type: DocBookTask) {
@@ -156,6 +160,7 @@ task steps(dependsOn: [ "xproc_schemas", "spec_schemas",
   pipeline "tools/xpl/formatspec.xpl"
 }
 allspecs.dependsOn "steps"
+overview.dependsOn "steps"
 
 task steps_assets(type: Copy) {
   from "src/main/resources"
@@ -179,13 +184,14 @@ task steps_xpl(dependsOn: ["steps:library"], type: Copy) {
 // ======================================================================
 // step-validate-relax-ng
 
-task validate_relax_ng(dependsOn: [ "xproc_schemas", "spec_schemas",
+task validate_relax_ng(dependsOn: [ "xproc", "steps", "xproc_schemas", "spec_schemas",
                                     "step-validate-relax-ng:specification",
                                     "validate_relax_ng_assets",
                                     "validate_relax_ng_src", "validate_relax_ng_xpl" ],
                        type: DocBookTask) {
   inputs.files fileTree(dir: "tools/xsl/")
   inputs.files fileTree(dir: "tools/xpl/")
+  inputs.file "xproc/build/toc.xml"
   input("source", "step-validate-relax-ng/build/source.xml")
   output("result", "build/dist/validate-with-relax-ng/index.html")
 
@@ -194,6 +200,7 @@ task validate_relax_ng(dependsOn: [ "xproc_schemas", "spec_schemas",
   pipeline "tools/xpl/formatspec.xpl"
 }
 allspecs.dependsOn "validate_relax_ng"
+overview.dependsOn "validate_relax_ng"
 
 task validate_relax_ng_assets(type: Copy) {
   from "src/main/resources"
@@ -217,7 +224,7 @@ task validate_relax_ng_xpl(dependsOn: ["step-validate-relax-ng:library"], type: 
 // ======================================================================
 // step-validate-xml-schema
 
-task validate_xml_schema(dependsOn: [ "xproc_schemas", "spec_schemas",
+task validate_xml_schema(dependsOn: [ "xproc", "steps", "xproc_schemas", "spec_schemas",
                                       "step-validate-xml-schema:specification",
                                       "validate_xml_schema_assets",
                                       "validate_xml_schema_src", "validate_xml_schema_xpl"],
@@ -232,6 +239,7 @@ task validate_xml_schema(dependsOn: [ "xproc_schemas", "spec_schemas",
   pipeline "tools/xpl/formatspec.xpl"
 }
 allspecs.dependsOn "validate_xml_schema"
+overview.dependsOn "validate_xml_schema"
 
 task validate_xml_schema_assets(type: Copy) {
   from "src/main/resources"
@@ -255,7 +263,7 @@ task validate_xml_schema_xpl(dependsOn: ["step-validate-xml-schema:library"], ty
 // ======================================================================
 // step-validate-schematron
 
-task validate_schematron(dependsOn: [ "xproc_schemas", "spec_schemas",
+task validate_schematron(dependsOn: [ "xproc", "steps", "xproc_schemas", "spec_schemas",
                                       "step-validate-schematron:specification",
                                       "validate_schematron_assets",
                                       "validate_schematron_src","validate_schematron_xpl" ],
@@ -270,6 +278,7 @@ task validate_schematron(dependsOn: [ "xproc_schemas", "spec_schemas",
   pipeline "tools/xpl/formatspec.xpl"
 }
 allspecs.dependsOn "validate_schematron"
+overview.dependsOn "validate_schematron"
 
 task validate_schematron_assets(type: Copy) {
   from "src/main/resources"
@@ -298,6 +307,9 @@ task spec_schemas(dependsOn: [ "spec_rng", "spec_sch" ]) {
 }
 
 task spec_rng(type: JavaExec) {
+  inputs.files fileTree(dir: "schema/")
+  outputs.file "build/schema/dbspec.rng"
+
   classpath = configurations.tools
   main = 'com.thaiopensource.relaxng.translate.Driver'
   args = ["schema/dbspec.rnc", "build/schema/dbspec.rng"]

--- a/overview/src/main/xml/specification.xml
+++ b/overview/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='overview'
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>
@@ -59,14 +60,14 @@ See also
 
 <itemizedlist>
 <listitem>
-<para><citetitle xlink:href="xproc/">XProc 3.0: A Pipeline Language</citetitle>
+<para><xspecref spec="xproc"/>
 defines the semantics of XProc pipelines.</para>
 </listitem>
 <listitem>
-<para><citetitle xlink:href="steps/">XProc 3.0: Standard Step Library</citetitle>
+<para><xspecref spec="steps"/>
 defines the required atomic steps. All conformant implementations implement
 these steps. General features of atomic steps are described in
-<citetitle xlink:href="steps-intro">XProc 3.0 Steps: An Introduction</citetitle>.
+<xspecref spec="steps-intro"/>.
 </para>
 </listitem>
 </itemizedlist>
@@ -79,15 +80,15 @@ these steps. General features of atomic steps are described in
 
 <itemizedlist>
 <listitem>
-<para><citetitle xlink:href="validate-with-relax-ng/">Validate with RELAX NG</citetitle>
+<para><xspecref spec="step-validate-relax-ng"/>
 </para>
 </listitem>
 <listitem>
-<para><citetitle xlink:href="validate-with-schematron/">Validate with Schematron</citetitle>
+<para><xspecref spec="step-validate-schematron"/>
 </para>
 </listitem>
 <listitem>
-<para><citetitle xlink:href="validate-with-xml-schema/">Validate with XML Schema</citetitle>
+<para><xspecref spec="step-validate-xml-schema"/>
 </para>
 </listitem>
 </itemizedlist>

--- a/schema/dbspec.rnc
+++ b/schema/dbspec.rnc
@@ -227,6 +227,23 @@ div {
 
 # ======================================================================
 
+db.xspecref.role.attribute = attribute role { text }
+db.xspecref.attlist =
+   db.xspecref.role.attribute?
+ & db.common.attributes
+ & db.common.linking.attributes
+ & attribute spec { xsd:NCName }
+ & attribute xref { xsd:NCName }?
+
+db.xspecref =
+   element xspecref {
+      db.xspecref.attlist, empty
+   }
+
+db.link.inlines |= db.xspecref
+
+# ======================================================================
+
 db.el =
    [ r:remap [ db:tag [ class="tag" ] ] ]
    element db:el {
@@ -240,5 +257,3 @@ db.att =
       db.common.attributes,
       db._text
    }
-
-

--- a/step-validate-relax-ng/src/main/xml/specification.xml
+++ b/step-validate-relax-ng/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='step-validate-relax-ng'
                class="ed" role="step"
                version="5.0-extension w3c-xproc">
 <info>
@@ -124,14 +125,17 @@ No document properties on the <port>schemas</port> port are preserved.</para>
 <title>Step Errors</title>
 
 <para>This step can raise
-<glossterm baseform="dynamic-error">dynamic errors</glossterm>.</para>
+<glossterm baseform="dynamic-error">dynamic errors</glossterm>.
+</para>
 
-<para>A <termdef xml:id="dt-dynamic-error">A <firstterm>dynamic
+<para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic
 error</firstterm> is one which occurs while a pipeline is being
 evaluated.</termdef> Examples of dynamic errors include references to
 URIs that cannot be resolved, steps which fail, and pipelines that
 exhaust the capacity of an implementation (such as memory or disk
-space).</para>
+space). For a more complete discussion of dynamic errors, see
+<xspecref spec="xproc" xref="dynamic-errors"/>.
+</para>
 
 <para>If a step fails due to a dynamic error, failure propagates
 upwards until either a <tag>p:try</tag> is encountered or the entire

--- a/step-validate-schematron/src/main/xml/specification.xml
+++ b/step-validate-schematron/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='step-validate-schematron'
                class="ed" role="step"
                version="5.0-extension w3c-xproc">
 <info>

--- a/step-validate-xml-schema/src/main/xml/specification.xml
+++ b/step-validate-xml-schema/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='step-validate-xml-schema'
                class="ed" role="step"
                version="5.0-extension w3c-xproc">
 <info>

--- a/steps-intro/src/main/xml/specification.xml
+++ b/steps-intro/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='steps-intro'
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:p="http://www.w3.org/ns/xproc"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='steps'
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>

--- a/tools/xpl/formatspec.xpl
+++ b/tools/xpl/formatspec.xpl
@@ -8,11 +8,19 @@
                 name="main">
 <p:input port="source"/>
 <p:input port="parameters" kind="parameter"/>
-<p:output port="result"/>
+<p:output port="result">
+  <p:pipe step="format-docbook" port="result"/>
+</p:output>
 <p:serialization port="result" indent="false" method="xhtml"/>
 <p:option name="style" select="'dbspec.xsl'"/>
 
 <p:import href="https://cdn.docbook.org/release/latest/xslt/base/pipelines/docbook.xpl"/>
+
+<p:declare-step type="cx:message">
+  <p:input port="source" sequence="true"/>
+  <p:output port="result" sequence="true"/>
+  <p:option name="message" required="true"/>
+</p:declare-step>
 
 <p:declare-step type="pos:env">
   <p:output port="result"/>
@@ -20,7 +28,7 @@
 
 <pos:env/>
 
-<dbp:docbook format="html">
+<dbp:docbook name="format-docbook" format="html" return-secondary="true">
   <p:input port="source">
     <p:pipe step="main" port="source"/>
   </p:input>
@@ -51,5 +59,14 @@
                 select="string((/c:result/c:env[@name='DELTA_BASE' or @name='DELTA_LOCAL'])[1]/@value)"/>
 -->
 </dbp:docbook>
+
+<p:for-each>
+  <p:iteration-source>
+    <p:pipe step="format-docbook" port="secondary"/>
+  </p:iteration-source>
+  <p:store name="store-chunk" encoding="utf-8" indent="true" method="xml">
+    <p:with-option name="href" select="base-uri(/)"/>
+  </p:store>
+</p:for-each>
 
 </p:declare-step>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -22,7 +22,7 @@
 <xsl:include href="rngsyntax.xsl"/>
 <xsl:include href="xprocns.xsl"/>
 
-<xsl:output method="xhtml" indent="no" doctype-public="-//W3C//DTD XHTML 1.0 Strict//EN" doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"/>
+<xsl:output method="xhtml" indent="no"/>
 
 <xsl:output name="library" method="xml" indent="yes"/>
 
@@ -43,6 +43,17 @@
 
 <xsl:param name="resource.root"
            select="''"/> <!-- http://cdn.docbook.org/release/2.0.20/resources/'"/> -->
+
+<xsl:variable name="xspecmap" as="element()">
+  <xspecmap>
+    <map id="xproc" uri="http://spec.xproc.org/master/head/xproc"/>
+    <map id="steps" uri="http://spec.xproc.org/master/head/steps"/>
+    <map id="overview" uri="http://spec.xproc.org/master/head/overview"/>
+    <map id="step-valid-relax-ng" uri="http://spec.xproc.org/master/head/validate-with-relax-ng"/>
+    <map id="step-valid-schematron" uri="http://spec.xproc.org/master/head/validate-with-schematron"/>
+    <map id="step-valid-xml-schema" uri="http://spec.xproc.org/master/head/validate-with-xml-schema"/>
+  </xspecmap>
+</xsl:variable>
 
 <!-- Default macros -->
 <xsl:variable name="ml:defaultMacros" select="document($defaultMacros)"/>
@@ -772,6 +783,71 @@
     <span class="error">@@FIXME:MISSING </span>
   </xsl:if>
   <xsl:next-match/>
+</xsl:template>
+
+<xsl:template match="db:xspecref">
+  <xsl:variable name="spec" select="string(@spec)"/>
+  <xsl:variable name="xref" select="@xref/string()"/>
+  <xsl:variable name="tocfn" select="concat('../../', @spec, '/build/toc.xml')"/>
+ 
+  <xsl:choose>
+    <xsl:when test="doc-available($tocfn)">
+      <xsl:variable name="toc" select="doc($tocfn)/db:toc"/>
+      <xsl:choose>
+        <xsl:when test="@xref">
+          <xsl:variable name="entry" select="$toc//*[@xml:id=$xref]"/>
+          <xsl:choose>
+            <xsl:when test="empty($entry)">
+              <xsl:message>
+                <xsl:text>Error: no toc entry for </xsl:text>
+                <xsl:value-of select="@xref"/>
+                <xsl:text> in xspecref to </xsl:text>
+                <xsl:value-of select="@spec"/>
+              </xsl:message>
+              <xsl:text>[XSPECREF ERROR: </xsl:text>
+              <xsl:value-of select="@spec"/>
+              <xsl:text>/</xsl:text>
+              <xsl:value-of select="@xref"/>
+              <xsl:text>]</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <cite>
+                <a href="{string($xspecmap/*[@id=$spec]/@uri)}/#{@xref}">
+                  <xsl:choose>
+                    <xsl:when test="$entry/self::db:tocdiv">
+                      <xsl:apply-templates select="$entry/db:title/node()"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:apply-templates select="$entry/node()"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </a>
+              </cite>
+              <xsl:text> in </xsl:text>
+              <cite>
+                <a href="{string($xspecmap/*[@id=$spec]/@uri)}/">
+                  <xsl:apply-templates select="$toc/db:title/node()"/>
+                </a>
+              </cite>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:when>
+        <xsl:otherwise>
+          <cite>
+            <a href="{string($xspecmap/*[@id=$spec]/@uri)}/">
+              <xsl:apply-templates select="$toc/db:title/node()"/>
+            </a>
+          </cite>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:message>Error: no toc for xspecref to <xsl:value-of select="@spec"/></xsl:message>
+      <xsl:text>[XSPECREF ERROR: </xsl:text>
+      <xsl:value-of select="@spec"/>
+      <xsl:text>]</xsl:text>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/tools/xsl/xproc-specs.xsl
+++ b/tools/xsl/xproc-specs.xsl
@@ -23,6 +23,73 @@
 
 <xsl:key name="errcode" match="db:error" use="@code"/>
 
+<xsl:template match="/">
+  <xsl:if test="/*/@xml:id">
+    <xsl:result-document href="{/*/@xml:id}/build/toc.xml" method="xml">
+      <xsl:apply-templates mode="make-toc-xml"/>
+    </xsl:result-document>
+  </xsl:if>
+  <xsl:next-match/>
+</xsl:template>
+
+<!-- ============================================================ -->
+
+<xsl:template match="db:specification" mode="make-toc-xml">
+  <toc xmlns="http://docbook.org/ns/docbook"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+       xmlns:xi="http://www.w3.org/2001/XInclude">
+    <xsl:apply-templates mode="make-toc-xml"/>
+  </toc>
+</xsl:template>
+
+<xsl:template match="db:section[db:section|db:appendix]
+                     |db:appendix[db:section|db:appendix]"
+              mode="make-toc-xml" priority="200">
+  <tocdiv xmlns="http://docbook.org/ns/docbook"
+          role="{local-name(.)}">
+    <xsl:sequence select="@xml:id"/>
+    <xsl:apply-templates mode="make-toc-xml"/>
+  </tocdiv>
+</xsl:template>
+
+<xsl:template match="db:section|db:appendix" mode="make-toc-xml" priority="100">
+  <tocentry xmlns="http://docbook.org/ns/docbook"
+            role="{local-name(.)}">
+    <xsl:sequence select="@xml:id"/>
+    <xsl:sequence select="db:info/db:title/node()"/>
+  </tocentry>
+</xsl:template>
+
+<xsl:template match="db:specification/db:info/db:title
+                     |db:section/db:info/db:title
+                     |db:appendix/db:info/db:title"
+              mode="make-toc-xml" priority="100">
+  <xsl:sequence select="."/>
+</xsl:template>
+
+<xsl:template match="db:figure[@xml:id]|db:example[@xml:id]|db:table[@xml:id]"
+              mode="make-toc-xml" priority="100">
+  <xsl:if test="db:info/db:title">
+    <tocentry xmlns="http://docbook.org/ns/docbook"
+              role="{local-name(.)}">
+      <xsl:sequence select="@xml:id"/>
+      <xsl:sequence select="db:info/db:title/node()"/>
+    </tocentry>
+  </xsl:if>
+</xsl:template>
+
+<xsl:template match="element()" mode="make-toc-xml">
+  <xsl:apply-templates mode="make-toc-xml"/>
+</xsl:template>
+
+<xsl:template match="attribute()|text()|comment()|processing-instruction()"
+              mode="make-toc-xml">
+  <!-- nop -->
+</xsl:template>
+
+<!-- ============================================================ -->
+
 <xsl:template match="db:bibliomixed">
   <xsl:param name="label" select="f:biblioentry-label(.)"/>
 

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5,6 +5,7 @@
                xmlns:xlink="http://www.w3.org/1999/xlink"
                xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
                xmlns:xi="http://www.w3.org/2001/XInclude"
+               xml:id='xproc'
                class="ed"
                version="5.0-extension w3c-xproc">
 <info>


### PR DESCRIPTION
This PR adds an `xspecref` element with two attributes, `spec` that identifies the spec and `xref` that identifies the section of the spec. Here's an example from the validate-with-relax-ng spec:

```xml
For a more complete discussion of dynamic errors, see
<xspecref spec="xproc" xref="dynamic-errors"/>.
```
