### PR TITLE
Add a general error code for syntactic errors

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3502,6 +3502,13 @@ attribute">extension attributes</glossterm>.</error>
               step.</error>
           </para>
         </listitem>
+        <listitem>
+          <para><error code="S0100">It is a <glossterm>static error</glossterm> if the pipeline
+          document does not conform to the grammar for pipeline documents.</error>
+          This is a general error code indicating that the pipeline is syntactically incorrect
+          in some way not identified more precisely in this specification.
+          </para>
+        </listitem>
       </itemizedlist>
       <para>If an XProc processor can determine statically that a dynamic error will
           <emphasis>always</emphasis> occur, it <rfc2119>may</rfc2119> report that error statically


### PR DESCRIPTION
Fix #333 