### PR TITLE
Clarify serialization in p:document-properties-map

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1818,13 +1818,19 @@ repeated for each item in the sequence.
 </para>
 </listitem>
 <listitem>
-<para>If a value is a map, the element content is the JSON serialization
-of that map.
+<para>If a map appears as a value, the property element will have an
+attribute named <tag class="attribute">map</tag> with the value “<code>true</code>”.
+<impl>It is <glossterm>implementation-defined</glossterm> how or if a
+processor attempts to serialize maps that appear in document properties.</impl>
+If the implementation does not serialize maps, the property element will be empty.
 </para>
 </listitem>
 <listitem>
-<para>If a value is an array, the element content is the JSON serialization
-of that array.
+<para>If an array appears as a value, the property element will have an
+attribute named <tag class="attribute">array</tag> with the value “<code>true</code>”.
+<impl>It is <glossterm>implementation-defined</glossterm> how or if a
+processor attempts to serialize arrays that appear in document properties.</impl>
+If the implementation does not serialize arrays, the property element will be empty.
 </para>
 </listitem>
 <listitem>
@@ -2641,7 +2647,10 @@ appear on the <code>messages</code> port.</para>
       </variablelist>
       <para>This specification also makes use of the prefix “<literal>xs:</literal>” to refer to the
           <biblioref linkend="xmlschema-1"/> namespace <uri type="xmlnamespace"
-          >http://www.w3.org/2001/XMLSchema</uri>. </para>
+          >http://www.w3.org/2001/XMLSchema</uri> and the prefix “<literal>xsi:</literal>”
+          to refer to the namepace <uri type="xmlnamespace"
+          >http://www.w3.org/2001/XMLSchema-instance</uri>
+      </para>
     </section>
     <section xml:id="scoping">
       <title>Scoping of Names</title>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1797,16 +1797,47 @@ of a document as an XML document.</para>
 <methodparam><type>item()</type><parameter>doc</parameter></methodparam>
 </methodsynopsis>
 
-<para>The document returned is a <code>c:document-properties</code>
+<para>The document returned is a <tag>c:document-properties</tag>
 document that contains (exclusively) the document properties
-associated with the <parameter>doc</parameter> specified. Each key in the
-properties becomes an element, each value becomes the content of that element.
-For atomic values other than string, an
-<tag class="attribute">xsi:type</tag> attribute is added to identify the
-type of the value.</para>
+associated with the <parameter>doc</parameter> specified.
+If the item is not associated with a document, the <tag>c:document-properties</tag>
+element will be empty.</para>
 
-<para>If the item is not associated with a document, the resulting document
-will be empty.</para>
+<para>The underlying properties are serialized as follows:</para>
+
+<itemizedlist>
+<listitem>
+<para>Each property/value pair in the map becomes an element in the
+document. The property name is used as the name of the element and the
+value becomes the element content.
+</para>
+</listitem>
+<listitem>
+<para>If the property value is a sequence, then the element is
+repeated for each item in the sequence.
+</para>
+</listitem>
+<listitem>
+<para>If a value is a map, the element content is the JSON serialization
+of that map.
+</para>
+</listitem>
+<listitem>
+<para>If a value is an array, the element content is the JSON serialization
+of that array.
+</para>
+</listitem>
+<listitem>
+<para>For atomic values other than maps, arrays, and strings, an <tag
+class="attribute">xsi:type</tag> attribute is added to the element to
+identify the type of the value.
+</para>
+</listitem>
+</itemizedlist>
+
+<para>If any values in the properties map cannot be serialized, an empty string
+is used for their value. Construction of the <tag>c:document-properties</tag> document
+never fails.</para>
 
 <para>The <function>p:document-properties-document</function> function behaves
 normally during static analysis.</para>


### PR DESCRIPTION
Fix #573 
Ths PR attempts to clarify how `p:document-properties-document` serializes the properties. This is a convenience function to make processing properties with pipeline steps easier. I think that complicated property values are going to be uncommon and perfect fidelity is not a goal of this function. But you may disagree :-)
