### PR TITLE
Attempt to fix 387

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4169,10 +4169,7 @@ serialized implementations
 specified options are allowed.</para>
 
 <para>For XML outputs, see <xref linkend="xml-serialization"/>.
-For non-XML outputs, see <xref linkend="non-xml-serialization"/>.
-<error code="D0041">It is a <glossterm>dynamic error</glossterm> if the
-map contains any property name not recognized as a serialization
-parameter.</error></para>
+For non-XML outputs, see <xref linkend="non-xml-serialization"/>.</para>
 
 <section xml:id="xproc-serialization">
 <title>XML serialization</title>


### PR DESCRIPTION
Removing XD0041 because it is not consistent with XPath's treatment of serialization parameter maps.