### PR TITLE
Fix p:run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,12 +133,12 @@ xproc_ancillary.doFirst {
 
 task xproc_library(type: XMLCalabashTask,
                    dependsOn: [ "steps_xpl", "step_validation_xpl",
-                                "step_exec_xpl", "step_xquery_xpl",
+                                "step_exec_xpl", "step_run_xpl", "step_xquery_xpl",
                                 "step_xsl_formatter_xpl"]) {
   // N.B. Because Travis jobs cannot see the filesystem, we have
   // to list the dependencies twice. :-(
   String steps = ""
-  ["steps", "validation", "exec", "xquery", "xsl-formatter"].each { s->
+  ["steps", "validation", "exec", "run", "xquery", "xsl-formatter"].each { s->
     steps = steps + " ../../build/dist/" + s + "/steps.xpl"
   }
 
@@ -353,6 +353,54 @@ task step_exec_xpl(dependsOn: ["step-exec:library"], type: Copy) {
 }
 
 // ======================================================================
+// step-run
+
+task step_run(type: DocBookTask,
+               dependsOn: [ "xproc", "steps", "xproc_schemas", "spec_schemas",
+                            "step-run:specification",
+                            "step_run_assets",
+                            "step_run_src", "step_run_xpl" ]) {
+  inputs.files fileTree(dir: "tools/xsl/")
+  inputs.files fileTree(dir: "tools/xpl/")
+  inputs.file "xproc/build/toc.xml"
+  input("source", "step-run/build/source.xml")
+  output("result", "build/dist/run/index.html")
+
+  param("schemaext.schema", new File("build/schema/dbspec.rng"))
+  param("travis", getenv("TRAVIS"))
+  param("travis-commit", getenv("TRAVIS_COMMIT"))
+  param("travis-build-number", getenv("TRAVIS_BUILD_NUMBER"))
+  param("travis-user", getenv("TRAVIS_USER"))
+  param("travis-repo", getenv("TRAVIS_REPO"))
+  param("travis-branch", getenv("TRAVIS_BRANCH"))
+  param("travis-tag", getenv("TRAVIS_TAG"))
+
+  option("style", new File("tools/xsl/xproc-specs.xsl"))
+  pipeline "tools/xpl/formatspec.xpl"
+}
+allspecs.dependsOn "step_run"
+overview.dependsOn "step_run"
+
+task step_run_assets(type: Copy) {
+  from "src/main/resources"
+  into "build/dist/run/"
+}
+
+task step_run_src(dependsOn: ["step-run:source"], type: Copy) {
+  from "step-run/build/"
+  into "build/dist/run/"
+  include "source.xml"
+  rename ("source.xml", "specification.xml")
+}
+
+task step_run_xpl(dependsOn: ["step-run:library"], type: Copy) {
+  from "step-run/build/"
+  into "build/dist/run/"
+  include "library.xml"
+  rename ("library.xml", "steps.xpl")
+}
+
+// ======================================================================
 // step-xquery
 
 task step_xquery(type: DocBookTask,
@@ -492,13 +540,13 @@ core_rng.doFirst {
 task xproc30_rng(type: XMLCalabashTask,
                dependsOn: [ "core_rng",
                             "steps:rng", "step-validation:rng",
-                            "step-exec:rng", "step-xquery:rng",
+                            "step-exec:rng", "step-run:rng", "step-xquery:rng",
                             "step-xsl-formatter:rng" ]) {
   // This is bogus; I'm having trouble getting the filesystem read to
   // happen at the right time:
   // https://discuss.gradle.org/t/controlling-order-of-execution-of-statements-wrt-execution-of-a-task/26291
   String files = ""
-  ["step-exec", "step-xsl-formatter", "steps",
+  ["step-exec", "step-run", "step-xsl-formatter", "steps",
    "step-validation", "step-xquery"].each { s ->
     files = files + " ../../" + s + "/build/steps.rng"
   }

--- a/overview/src/main/xml/specification.xml
+++ b/overview/src/main/xml/specification.xml
@@ -92,6 +92,10 @@ and all optional steps.</para>
 </para>
 </listitem>
 <listitem>
+<para><xspecref spec="step-run"/>
+</para>
+</listitem>
+<listitem>
 <para><xspecref spec="step-xquery"/>
 </para>
 </listitem>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
 include 'overview', 'xproc', 'steps', 'steps-intro', 'step-validation',
-        'step-exec', 'step-xquery', 'step-xsl-formatter'
+        'step-exec', 'step-xquery', 'step-xsl-formatter', 'step-run'

--- a/step-exec/src/main/xml/specification.xml
+++ b/step-exec/src/main/xml/specification.xml
@@ -30,7 +30,7 @@
 </authorgroup>
 
 <abstract>
-<para>This specification describes the <code>p:validate-with-relax-ng</code>
+<para>This specification describes the <code>p:exec</code>
 step for
 <citetitle>XProc 3.0: An XML Pipeline Language</citetitle>.</para>
 </abstract>

--- a/step-run/build.gradle
+++ b/step-run/build.gradle
@@ -1,0 +1,107 @@
+configurations {
+  tools {
+    description = "Run tools"
+    transitive = true
+  }
+}
+
+dependencies {
+  tools (
+    fileTree(dir: '../tools/lib').include("*.jar")
+  )
+}
+
+defaultTasks 'specification'
+
+apply plugin: 'com.xmlcalabash.task'
+
+import com.xmlcalabash.XMLCalabashTask
+import com.nwalsh.tasks.StripAmblesTask
+
+task xinclude(dependsOn: [":spec_schemas"], type: XMLCalabashTask) {
+  inputs.files fileTree(dir: "src/main/xml/")
+  outputs.file "build/xinclude.xml"
+  input("source", "src/main/xml/specification.xml")
+  output("result", "build/xinclude.xml")
+  pipeline "../tools/xpl/validate.xpl"
+}
+xinclude.doFirst {
+  mkdir("build")
+}
+
+task source(dependsOn: ["glossary"], type: XMLCalabashTask) {
+  inputs.file "../tools/xsl/masterbib.xsl"
+  inputs.file "../src/main/xml/bibliography.xml"
+  inputs.file "src/main/xml/specification.xml"
+  inputs.file "build/glossary.xml"
+  outputs.file "build/source.xml"
+  input("source", "src/main/xml/specification.xml")
+  output("result", "build/source.xml")
+  pipeline "../tools/xpl/validate.xpl"
+}
+
+task glossary(dependsOn: ["xinclude"], type: XMLCalabashTask) {
+  inputs.file "build/xinclude.xml"
+  inputs.file "../tools/xpl/makeglossary.xpl"
+  inputs.file "../tools/xsl/makeglossary.xsl"
+  outputs.file "build/glossary.xml"
+  input("source", "build/xinclude.xml")
+  output("result", "build/glossary.xml")
+  pipeline "../tools/xpl/makeglossary.xpl"
+}
+
+task library(dependsOn: ["source"], type: XMLCalabashTask) {
+  inputs.file "build/source.xml"
+  inputs.file "../tools/xpl/typed-pipeline-library.xpl"
+  inputs.file "../tools/xsl/typed-pipeline-library.xsl"
+  outputs.file "build/library.xml"
+  input("source", "build/source.xml")
+  output("result", "build/library.xml")
+  pipeline "../tools/xpl/typed-pipeline-library.xpl"
+}
+
+task rnc(dependsOn: ["library"], type: XMLCalabashTask) {
+  inputs.file "build/library.xml"
+  inputs.file "../tools/xpl/library-to-rnc.xpl"
+  inputs.file "../tools/xsl/library-to-rnc.xsl"
+  outputs.file "build/steps.rnc"
+  input("source", "build/library.xml")
+  output("result", "build/steps.rnc")
+  pipeline "../tools/xpl/library-to-rnc.xpl"
+}
+
+task rng(dependsOn: ["rnc"], type: JavaExec) {
+  inputs.file "build/steps.rnc"
+  outputs.file "build/steps.rng"
+  classpath = configurations.tools
+  main = 'com.thaiopensource.relaxng.translate.Driver'
+  args = ["build/steps.rnc", "build/steps.rng"]
+}
+
+task specification(dependsOn: [ "source", "library", "rng" ]) {
+  // nop
+}
+
+// ================================================================================
+// Process the examples
+
+def stripFiles = [ ]
+
+stripFiles.each { String name ->
+  String newname = name.substring(0, name.lastIndexOf(".")) + ".txt"
+
+  task "process_$name"(type: StripAmblesTask) {
+    input = file("src/main/examples/$name")
+    output = file("$buildDir/examples/$newname")
+  }
+  xinclude.dependsOn "process_$name"
+}
+
+// ================================================================================
+// Process the examples
+
+task clean() {
+  doFirst {
+    delete("build")
+  }
+}

--- a/step-run/src/main/xml/ancillary.xml
+++ b/step-run/src/main/xml/ancillary.xml
@@ -1,0 +1,21 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xmlns:xlink="http://www.w3.org/1999/xlink"
+	  xmlns:xi="http://www.w3.org/2001/XInclude"
+	  version="5.0-extension w3c-xproc"
+	  xml:id="ancillary-files">
+<title>Ancillary files</title>
+
+<para>This specification includes by reference a number of
+ancillary files.</para>
+
+<variablelist>
+<varlistentry>
+<term><link xlink:href="steps.xpl"/></term>
+<listitem>
+<para>An XProc step library for the declared steps.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+</appendix>

--- a/step-run/src/main/xml/conformance.xml
+++ b/step-run/src/main/xml/conformance.xml
@@ -1,0 +1,42 @@
+<appendix xmlns="http://docbook.org/ns/docbook"
+	  xml:id="conformance">
+<title>Conformance</title>
+
+<para>Conformant processors <rfc2119>must</rfc2119> implement all of the features
+described in this specification except those that are explicitly identified
+as optional.</para>
+
+<para>Some aspects of processor behavior are not completely specified; those
+features are either <glossterm role='unwrapped'>implementation-dependent</glossterm> or
+<glossterm role='unwrapped'>implementation-defined</glossterm>.</para>
+
+<para><termdef xml:id="dt-implementation-dependent">An
+<firstterm>implementation-dependent</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Implementations are not required to document or explain
+how <glossterm role='unwrapped'>implementation-dependent</glossterm> features are performed.</termdef>
+</para>
+
+<para><termdef xml:id="dt-implementation-defined">An
+<firstterm>implementation-defined</firstterm> feature is one where the
+implementation has discretion in how it is performed.
+Conformant implementations <rfc2119>must</rfc2119> document
+how <glossterm role='unwrapped'>implementation-defined</glossterm> features are performed.</termdef>
+</para>
+
+<section xml:id="implementation-defined">
+<title>Implementation-defined features</title>
+
+<para>The following features are implementation-defined:</para>
+
+<?implementation-defined-features?>
+</section>
+
+<section xml:id="implementation-dependent">
+<title>Implementation-dependent features</title>
+
+<para>The following features are implementation-dependent:</para>
+
+<?implementation-dependent-features?>
+</section>
+</appendix>

--- a/step-run/src/main/xml/run.xml
+++ b/step-run/src/main/xml/run.xml
@@ -1,7 +1,10 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.exec">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xml:id="c.run">
 <title>p:run</title>
-
-<para>THIS IS UNREVIEWED PLACHOLDER TEXT</para>
 
 <para>The <tag>p:run</tag> step runs a dynamically loaded pipeline.</para>
 
@@ -12,14 +15,13 @@
 
 <para>THIS IS UNREVIEWED PLACHOLDER TEXT</para>
 
-<!--
 <para>The <tag>p:run</tag> step functions mostly like an atomic step in that
 you can define inputs connections and option values for it. However,
 unlike atomic steps, it has no defined signature. Any inputs are
 allowed and any outputs may be connected.
 </para>
 
-<para>One input port is specificaly designated the pipeline input
+<para>One input port is specifically designated the pipeline input
 port. By default, that port is named <port>pipeline</port>, but its
 name can be changed by specifying a different name in the
 <option>p:pipeline</option> option.
@@ -51,6 +53,5 @@ the pipeline evaluated does not have a primary output port, an empty
 sequence appears on that port. (Alternatively, that could be a dynamic
 error)
 </para>
--->
 
 </section>

--- a/step-run/src/main/xml/specification.xml
+++ b/step-run/src/main/xml/specification.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<specification xmlns="http://docbook.org/ns/docbook"
+               xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
+               xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+               xmlns:p="http://www.w3.org/ns/xproc"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xmlns:xlink="http://www.w3.org/1999/xlink"
+               xml:id='step-run'
+               class="ed" role="step"
+               version="5.0-extension w3c-xproc">
+<info>
+<title>XProc 3.0: Run</title>
+<!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
+<copyright><year>2018</year><holder>@@FIXME:</holder></copyright>
+
+<bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+<authorgroup>
+  <author>
+    <personname>Achim Berndzen</personname>
+  </author>
+  <author>
+    <personname>Gerrit Imsieke</personname>
+  </author>
+  <author>
+    <personname>Erik Siegel</personname>
+  </author>
+  <author>
+    <personname>Norman Walsh</personname>
+  </author>
+</authorgroup>
+
+<abstract>
+<para>This specification describes the <code>p:run</code>
+step for
+<citetitle>XProc 3.0: An XML Pipeline Language</citetitle>.</para>
+</abstract>
+
+<legalnotice role="status">
+
+<para><emphasis>This section describes the status of this document at
+the time of its publication. Other documents may supersede this
+document.</emphasis></para>
+
+<para>This document is derived from
+<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
+An XML Pipeline Language</link> published by the W3C.</para>
+</legalnotice>
+</info>
+
+<section xml:id="introduction">
+<title>Introduction</title>
+
+<para>This specification describes the <code>p:run</code> XProc step.
+A machine-readable description of these steps may be found in
+<link xlink:href="steps.xpl">steps.xpl</link>.
+</para>
+
+<para>Familarity with the general nature of <biblioref linkend="xproc30"/>
+steps is assumed; for background details, see
+<biblioref linkend="xproc30-steps"/>.</para>
+</section>
+
+<section xml:id="c.run">
+<title>p:run</title>
+
+<para>The <tag>p:run</tag> step runs a dynamically loaded pipeline.</para>
+
+<p:declare-step type="p:run">
+  <p:input port="source" primary="true" sequence="true" content-types="*/*"/>
+  <p:output port="result" primary="true" content-types="*/*"/>
+</p:declare-step>
+
+<para>THIS IS UNREVIEWED PLACHOLDER TEXT</para>
+
+<para>The <tag>p:run</tag> step functions mostly like an atomic step in that
+you can define inputs connections and option values for it. However,
+unlike atomic steps, it has no defined signature. Any inputs are
+allowed and any outputs may be connected.
+</para>
+
+<para>One input port is specifically designated the pipeline input
+port. By default, that port is named <port>pipeline</port>, but its
+name can be changed by specifying a different name in the
+<option>p:pipeline</option> option.
+</para>
+
+<para>The <tag>p:run</tag> step
+expects a single pipeline document on the pipeline port.
+<error code="C0080">It is a <glossterm>dynamic error</glossterm>
+if the pipeline input to the <tag>p:run</tag> step is not a
+valid pipeline.
+</error>
+</para>
+
+<para>The pipeline that appears on the pipeline port is evaluated
+using the inputs and options specified on the <tag>p:run</tag> step.
+<error code="C0081">It is a <glossterm>dynamic error</glossterm>
+if the pipeline has inputs that are not specified on the <tag>p:run</tag> step.
+</error>
+<error code="C0082">It is a <glossterm>dynamic error</glossterm>
+if the pipeline has required options that are not specified on
+the <tag>p:run</tag> step.
+</error>
+</para>
+
+<para>The outputs of the pipeline appear on the correspondingly named output
+ports of the <tag>p:run</tag> step. If the pipeline has an output is
+not bound on the <tag>p:run</tag> step, that output is discarded. If
+the <tag>p:run</tag> step has an output port that is not provided by
+the pipeline, an empty sequence appears on that port.
+</para>
+
+<para>The <tag>p:run</tag> step is assumed to have a primary output port. If
+the pipeline evaluated does not have a primary output port, an empty
+sequence appears on that port. (Alternatively, that could be a dynamic
+error)
+</para>
+
+<section>
+<title>Document properties</title>
+<para feature="exec-preserves-none">No document properties are preserved.</para>
+</section>
+</section>
+
+<section xmlns="http://docbook.org/ns/docbook" xml:id="errors">
+<title>Step Errors</title>
+
+<para>This step can raise
+<glossterm baseform="dynamic-error">dynamic errors</glossterm>.
+</para>
+
+<para>The following errors can be raised by this step:</para>
+
+<?step-error-list level="none"?>
+
+</section>
+
+<xi:include href="conformance.xml"/>
+
+<appendix xml:id="references">
+<title>References</title>
+<bibliolist>
+<bibliomixed xml:id="xproc30"/>
+<bibliomixed xml:id="xproc30-steps"/>
+</bibliolist>
+</appendix>
+
+<!-- This glossary will automatically be elided if there are no
+     terms marked up as 'firstterm's in this specification. -->
+<xi:include href="../../../build/glossary.xml">
+  <xi:fallback>
+    <glossary xml:id="glossary">
+      <title>Glossary</title>
+      <para>Glossary needs to be generated</para>
+    </glossary>
+  </xi:fallback>
+</xi:include>
+
+<xi:include href="ancillary.xml"/>
+
+</specification>


### PR DESCRIPTION
The `p:run` step has been sitting orphaned in the steps specification. It's clearly going to be optional, so I think that means it should be a separate spec under the new rules. This PR pulls it out and makes it so. I've clearly labeled the prose as "unreviewed".
