### PR TITLE
Add static error for p: attributes on p: elements

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -2881,6 +2881,9 @@ explicitly in the XProc namespace. They are in no namespace when they
 appear on an XProc element; they are in the XProc namespace when they
 are on an element in any other namespace. In this way, they do not
 conflict with the names used in other vocabularies.
+<error code="S0097">It is a <glossterm>static error</glossterm> if an
+attribute in the XProc namespace appears on an element in the XProc
+namespace.</error>
 </para>
 
 <section xml:id="expand-text-attribute">
@@ -2926,8 +2929,8 @@ nodes <emphasis>are</emphasis> value templates.</para>
 
 <!-- feature="no-p-expand-text-on-p"-->
 <para><error code="S0084">It is a <glossterm>static error</glossterm>
-if the <tag class="attribute">p:inline-expand-text</tag> attribute appears on
-any element in the XProc namespace that is not a descendant of a
+if the <tag class="attribute">[p:]inline-expand-text</tag> attribute appears on
+any element that is not a descendant of a
 <tag>p:inline</tag> element or implicit inline.</error>
 </para>
 </section>


### PR DESCRIPTION
Fix #582 

1. This PR adds a static error for p: attributes on p: elements
2. It also fixes what I assume was a carelessly structured description of err:XS0084.