### PR TITLE
Clarify the way lists work in p:directory-list

### DIFF
--- a/steps/src/main/xml/steps/directory-list.xml
+++ b/steps/src/main/xml/steps/directory-list.xml
@@ -32,17 +32,27 @@ see <xref linkend="dir-list-details"/>.</para>
 
 <para>If present, the value of the <option>include-filter</option>
 or <option>exclude-filter</option>
-option <rfc2119>must</rfc2119> be a regular expression as specified in <biblioref linkend="xpath-functions"/>, section 7.61 “<literal>Regular Expression
+option <rfc2119>must</rfc2119> be a list of regular expression as specified in <biblioref linkend="xpath-functions"/>, section 7.61 “<literal>Regular Expression
 Syntax</literal>”.</para>
 
-  <para>If the <option>include-filter</option> pattern matches a directory
-    entry's name, the entry is included in the output. If the
-      <option>exclude-filter</option> pattern matches a directory entry's name,
-    the entry is excluded in the output. If both options are provided, the
-    include filter is processed first, then the exclude filter. As a result: An
-    item is included if it matches (at least) one of the
-      <option>include-filter</option> values and none of the
-      <option>exclude-filter</option> values.</para>
+<para>If any <option>include-filter</option> pattern matches a
+directory entry's name, the entry is included in the output. If any
+<option>exclude-filter</option> pattern matches a directory entry's
+name, the entry is excluded in the output. If both options are
+provided, the include filter is processed first, then the exclude
+filter. As a result: an item is included if it matches (at least) one
+of the <option>include-filter</option> values and none of the
+<option>exclude-filter</option> values.</para>
+
+<note>
+<para>There is no way to specify a list of values using attribute value
+templates. If the option shortcut syntax is used to provide the
+<option>include-filter</option> or <option>exclude-filter</option> option,
+it will consist of a single regular expression. To specify a list of
+regular expressions, you must use the  <tag>p:with-option</tag>
+syntax.
+</para>
+</note>
 
 <para xml:id="cv.directory">The result document produced for
 the specified directory path has a <tag>c:directory</tag> document


### PR DESCRIPTION
Assuming we keep lists, we have to clarify how they work.