### PR TITLE
Attempt to fix issue 368

### DIFF
--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -83,6 +83,10 @@ the processor does not support DTD validation.</error></para>
 <title>Loading text data</title>
 <para>For a text media type, the content is loaded as a text document.</para>
 
+<para><error code="D0060">It is a <glossterm>dynamic error</glossterm> if the 
+<option>content-type</option> specifies an encoding, which is not supported 
+by the processor.</error></para>
+  
 <para><impl>Text parameters are <glossterm>implementation-defined</glossterm>.
 </impl></para>
 


### PR DESCRIPTION
Fixing #368: Added error for p:document/p:load with content-type "text/xxx; charset=yyyyy" where yyyy is not supported by the processor.