### PR TITLE
Make ancillary build targets part of the distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,8 @@ task overview_src(dependsOn: ["overview:source"], type: Copy) {
 // ================================================================================
 
 task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
-                        "xproc:specification", "xproc_assets", "xproc_src" ],
+                        "xproc:specification", "xproc_assets", "xproc_src",
+                        "xproc_ancillary", "xproc_library"],
              type: DocBookTask) {
   inputs.files fileTree(dir: "tools/xsl/")
   inputs.files fileTree(dir: "tools/xpl/")
@@ -119,6 +120,25 @@ task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
 }
 allspecs.dependsOn "xproc"
 overview.dependsOn "xproc"
+
+task xproc_ancillary(dependsOn: [ "xproc10_rng", "xproc30_rnc", "xproc_rng" ], type: Copy) {
+  from "build/"
+  into "build/dist/xproc/"
+  include "xproc*.rnc"
+  include "xproc*.rng"
+}
+xproc_ancillary.doFirst {
+  mkdir("build/dist/xproc")
+}
+
+task xproc_library(dependsOn: [ "steps_xpl", "step_validation_xpl",
+                                "step_exec_xpl", "step_xquery_xpl",
+                                "step_xsl_formatter_xpl"]) {
+  println "FIXME: build a combined library.xpl file for xproc"
+}
+xproc_library.doFirst {
+  mkdir("build/dist/xproc")
+}
 
 task xproc_assets(dependsOn: [ "xproc_web_assets" ], type: Copy) {
   from "xproc/build/graphics"

--- a/step-exec/build.gradle
+++ b/step-exec/build.gradle
@@ -19,7 +19,7 @@ import com.xmlcalabash.XMLCalabashTask
 import com.nwalsh.tasks.StripAmblesTask
 
 task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   outputs.file "build/xinclude.xml"
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")

--- a/step-exec/src/main/xml/ancillary.xml
+++ b/step-exec/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-exec/src/main/xml/specification.xml
+++ b/step-exec/src/main/xml/specification.xml
@@ -260,4 +260,6 @@ failure causes the entire pipeline to fail.</para>
   </xi:fallback>
 </xi:include>
 
+<xi:include href="ancillary.xml"/>
+
 </specification>

--- a/step-validation/build.gradle
+++ b/step-validation/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.xmlcalabash.task'
 import com.xmlcalabash.XMLCalabashTask
 
 task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   outputs.file "build/xinclude.xml"
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")

--- a/step-validation/src/main/xml/ancillary.xml
+++ b/step-validation/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -338,4 +338,6 @@ failure causes the entire pipeline to fail.</para>
   </xi:fallback>
 </xi:include>
 
+<xi:include href="ancillary.xml"/>
+
 </specification>

--- a/step-xquery/build.gradle
+++ b/step-xquery/build.gradle
@@ -19,7 +19,7 @@ import com.xmlcalabash.XMLCalabashTask
 import com.nwalsh.tasks.StripAmblesTask
 
 task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   outputs.file "build/xinclude.xml"
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")

--- a/step-xquery/src/main/xml/ancillary.xml
+++ b/step-xquery/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-xquery/src/main/xml/specification.xml
+++ b/step-xquery/src/main/xml/specification.xml
@@ -317,4 +317,6 @@ failure causes the entire pipeline to fail.</para>
   </xi:fallback>
 </xi:include>
 
+<xi:include href="ancillary.xml"/>
+
 </specification>

--- a/step-xsl-formatter/build.gradle
+++ b/step-xsl-formatter/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'com.xmlcalabash.task'
 import com.xmlcalabash.XMLCalabashTask
 
 task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   outputs.file "build/xinclude.xml"
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")

--- a/step-xsl-formatter/src/main/xml/ancillary.xml
+++ b/step-xsl-formatter/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-xsl-formatter/src/main/xml/specification.xml
+++ b/step-xsl-formatter/src/main/xml/specification.xml
@@ -163,4 +163,6 @@ failure causes the entire pipeline to fail.</para>
   </xi:fallback>
 </xi:include>
 
+<xi:include href="ancillary.xml"/>
+
 </specification>

--- a/steps/src/main/xml/ancillary.xml
+++ b/steps/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/steps/src/main/xml/specification.xml
+++ b/steps/src/main/xml/specification.xml
@@ -119,4 +119,6 @@ steps is assumed; for background details, see
   </xi:fallback>
 </xi:include>
 
+<xi:include href="ancillary.xml"/>
+
 </specification>

--- a/xproc/build.gradle
+++ b/xproc/build.gradle
@@ -12,14 +12,7 @@ import com.nwalsh.tasks.StripAmblesTask
 // XInclude the sources
 
 task xinclude(dependsOn: [ ":spec_schemas" ], type: XMLCalabashTask) {
-  inputs.file "src/main/xml/specification.xml"
-  inputs.file "src/main/xml/conformance.xml"
-  inputs.file "src/main/xml/error-codes.xml"
-  inputs.file "src/main/xml/language-summary.xml"
-  inputs.file "src/main/xml/mediatype.xml"
-  inputs.file "src/main/xml/namespace-fixup.xml"
-  inputs.file "src/main/xml/parallel.xml"
-  inputs.file "src/main/xml/references.xml"
+  inputs.files fileTree(dir: "src/main/xml/")
   outputs.file "build/xinclude.xml"
   input("source", "src/main/xml/specification.xml")
   output("result", "build/xinclude.xml")
@@ -29,7 +22,7 @@ xinclude.doFirst {
   mkdir("build")
 }
 
-task source(dependsOn: ["glossary"], type: XMLCalabashTask) {
+task source(dependsOn: ["glossary", "xinclude"], type: XMLCalabashTask) {
   inputs.file "../tools/xsl/masterbib.xsl"
   inputs.file "../src/main/xml/bibliography.xml"
   inputs.file "src/main/xml/specification.xml"

--- a/xproc/src/main/xml/ancillary.xml
+++ b/xproc/src/main/xml/ancillary.xml
@@ -1,0 +1,41 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="xproc30.rnc"/>, <link xlink:href="xproc30.rng"/></term>
+<listitem>
+<para>A RELAX NG Schema for XProc 3.0 pipelines, in compact or XML form.
+</para>
+</listitem>
+</varlistentry>
+
+<varlistentry>
+<term><link xlink:href="xproc10.rnc"/>, <link xlink:href="xproc10.rng"/></term>
+<listitem>
+<para>A RELAX NG Schema for XProc 1.0 pipelines, in compact or XML form.
+</para>
+</listitem>
+</varlistentry>
+
+<varlistentry>
+<term><link xlink:href="xproc.rnc"/>, <link xlink:href="xproc.rng"/></term>
+<listitem>
+<para>A RELAX NG Schema for XProc pipelines, in compact or XML form.
+It will validate either XProc 1.0 pipelines or XProc 3.0 pipelines,
+depending on the value of the version attribute.
+</para>
+<para>In order to use this schema, you must also download the 1.0 and 3.0
+schemas; they are included into this one.</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/xproc/src/main/xml/handle-imports.xml
+++ b/xproc/src/main/xml/handle-imports.xml
@@ -1,0 +1,94 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="handling-imports">
+<title>Handling Circular and Re-entrant Library Imports (Non-Normative)</title>
+
+<para>When handling imports, an implementation needs to be able to detect the following
+      situations, and distinguish them from cases where multiple import chains produce genuinely
+      conflicting step definitions:</para>
+    <orderedlist>
+      <listitem>
+        <para>Circular imports: A imports B, B imports A.</para>
+      </listitem>
+      <listitem>
+        <para>Re-entrant imports: A imports B and C, B imports D, C imports D.</para>
+      </listitem>
+    </orderedlist>
+    <para>One way to achieve this is as follows:</para>
+    <para><termdef xml:id="dt-step-type-exports">The <firstterm>step type exports</firstterm> of an
+        XProc element, against the background of a set of URIs of resources already visited (call
+        this set <emphasis>Visited</emphasis>), are defined by cases.</termdef></para>
+    <para>The <link linkend="dt-step-type-exports">step type exports</link> of an XProc element are
+      as follows:</para>
+    <variablelist>
+      <varlistentry>
+        <term>p:declare-step</term>
+        <listitem>
+          <para>A singleton bag containing the <code>type</code> of the element</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>p:library</term>
+        <listitem>
+          <para>The <glossterm>bag-merger</glossterm> of the <glossterm>step type
+              exports</glossterm> of all the element's children</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>p:import</term>
+        <listitem>
+          <para>Let <emphasis>RU</emphasis> be the actual resolved URI of the resource identified by
+            the <code>href</code> of the element. If <emphasis>RU</emphasis> is a member of
+              <emphasis>Visited</emphasis>, then an empty bag, otherwise update
+              <emphasis>Visited</emphasis> by adding <emphasis>RU</emphasis> to it, and return the
+              <glossterm>step type exports</glossterm> of the document element of the retrieved
+            representation</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>all other elements</term>
+        <listitem>
+          <para>An empty bag</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+    <para>The changes to <emphasis>Visited</emphasis> mandated by the <code>p:import</code> case
+      above are persistent, not scoped. That is, not only the recursive processing of the imported
+      resource but also subsequent processing of siblings and ancestors must be against the
+      background of the updated value. In practice this means either using a side-effected global
+      variable, or not only passing <emphasis>Visited</emphasis> as an argument to any recursive or
+      iterative processing, but also <emphasis>returning</emphasis> its updated value for subsequent
+      use, along with the bag of step types.</para>
+    <para>Given a pipeline library document with actual resolved URI <emphasis>DU</emphasis>, <error
+        code="S0036">it is a <glossterm>static error</glossterm> if the <glossterm>step type
+          exports</glossterm> of the document element of the retrieved representation, against the
+        background of a singleton set containing <emphasis>DU</emphasis> as the initial
+          <emphasis>Visited</emphasis> set, contains any duplicates.</error></para>
+    <para>Given a top-level pipeline document with actual resolved URI <emphasis>DU</emphasis>,
+        <error code="S0036">it is a <glossterm>static error</glossterm> if the
+          <glossterm>bag-merger</glossterm> of the <glossterm>step type exports</glossterm> of the
+        document element of the retrieved representation with the <glossterm>step type
+          exports</glossterm> of its children, against the background of a singleton set containing
+          <emphasis>DU</emphasis> as the initial <emphasis>Visited</emphasis> set, contains any
+        duplicates.</error></para>
+    <para>Given a non-top-level <code>p:declare-step</code> element,
+        <error code="S0036">it is a <glossterm>static error</glossterm> if the
+          <glossterm>bag-merger</glossterm> of the <glossterm>step type exports</glossterm> of its
+        parent with the <glossterm>step type exports</glossterm> of its children, against the
+        background of a copy of the <emphasis>Visited</emphasis> set of its parent as the initial
+          <emphasis>Visited</emphasis> set, contains any duplicates.</error></para>
+    <para>The phrase "a copy of the <emphasis>Visited</emphasis> set" in the preceding paragraph is
+      meant to indicate that checking of non-top-level
+        <code>p:declare-step</code> elements does <emphasis>not</emphasis> have a persistent impact
+      on the checking of its parent. The contrast is that whereas changes to
+        <emphasis>Visited</emphasis> pass both up <emphasis>and</emphasis> down through
+        <code>p:import</code>, they pass only <emphasis>down</emphasis> through
+        <emphasis>p:declare-step</emphasis>.</para>
+    <para><termdef xml:id="dt-bag-merger">The <firstterm>bag-merger</firstterm> of two or more bags
+        (where a bag is an unordered list or, equivalently, something like a set except that it may
+        contain duplicates) is a bag constructed by starting with an empty bag and adding each
+        member of each of the input bags in turn to it. It follows that the cardinality of the
+        result is the sum of the cardinality of all the input bags.</termdef></para>
+</appendix>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5492,110 +5492,23 @@ possible set of parameter values.</para>
     </section>
   </section>
 
-  <xi:include href="conformance.xml"/>
-  <xi:include href="references.xml"/>
-  <xi:include href="../../../build/glossary.xml">
-    <xi:fallback>
-      <glossary xml:id="glossary">
-        <title>Glossary</title>
-        <para>Glossary needs to be generated</para>
-      </glossary>
-    </xi:fallback>
-  </xi:include>
-  <xi:include href="language-summary.xml"/>
-  <xi:include href="error-codes.xml"/>
-  <xi:include href="namespace-fixup.xml"/>
-  <appendix xml:id="handling-imports">
-    <title>Handling Circular and Re-entrant Library Imports (Non-Normative)</title>
-    <para>When handling imports, an implementation needs to be able to detect the following
-      situations, and distinguish them from cases where multiple import chains produce genuinely
-      conflicting step definitions:</para>
-    <orderedlist>
-      <listitem>
-        <para>Circular imports: A imports B, B imports A.</para>
-      </listitem>
-      <listitem>
-        <para>Re-entrant imports: A imports B and C, B imports D, C imports D.</para>
-      </listitem>
-    </orderedlist>
-    <para>One way to achieve this is as follows:</para>
-    <para><termdef xml:id="dt-step-type-exports">The <firstterm>step type exports</firstterm> of an
-        XProc element, against the background of a set of URIs of resources already visited (call
-        this set <emphasis>Visited</emphasis>), are defined by cases.</termdef></para>
-    <para>The <link linkend="dt-step-type-exports">step type exports</link> of an XProc element are
-      as follows:</para>
-    <variablelist>
-      <varlistentry>
-        <term>p:declare-step</term>
-        <listitem>
-          <para>A singleton bag containing the <code>type</code> of the element</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>p:library</term>
-        <listitem>
-          <para>The <glossterm>bag-merger</glossterm> of the <glossterm>step type
-              exports</glossterm> of all the element's children</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>p:import</term>
-        <listitem>
-          <para>Let <emphasis>RU</emphasis> be the actual resolved URI of the resource identified by
-            the <code>href</code> of the element. If <emphasis>RU</emphasis> is a member of
-              <emphasis>Visited</emphasis>, then an empty bag, otherwise update
-              <emphasis>Visited</emphasis> by adding <emphasis>RU</emphasis> to it, and return the
-              <glossterm>step type exports</glossterm> of the document element of the retrieved
-            representation</para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
-        <term>all other elements</term>
-        <listitem>
-          <para>An empty bag</para>
-        </listitem>
-      </varlistentry>
-    </variablelist>
-    <para>The changes to <emphasis>Visited</emphasis> mandated by the <code>p:import</code> case
-      above are persistent, not scoped. That is, not only the recursive processing of the imported
-      resource but also subsequent processing of siblings and ancestors must be against the
-      background of the updated value. In practice this means either using a side-effected global
-      variable, or not only passing <emphasis>Visited</emphasis> as an argument to any recursive or
-      iterative processing, but also <emphasis>returning</emphasis> its updated value for subsequent
-      use, along with the bag of step types.</para>
-    <para>Given a pipeline library document with actual resolved URI <emphasis>DU</emphasis>, <error
-        code="S0036">it is a <glossterm>static error</glossterm> if the <glossterm>step type
-          exports</glossterm> of the document element of the retrieved representation, against the
-        background of a singleton set containing <emphasis>DU</emphasis> as the initial
-          <emphasis>Visited</emphasis> set, contains any duplicates.</error></para>
-    <para>Given a top-level pipeline document with actual resolved URI <emphasis>DU</emphasis>,
-        <error code="S0036">it is a <glossterm>static error</glossterm> if the
-          <glossterm>bag-merger</glossterm> of the <glossterm>step type exports</glossterm> of the
-        document element of the retrieved representation with the <glossterm>step type
-          exports</glossterm> of its children, against the background of a singleton set containing
-          <emphasis>DU</emphasis> as the initial <emphasis>Visited</emphasis> set, contains any
-        duplicates.</error></para>
-    <para>Given a non-top-level <code>p:declare-step</code> element,
-        <error code="S0036">it is a <glossterm>static error</glossterm> if the
-          <glossterm>bag-merger</glossterm> of the <glossterm>step type exports</glossterm> of its
-        parent with the <glossterm>step type exports</glossterm> of its children, against the
-        background of a copy of the <emphasis>Visited</emphasis> set of its parent as the initial
-          <emphasis>Visited</emphasis> set, contains any duplicates.</error></para>
-    <para>The phrase "a copy of the <emphasis>Visited</emphasis> set" in the preceding paragraph is
-      meant to indicate that checking of non-top-level
-        <code>p:declare-step</code> elements does <emphasis>not</emphasis> have a persistent impact
-      on the checking of its parent. The contrast is that whereas changes to
-        <emphasis>Visited</emphasis> pass both up <emphasis>and</emphasis> down through
-        <code>p:import</code>, they pass only <emphasis>down</emphasis> through
-        <emphasis>p:declare-step</emphasis>.</para>
-    <para><termdef xml:id="dt-bag-merger">The <firstterm>bag-merger</firstterm> of two or more bags
-        (where a bag is an unordered list or, equivalently, something like a set except that it may
-        contain duplicates) is a bag constructed by starting with an empty bag and adding each
-        member of each of the input bags in turn to it. It follows that the cardinality of the
-        result is the sum of the cardinality of all the input bags.</termdef></para>
-  </appendix>
-  <xi:include href="parallel.xml"/>
-  <xi:include href="mediatype.xml"/>
+<xi:include href="conformance.xml"/>
+<xi:include href="references.xml"/>
+<xi:include href="../../../build/glossary.xml">
+  <xi:fallback>
+    <glossary xml:id="glossary">
+      <title>Glossary</title>
+      <para>Glossary needs to be generated</para>
+    </glossary>
+  </xi:fallback>
+</xi:include>
+<xi:include href="language-summary.xml"/>
+<xi:include href="error-codes.xml"/>
+<xi:include href="namespace-fixup.xml"/>
+<xi:include href="handle-imports.xml"/>
+<xi:include href="parallel.xml"/>
+<xi:include href="mediatype.xml"/>
+<xi:include href="ancillary.xml"/>
 
 <appendix xml:id="changelog">
 <title>Change Log</title>


### PR DESCRIPTION
For example, the schemas and step libraries.
