### PR TITLE
Attempt to fix issue 359

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5097,7 +5097,8 @@ or the provided map does not contain a "content-type" key, the value
 "<literal>application/xml</literal>" is assumed.
 </para>
 
-<para>How the content of a <tag>p:inline</tag> element is interpreted
+<para>The base URI of the document is the base URI of the p:inline element. 
+How the content of a <tag>p:inline</tag> element is interpreted
 depends on the document's content type and the <tag
 class="attribute">encoding</tag> attribute.
 </para>


### PR DESCRIPTION
Copy lost sentence from the XProc 1.0 spec into section p:inline. (issue #359)