### PR TITLE
Make it an error to shadow a static variable or option

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4864,6 +4864,11 @@ a <glossterm>static error</glossterm> if the name attribute on
 <tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is not
 bound to a namespace.</error>
 </para>
+<para><error code="S0088">It is
+a <glossterm>static error</glossterm> if the qualified name of a
+<tag>p:variable</tag> <glossterm baseform="shadow">shadows</glossterm>
+the name of a static variable or option.</error>
+</para>
 </listitem>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
@@ -5025,6 +5030,11 @@ option or variable in the XProc namespace.</error> <error code="S0087">It is
 a <glossterm>static error</glossterm> if the name attribute on
 <tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is not
 bound to a namespace.</error>
+</para>
+<para><error code="S0088">It is
+a <glossterm>static error</glossterm> if the qualified name of a
+<tag>p:option</tag> <glossterm baseform="shadow">shadows</glossterm>
+the name of a static variable or option.</error>
 </para>
 </listitem>
 </varlistentry>


### PR DESCRIPTION
I have reservations about this, but it's what is documented as the consensus position.