### PR TITLE
Removed XS0005 as part of fixing issue-482

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -526,14 +526,7 @@ output named “<literal>result</literal>”, and the same set of options.
          <para>The <glossterm>declared outputs</glossterm> of a step are only connected when they
             are used by another step or expression.  Usually, this connection is made in reverse
             where the use of the output describes the connection (see <xref linkend="connections"
-            />).</para>
-
-<para>The <glossterm>primary output port</glossterm> of a step
-<rfc2119>must</rfc2119> be connected to some consumer. <error
-code="S0005">It is a <glossterm>static error</glossterm> if the
-primary output port of any step is not connected.</error> Other
-outputs can remain unconnected. Any documents produced on an
-unconnected output port are discarded.</para>
+            />). Any documents produced on an unconnected output port are discarded.</para>
 
 <para>Primary input and primary output ports may be implicitly
 connected if no explicit connection is given, see <xref


### PR DESCRIPTION
The rule, that primary output port have to be connected to something does not hold anymore.