### PR TITLE
Attempt to fix 548

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3971,7 +3971,8 @@ expression is ignored.</para>
 <listitem>
 <para>The <tag class="attribute">content-types</tag> attribute lists one
 or more (space separated) content types that this input port will
-accept. A content type must be of the form
+accept. If the attribute is not specified, <literal>*/*</literal> is assumed. 
+A content type must be of the form
 “<literal><replaceable>type</replaceable>/<replaceable>subtype</replaceable>+<replaceable>ext</replaceable></literal>”
 where any of <replaceable>type</replaceable>,
 <replaceable>subtype</replaceable>, and <replaceable>ext</replaceable>


### PR DESCRIPTION
Fixing issue #548 by explicitly saying, that the default value of content-types on p:input is "\*/*".