### PR TITLE
Attempt to fix 408

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5031,7 +5031,8 @@ attribute">extension
           port.</error></para>
         <para>The requested <tag class="attribute">xpath-version</tag>
           <rfc2119>must</rfc2119> be used to evaluate XPath expressions subject to the constraints
-          outlined in <xref linkend="xpath-context"/>.</para>
+          outlined in <xref linkend="xpath-context"/>. If the attribute is not specified, the value
+          “<literal>3.1</literal>” is assumed. </para>
         <para>The <tag class="attribute">psvi-required</tag> attribute allows the author to declare
           that a step relies on the processor's ability to pass PSVI annotations between steps, see
             <xref linkend="psvi-support"/>. If the attribute is not specified, the value
@@ -5050,6 +5051,14 @@ has no ancestors in the XProc namespace, then it <rfc2119>must</rfc2119>
 have a <tag class="attribute">version</tag> attribute.
 See <xref linkend="versioning-considerations"/>.</para>
 
+<para>The requested <tag class="attribute">xpath-version</tag>
+          <rfc2119>must</rfc2119> be used to evaluate XPath expressions subject to the constraints
+          outlined in <xref linkend="xpath-context"/>. If the attribute is not specified, the value
+          “<literal>3.1</literal>” is assumed. </para>
+        <para>The <tag class="attribute">psvi-required</tag> attribute allows the author to declare
+          that a step relies on the processor's ability to pass PSVI annotations between steps, see
+            <xref linkend="psvi-support"/>. If the attribute is not specified, the value
+            “<literal>false</literal>” is assumed. </para>
       <para>For a description of <tag class="attribute">psvi-required</tag>, see <xref
           linkend="psvi-support"/>; for <tag class="attribute">xpath-version</tag>, see <xref
           linkend="xpath-context"/>; for <tag class="attribute">exclude-inline-prefixes</tag>, see


### PR DESCRIPTION
Specifying default value of @xpath-version in prose.
Additionally explaining psvi-required for p:library.