### PR TITLE
Added @tunnel to p:option (description only)

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4642,6 +4642,21 @@ default value.</error></para>
 the <tag class="attribute">select</tag> expression makes reference to
 the context node, size, or position.</error></para>
 
+  <para>An option may declare itself tunneling by specifying the value
+    <literal>true</literal> for the <tag class="attribute">tunnel</tag>
+    attribute. If a called step has declared an option as tunneling and
+    the calling step does not specify a value for that option using
+    <tag>p:with-option</tag>, the in-scope value from the calling step
+    is inherited. This allows passing often used options
+    implicitly.</para>
+  
+  <para><error code="S0088">It is a <glossterm>static error</glossterm> to
+    specify that an option as tunneling with a different type than
+    declared in the calling step. Option types are considered different
+    when the values of their <tag class="attribute">as</tag> attributes
+    differ after space normalization. </error>
+  </para>
+  
 </section>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
Hi. I added some text about the tunneling option to the specification. I don't feel enough at home to make the (probably simple) change to the schema also, so that remains to be done. 
It might also be that my writings are not exact enough for the implementors but it can serve as a starting point?