### PR TITLE
Attempt to fix #450

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3133,8 +3133,9 @@ attribute">extension attributes</glossterm>.</error>
               no visible declaration may raise this error. </error></para>
         </listitem>
         <listitem>
-          <para><error code="S0037">It is a <glossterm>static error</glossterm> if any step directly
-              contains text nodes that do not consist entirely of whitespace.</error>
+          <para><error code="S0037">It is a <glossterm>static error</glossterm> if any user extension 
+            step or any element in the XProc namespace other than <tag>p:inline</tag> directly contains 
+            text nodes that do not consist entirely of whitespace.</error>
           </para>
         </listitem>
         <listitem>


### PR DESCRIPTION
Fixing #450 by changing the error text of XS0037 to cover all cases of non-whitespace text nodes.