### PR TITLE
Attempt to fix #285

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -397,15 +397,15 @@ in an XProc pipeline is <glossterm>implementation-defined</glossterm>.</impl>
 <section xml:id="text-documents">
 <title>Text Documents</title>
 
-<para>Text documents are non-XML documents.
-<impl>Representations of text documents are are
-<glossterm>implementation-dependent</glossterm>.</impl>
-</para>
+<para>Text documents are non-XML documents. A text document is represented by
+a single text node wrapped in a document node as instances of the 
+<biblioref linkend="xpath-datamodel"/>.</para>
 
 <para>Text documents are identified by a text media type.
 <termdef xml:id="dt-text-media-type">Media types of the form
 “<literal>text/<replaceable>something</replaceable></literal>”
-are <firstterm baseform="text media type">text media types</firstterm>.
+are <firstterm baseform="text media type">text media types</firstterm> with the
+exception of “<literal>text/xml</literal>” which is an XML media type.
 </termdef>
 </para>
 </section>


### PR DESCRIPTION
Defining a text document as a text node wrapped in a document node.
Adding a clarification, that "text/xml" is not a text media type, but an XML media type as specified in section 2.2.1.1