### PR TITLE
Ignore [p:]expand-text when encoding is specified

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5737,10 +5737,9 @@ the body is not correctly encoded per the value of the <tag
 class="attribute">encoding</tag> attribute.</error>
 </para>
 
-<para><error code="S0088">It is a <glossterm>static error</glossterm>
-if a text node designated as a <link linkend="text-value-templates">text
-value template</link> appears in a <tag>p:inline</tag> where an
-<tag class="attribute">encoding</tag> is specified.</error></para>
+<para>If an <tag class="attribute">encoding</tag> attribute is present,
+value templates are never expanded. The value of
+<tag class="attribute">[p:]expand-text</tag> is irrelevant and always ignored.</para>
 
 <para>The interpretation of the (possibily decoded) content
 depends on the document's content type.


### PR DESCRIPTION
Fix #561.
