### PR TITLE
Fix primary output port auto connection for compounds

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -745,7 +745,8 @@ content types, that they accept. Input documents must
           step</glossterm> in its subpipeline has an unconnected primary output, then an implicit
         primary output port will be added to the compound step (and consequently the last step's
         primary output will be connected to it). This implicit output port has no name. It inherits
-        the <tag class="attribute">sequence</tag> property of the port connected to it. This rule
+        the <tag class="attribute">sequence</tag> and the <tag class="attribute">content-types</tag>
+        properties of the port connected to it. This rule
         does not apply to <tag>p:declare-step</tag>; step declarations must provide explicit names
         for all of their outputs.</para>
     </section>


### PR DESCRIPTION
Currently we just say, that @sequence is inherited if an unnamed primary output port is manufactured for a compound step without output ports, but I think @content-types needs to be inherited too.