### PR TITLE
Make clear that a successful report is the same as a failed assert

### DIFF
--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -142,7 +142,7 @@ processing to the <port>source</port> document.</para>
 
 <para><error code="C0054">It is a <glossterm>dynamic error</glossterm>
 if the <option>assert-valid</option> option is <literal>true</literal>
-and any Schematron assertions fail.</error></para>
+and any Schematron assertions fail or reports succeed.</error></para>
 
 <para>The value of the <option>phase</option> option identifies the
 Schematron validation phase with which validation begins.</para>


### PR DESCRIPTION
Close #474 

I updated the description of err:XC0054 in a way that I think will clarify the point.
