### PR TITLE
Added p:message to the spec

### DIFF
--- a/steps-intro/src/main/xml/specification.xml
+++ b/steps-intro/src/main/xml/specification.xml
@@ -153,44 +153,51 @@ linkend="rfc2119"/>.</para>
   
 <section xml:id="common-options">
 <title>Common options</title>
-<para>All XProc steps <rfc2119>must</rfc2119> accept the option 
-<option>p:timeout</option>. As a debugging tool this option can be used 
-to tell the XProc processor that a step with such an option should be terminated 
-if its execution does take more time than expected. The value of the 
-<option>p:timeout</option> option must be a <type>xs:positiveInteger</type>. 
-It is interpreted as the maximal number of seconds the step is expected to run. The 
-measurement of time starts after all bindings for input ports and all options are evaluated. 
-If the XProc processor realizes a longer runtime, it should terminate the execution of the step 
-as soon as possible, do cleanup to ensure proper execution of other steps in 
-the pipeline and then raise a dynamic error.</para>
+  
+  <note>
+    <title>Note</title>
+    <para>Note that these options are always in the XProc namespace. This limits the extent to which the
+      option restricts the space of available option names for steps.
+      (If the option name wasn’t in a namespace, then no step could have an option with the same name as the common
+      option, for instance “<literal>timeout</literal>”, which seems unreasonable.)
+    </para>
+  </note>
+  
+      <section>
+        <title>p:timeout</title>
+        <para>All XProc steps <rfc2119>must</rfc2119> accept the option <option>p:timeout</option>. As a debugging tool
+          this option can be used to tell the XProc processor that a step with such an option should be terminated if
+          its execution does take more time than expected. The value of the <option>p:timeout</option> option must be a
+            constant <type>xs:positiveInteger</type> (not an AVT). It is interpreted as the maximal number of seconds the step is expected to
+          run. The measurement of time starts after all bindings for input ports and all options are evaluated. If the
+          XProc processor realizes a longer runtime, it should terminate the execution of the step as soon as possible,
+          do cleanup to ensure proper execution of other steps in the pipeline and then raise a dynamic error.</para>
 
-<para><error code="D0053">It is a <glossterm>dynamic error</glossterm> if a step runs 
-longer than its timeout value.</error> <impl>It is
-<glossterm>implementation-defined</glossterm> whether a processor supports
-timeouts, and if it does, how precisely and precisely how the
-execution time of a step is measured.</impl>
-</para>
+        <para><error code="D0053">It is a <glossterm>dynamic error</glossterm> if a step runs longer than its timeout
+            value.</error>
+          <impl>It is <glossterm>implementation-defined</glossterm> whether a processor supports timeouts, and if it
+            does, how precisely and precisely how the execution time of a step is measured.</impl>
+        </para>
 
-<note>
-<title>Note</title>
-<para>Since the exact time a step takes to perform its task depends on the used computer, 
-the XProc processor's execution strategy, the system load etc., this feature can not 
-be used as an exact timing tool in XProc. Execution times may vary on different executions 
-of the same pipeline on the same computer and the same XProc processor due to  
-execution contingencies. Developers are advised to calculate the value for p:timeout 
-generously, so the dynamic error is raised only in extreme cases.</para>
-</note>
-
-<note>
-<title>Note</title>
-<para>Note that the name of this option is <option>p:timeout</option>
-even on steps in the XProc namespace. This limits the extent to which the
-option restricts the space of available option names for steps.
-(If the option name wasn’t in a namespace, then no step could have an option
-named “<literal>timeout</literal>” which seems unreasonable.)
-</para>
-</note>
-</section>
+        <note>
+          <title>Note</title>
+          <para>Since the exact time a step takes to perform its task depends on the used computer, the XProc
+            processor's execution strategy, the system load etc., this feature can not be used as an exact timing tool
+            in XProc. Execution times may vary on different executions of the same pipeline on the same computer and the
+            same XProc processor due to execution contingencies. Developers are advised to calculate the value for
+            p:timeout generously, so the dynamic error is raised only in extreme cases.</para>
+        </note>
+      </section>
+  
+      <section>
+        <title>p:message</title>
+        <para>All XProc steps <rfc2119>must</rfc2119> accept the option <option>p:message</option>. Its value is an AVT.
+          The resulting attribute's value can be made available by the processor for debugging purposes, for instance
+          written to the standard output or to a log file.</para>
+        <para>It is <glossterm>implementation-defined</glossterm> whether a processor supports messages, and if it does,
+          under which conditions and how the message is made available.</para>
+      </section>
+  
 </section>
 
 <section xmlns="http://docbook.org/ns/docbook" xml:id="errors">


### PR DESCRIPTION
This resolves #29. I did a bit of refactoring in the text's structure to make it more logical. 