### PR TITLE
New error for invalid pipe attributes

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5865,7 +5865,10 @@ step.</para>
 another step. It identifies the readable port to which it connects
 with the name of the step in the <tag class="attribute">step</tag>
 attribute and the name of the port on that step in the
-<tag class="attribute">port</tag> attribute.</para>
+<tag class="attribute">port</tag> attribute. <error code="S0099">It
+is a <glossterm>static error</glossterm> if <tag class="attribute">step</tag> 
+or <tag class="attribute">port</tag> are not valid instances of 
+<literal>NCName</literal>.</error></para>
 
 <para>If the <tag class="attribute">step</tag> attribute is not specified,
 it defaults to the step which provides the default readable port.


### PR DESCRIPTION
Introduced XS0099 raised, if p:pipe/@step or p:pipe/@port are not valid NCNames. We did not have this error in XProc 1.0 which caused compliant processor to raise different errors for this case.
I think we should fix this for XProc 3.0