### PR TITLE
Fix p:group: It is not a non-step wrapper anymore

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3950,9 +3950,8 @@ on the <tag>p:if</tag> will produce any documents.</para>
 </section>
 
     <section xml:id="p.group"><title>p:group</title><para>A group is specified by the
-          <tag>p:group</tag> element. In a <tag>p:try</tag>, it is a non-step wrapper, everywhere
-        else, it is a <glossterm>compound step</glossterm>. A group encapsulates the behavior of its
-          <glossterm>subpipeline</glossterm>.</para>
+          <tag>p:group</tag> element. It is a <glossterm>compound step</glossterm> that
+           encapsulates the behavior of its <glossterm>subpipeline</glossterm>.</para>
       <e:rng-pattern name="Group"/>
       <para>A <tag>p:group</tag> is a convenience wrapper for a collection of steps. </para><section
         xml:id="example-group" role="tocsuppress">


### PR DESCRIPTION
Since the initial pipeline of a p:try is not a p:group anymore, p:group is just a compound step and never a "non-step wrapper".