### PR TITLE
Attempt to fix 382

### DIFF
--- a/steps/src/main/xml/steps/insert.xml
+++ b/steps/src/main/xml/steps/insert.xml
@@ -17,7 +17,7 @@ port's document relative to the matching elements in the
 <para>The value of the <option>match</option> option
 <rfc2119>must</rfc2119> be an XSLTMatchPattern. <error code="C0023">It
 is a <glossterm>dynamic error</glossterm> if that pattern matches
-anything other than element, text, processing-instruction, or comment nodes.</error>
+an attribute or a namespace node.</error>
 Multiple matches are
 allowed, in which case multiple copies of the <port>insertion</port>
 documents will occur. If no elements match, then the document is
@@ -43,10 +43,13 @@ the following list:
 </itemizedlist>
 
 <para><error code="C0025">It is a <glossterm>dynamic error</glossterm>
-if the match pattern matches anything other than an element node and
-the value of the <option>position</option> option is
+if the match pattern matches anything other than an element or a document
+node and the value of the <option>position</option> option is
 “<literal>first-child</literal>” or
-“<literal>last-child</literal>”.</error></para>
+“<literal>last-child</literal>”.</error> <error code="C0024">It is a 
+<glossterm>dynamic error</glossterm> if the match pattern matches a document 
+node and the value of the <option>position</option> is “<literal>before</literal>” or
+“<literal>after</literal>”.</error></para>
 
 <para>As the inserted elements are part of the output of the step they
 are not considered in determining matching elements. If an empty sequence


### PR DESCRIPTION
Fixing issue #382 by 
(1) allowing document nodes to be matched in general (so now only attribute node and namespace nodes are forbidden), 
(2) allowing document nodes to be matched, when position is first-/last-child.
(3) introducing new error (C0024) which is raised, when document node is matched and position is "before" or "after".