### PR TITLE
Fix typos in description of document-properties functions

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1829,13 +1829,16 @@ of a document as an XML document.</para>
 <methodparam><type>item()</type><parameter>doc</parameter></methodparam>
 </methodsynopsis>
 
-<para>The document returned is a <code>p:document-properties</code>
+<para>The document returned is a <code>c:document-properties</code>
 document that contains (exclusively) the document properties
 associated with the <parameter>doc</parameter> specified. Each key in the
 properties becomes an element, each value becomes the content of that element.
 For atomic values other than string, an
 <tag class="attribute">xsi:type</tag> attribute is added to identify the
 type of the value.</para>
+
+<para>If the item is not associated with a document, the resulting document
+will be empty.</para>
 
 <para>The <function>p:document-properties-document</function> function behaves
 normally during static anlaysis.</para>


### PR DESCRIPTION
I don't believe these will be controversial changes, but they will break some tests.
1. I assume that making the output a `p:` document and not a `c:` document was a simple oversight.
2. I clarified that `p:document-properties-document` behaves the same way as `p:document-properties` if the item passed in is not associated with a document.
