### PR TITLE
Attempt to fix #440

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5523,8 +5523,9 @@ optionally preceded and/or followed by whitespace, in any namespace
 other than the XProc namespace, occurs where a <tag>p:inline</tag> is
 allowed, each is treated as if it was enclosed within a
 <tag>p:inline</tag> element (with no attributes). Any preceding or
-following whitespace is discarded. Any <tag>p:documentation</tag> or 
-<tag>p:pipeinfo</tag> before, between and after this elements is ignored.</para>
+following whitespace is discarded. Elements in the XProc namespace are 
+forbidden except for <tag>p:documentation</tag>
+and <tag>p:pipeinfo</tag> which are ignored.</para>
 
 <para>The following example demonstrates this implicit behaviour:</para>
 

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5523,7 +5523,8 @@ optionally preceded and/or followed by whitespace, in any namespace
 other than the XProc namespace, occurs where a <tag>p:inline</tag> is
 allowed, each is treated as if it was enclosed within a
 <tag>p:inline</tag> element (with no attributes). Any preceding or
-following whitespace is discarded.</para>
+following whitespace is discarded. Any <tag>p:documentation</tag> or 
+<tag>p:pipeinfo</tag> before, between and after this elements is ignored.</para>
 
 <para>The following example demonstrates this implicit behaviour:</para>
 


### PR DESCRIPTION
Fixing #440 by explicitly saying that p:documentation and p:pipeinfo are ignored.