### PR TITLE
Attempt to fix-484

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4922,9 +4922,10 @@ to specify that an option is both <tag class="attribute">required</tag>
 <emphasis>and</emphasis> static.</error></para>
 </listitem>
 <listitem>
-<para><error code="D0026">It is a <glossterm>dynamic error</glossterm> if
-the <tag class="attribute">select</tag> expression makes reference to
-the context node, size, or position.</error></para>
+<para><error code="S0097">It is a <glossterm>static error</glossterm> if
+the <tag class="attribute">select</tag> expression can not be evaluted because
+it is no valid XPath expression or makes reference to the context node, size, 
+or position.</error></para>
 </listitem>
 </itemizedlist>
 </section>


### PR DESCRIPTION
Introducing new static error (S0097) raised, when @select on p:option is syntactically invalid or makes reference to context node, size, or position.