### PR TITLE
Attempt to fix #273

### DIFF
--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -61,7 +61,8 @@ be loaded:
 
 <para>For an XML media type, the content is loaded and parsed as XML.</para>
 
-<para>If the <option>dtd-validate</option> parameter is <literal>true</literal>,
+<para>If the <option>dtd-validate</option> parameter is <literal>true</literal>
+and the document has a <literal>doctype</literal> declaration,
 then DTD validation must be performed when parsing the document.
 <error code="C0027">It is a <glossterm>dynamic error</glossterm> if a DTD
 validation is performed and the document is not valid.</error>


### PR DESCRIPTION
Clarifying, that a DTD validation on p:load is only performed, when "dtd-validation" is true and there is a doctype declaration in the document.