### PR TITLE
Support new #types and values attribute

### DIFF
--- a/src/main/resources/css/xproc.css
+++ b/src/main/resources/css/xproc.css
@@ -1,3 +1,11 @@
+p code {
+    font-size: 120%;
+}
+
+p.element-syntax code {
+    font-size: 100%;
+}
+
 dl.toc             { margin-top: 0;
                      margin-bottom: 0
 }

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -8,19 +8,24 @@ namespace xs = "http://www.w3.org/2001/XMLSchema"
 # This schema neither supports nor requires the use of RELAX NG DTD Compatibility
 
 [
-   sa:model = "XPathExpression"
+   sa:model = "#XPathExpression"
 ]
 XPathExpression = text
 
 [
-   sa:model = "XSLTSelectionPattern"
+   sa:model = "#XSLTSelectionPattern"
 ]
 XSLTSelectionPattern = text
 
 [
-   sa:model = "XPathSequenceType"
+   sa:model = "#XProcSequenceType"
 ]
-XPathSequenceType = text
+XProcSequenceType = text
+
+[
+   sa:model = "#QName"
+]
+QName = text
 
 [
    sa:model = "ContentType"
@@ -54,7 +59,7 @@ Char = text
 
 name.ncname.attr = attribute name { xsd:NCName }
 name.qname.attr = attribute name { xsd:QName }
-as.attr = attribute as { XPathSequenceType }
+as.attr = attribute as { XProcSequenceType }
 port.attr = attribute port { xsd:NCName }
 required.attr = attribute required { xsd:boolean }
 sequence.attr = attribute sequence { xsd:boolean }
@@ -387,6 +392,7 @@ Option =
    element option {
       name.qname.attr,
       as.attr?,
+      attribute values { text }?,
       static.attr?,
       required.attr?,
       select.attr?,
@@ -403,6 +409,7 @@ StaticOption =
    element option {
       name.qname.attr,
       as.attr?,
+      attribute values { text }?,
       attribute static { "true" },
       select.attr,
       common.attributes,

--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -135,7 +135,7 @@ processing to the <port>source</port> document.</para>
   <p:input port="schema" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" primary="true" content-types="application/xml"/>
   <p:output port="report" sequence="true" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
   <p:option name="phase" select="'#ALL'" as="xs:string"/>
   <p:option name="assert-valid" select="true()" as="xs:boolean"/>
 </p:declare-step>
@@ -184,8 +184,8 @@ validity assessment to the <port>source</port> input.</para>
   <p:option name="use-location-hints" select="false()" as="xs:boolean"/>
   <p:option name="try-namespaces" select="false()" as="xs:boolean"/>
   <p:option name="assert-valid" select="true()" as="xs:boolean"/>
-  <p:option name="mode" select="'strict'" as="xs:token" e:type="strict|lax"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="mode" select="'strict'" as="xs:token" values="('strict','lax')"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>The values of the <option>use-location-hints</option>,

--- a/step-xquery/src/main/xml/specification.xml
+++ b/step-xquery/src/main/xml/specification.xml
@@ -75,8 +75,8 @@ provided on the <port>source</port> port.</para>
            sequence="true" primary="true"/>
   <p:input port="query" content-types="application/xml */*+xml text/*"/>
   <p:output port="result" sequence="true" content-types="*/*"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>If a sequence of documents is provided on the

--- a/step-xsl-formatter/src/main/xml/specification.xml
+++ b/step-xsl-formatter/src/main/xml/specification.xml
@@ -74,8 +74,8 @@ port.</para>
 <p:declare-step type="p:xsl-formatter">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="*/*"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="content-type" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="content-type" as="xs:string?"/>
 </p:declare-step>
 
 <para>The content-type of the output is controlled by the

--- a/steps/src/main/xml/steps/add-attribute.xml
+++ b/steps/src/main/xml/steps/add-attribute.xml
@@ -20,10 +20,10 @@ with the specified value.
 <p:declare-step type="p:add-attribute">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="attribute-name" required="true" as="xs:QName"/>
-  <p:option name="attribute-prefix" as="xs:NCName"/>
-  <p:option name="attribute-namespace" as="xs:anyURI"/>
+  <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
+  <p:option name="attribute-name" required="true" as="#QName"/>
+  <p:option name="attribute-prefix" as="xs:NCName?"/>
+  <p:option name="attribute-namespace" as="xs:anyURI?"/>
   <p:option name="attribute-value" required="true" as="xs:string"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/add-xml-base.xml
+++ b/steps/src/main/xml/steps/add-xml-base.xml
@@ -11,8 +11,8 @@ by the options on this step.</para>
 <p:declare-step type="p:add-xml-base">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="all" select="false()" as="xs:boolean"/>
-   <p:option name="relative" select="true()" as="xs:boolean"/>
+   <p:option name="all" as="xs:boolean" select="false()"/>
+   <p:option name="relative" as="xs:boolean" select="true()"/>
 </p:declare-step>
 
  <para>The value of the <option>all</option> option

--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -8,7 +8,7 @@ of its input.</para>
    <p:input port="source" content-types="*/*"/>
    <p:output port="result" content-types="*/*"/>
    <p:option name="content-type" required="true" as="xs:string"/>
-   <p:option name="parameters" as="map(*)?"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>The input document is transformed from one media type to another.

--- a/steps/src/main/xml/steps/compare.xml
+++ b/steps/src/main/xml/steps/compare.xml
@@ -9,9 +9,9 @@ equality.</para>
    <p:input port="alternate" content-types="*/*"/>
    <p:output port="result" content-types="application/xml"/>
    <p:output port="differences" content-types="*/*" sequence="true"/>
-   <p:option name="method" as="xs:QName"/>
-   <p:option name="fail-if-not-equal" select="false()" as="xs:boolean"/>
-   <p:option name="parameters" as="map(xs:QName,item())"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+   <p:option name="method" as="#QName?"/>
+   <p:option name="fail-if-not-equal" as="xs:boolean" select="false()"/>
 </p:declare-step>
 
 <para>This step takes single documents on each of two ports and

--- a/steps/src/main/xml/steps/count.xml
+++ b/steps/src/main/xml/steps/count.xml
@@ -11,7 +11,7 @@ sequence.</para>
 <p:declare-step type="p:count">
    <p:input port="source" content-types="*/*" sequence="true"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="limit" select="0" as="xs:integer"/>
+   <p:option name="limit" as="xs:integer" select="0"/>
 </p:declare-step>
 
 <para>If the <tag feature="p-count-limit" class="attribute">limit</tag> option is specified

--- a/steps/src/main/xml/steps/delete.xml
+++ b/steps/src/main/xml/steps/delete.xml
@@ -9,7 +9,7 @@ with the deleted items removed, on the <port>result</port> port.</para>
 <p:declare-step type="p:delete">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/directory-list.xml
+++ b/steps/src/main/xml/steps/directory-list.xml
@@ -7,9 +7,9 @@
 <p:declare-step type="p:directory-list">
   <p:output port="result" content-type="application/xml"/>
   <p:option name="path" required="true" as="xs:anyURI"/>
-  <p:option name="detailed" select="false()" as="xs:boolean"/>
-  <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
-  <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
+  <p:option name="detailed" as="xs:boolean" select="false()"/>
+  <p:option name="include-filter" as="#RegularExpression*"/>
+  <p:option name="exclude-filter" as="#RegularExpression*"/>
 </p:declare-step>
 
 <para><impl>Conformant processors <rfc2119>must</rfc2119> support directory paths whose

--- a/steps/src/main/xml/steps/error.xml
+++ b/steps/src/main/xml/steps/error.xml
@@ -7,7 +7,7 @@ to the step.</para>
 <p:declare-step type="p:error">
     <p:input port="source" sequence="true" content-types="application/xml text/xml */*+xml text/*"/>
     <p:output port="result" sequence="true" content-types="application/xml text/xml */*+xml text/*"/>
-    <p:option name="code" required="true" as="xs:anyAtomicType"/>
+    <p:option name="code" required="true" as="#QName"/>
     <p:option name="code-prefix" as="xs:NCName?"/>
     <p:option name="code-namespace" as="xs:anyURI?"/>
 </p:declare-step>

--- a/steps/src/main/xml/steps/file-head.xml
+++ b/steps/src/main/xml/steps/file-head.xml
@@ -9,6 +9,7 @@
     <title>Editorial Note</title>
     <para>TBD: This is an almost direct port from EXProc. Details might still change.</para>
     <para>Check and amend the error codes.</para>
+    <para>Norm, offline at the moment, asks: why does this step return XML instead of text?</para>
   </note>
 
   <p:declare-step type="p:file-head">

--- a/steps/src/main/xml/steps/file-tempfile.xml
+++ b/steps/src/main/xml/steps/file-tempfile.xml
@@ -15,11 +15,11 @@
 
   <p:declare-step type="p:file-tempfile">
     <p:output port="result" primary="true" content-types="application/xml"/>
-    <p:option name="href" required="false" as="xs:anyURI"/>
-    <p:option name="suffix" required="false" as="xs:string"/>
-    <p:option name="prefix" required="false" as="xs:string"/>
-    <p:option name="delete-on-exit" required="false" as="xs:boolean" select="false()"/>
-    <p:option name="fail-on-error" required="false" as="xs:boolean" select="true()"/>
+    <p:option name="href" as="xs:anyURI?"/>
+    <p:option name="suffix" as="xs:string?"/>
+    <p:option name="prefix" as="xs:string?"/>
+    <p:option name="delete-on-exit" as="xs:boolean" select="false()"/>
+    <p:option name="fail-on-error" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
   <para>The <tag>p:file-tempfile</tag> creates a temporary file. The temporary file is guaranteed not to already exist

--- a/steps/src/main/xml/steps/file-touch.xml
+++ b/steps/src/main/xml/steps/file-touch.xml
@@ -14,8 +14,8 @@
   <p:declare-step type="p:file-touch">
     <p:output port="result" primary="true" content-types="application/xml"/>
     <p:option name="href" required="true" as="xs:anyURI"/>
-    <p:option name="timestamp" required="false" as="xs:dateTime"/>
-    <p:option name="fail-on-error" required="false" as="xs:boolean" select="true()"/>
+    <p:option name="timestamp" as="xs:dateTime?"/>
+    <p:option name="fail-on-error" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
   <para>The <tag>p:file-touch</tag> step updates the modification timestamp of the fiel specified in the

--- a/steps/src/main/xml/steps/filter.xml
+++ b/steps/src/main/xml/steps/filter.xml
@@ -7,7 +7,7 @@ based on a (possibly dynamically constructed) XPath select expression.</para>
 <p:declare-step type="p:filter">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" sequence="true" content-types="application/xml"/>
-  <p:option name="select" required="true" as="xs:string" e:type="XPathExpression"/>
+  <p:option name="select" required="true" as="#XPathExpression"/>
 </p:declare-step>
 
 <para>This step behaves just like an <tag>p:input</tag> with

--- a/steps/src/main/xml/steps/hash.xml
+++ b/steps/src/main/xml/steps/hash.xml
@@ -7,11 +7,11 @@ for some value and injects it into the <port>source</port> document.</para>
 <p:declare-step type="p:hash">
   <p:input port="source" primary="true" content-types="*/*"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
   <p:option name="value" required="true" as="xs:string"/>
-  <p:option name="algorithm" required="true" as="xs:QName"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="algorithm" required="true" as="#QName"/>
+  <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>The value of the <option>algorithm</option> option must be a QName.

--- a/steps/src/main/xml/steps/identity.xml
+++ b/steps/src/main/xml/steps/identity.xml
@@ -5,7 +5,7 @@
 available on its output.</para>
 
 <p:declare-step type="p:identity">
-  <p:input port="source" content-types="*/*" sequence="true"/>
+  <p:input port="source" sequence="true" content-types="*/*"/>
   <p:output port="result" sequence="true" content-types="*/*"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/in-scope-names.xml
+++ b/steps/src/main/xml/steps/in-scope-names.xml
@@ -6,7 +6,7 @@ in-scope variables and options as a set of parameters in a
 <tag>c:param-set</tag> document.</para>
 
 <p:declare-step type="p:in-scope-names">
-  <p:output port="result" primary="false" content-types="application/xml"/>
+  <p:output port="result" content-types="application/xml"/>
 </p:declare-step>
 
 <para>Each in-scope variable and option is converted into a

--- a/steps/src/main/xml/steps/insert.xml
+++ b/steps/src/main/xml/steps/insert.xml
@@ -10,8 +10,8 @@ port's document relative to the matching elements in the
    <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
    <p:input port="insertion" sequence="true" content-types="application/xml text/* */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-   <p:option name="position" required="true" as="xs:token" e:type="first-child|last-child|before|after"/>
+   <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
+   <p:option name="position" required="true" as="xs:token" values="('first-child','last-child','before','after')"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option

--- a/steps/src/main/xml/steps/label-elements.xml
+++ b/steps/src/main/xml/steps/label-elements.xml
@@ -7,12 +7,12 @@ element and stores that label in the specified attribute.</para>
 <p:declare-step type="p:label-elements">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="attribute" select="'xml:id'" as="xs:QName"/>
-  <p:option name="attribute-prefix" as="xs:NCName"/>
-  <p:option name="attribute-namespace" as="xs:anyURI"/>
-  <p:option name="label" select="'concat(&#34;_&#34;,$p:index)'" as="xs:string" e:type="XPathExpression"/>
-  <p:option name="match" select="'*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="replace" select="'true'" as="xs:boolean"/>
+  <p:option name="attribute" as="#QName" select="'xml:id'"/>
+  <p:option name="attribute-prefix" as="xs:NCName?"/>
+  <p:option name="attribute-namespace" as="xs:anyURI?"/>
+  <p:option name="label" as="#XPathExpression" select="'concat(&#34;_&#34;,$p:index)'"/>
+  <p:option name="match" as="#XSLTSelectionPattern" select="'*'"/>
+  <p:option name="replace" as="xs:boolean" select="true()"/>
 </p:declare-step>
 
 <para>The value of the <option>attribute</option> option

--- a/steps/src/main/xml/steps/load-directory-list.xml
+++ b/steps/src/main/xml/steps/load-directory-list.xml
@@ -11,8 +11,8 @@
 <p:declare-step type="p:load-directory-list">
   <p:output port="result" content-type="application/xml"/>
   <p:option name="path" required="true" as="xs:anyURI"/>
-  <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
-  <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
+  <p:option name="include-filter" as="#RegularExpression*"/>
+  <p:option name="exclude-filter" as="#RegularExpression*"/>
 </p:declare-step>
 
 <para><impl>Conformant processors <rfc2119>must</rfc2119> support directory paths whose

--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -7,9 +7,9 @@ result a document (or documents) specified by an IRI.</para>
 <p:declare-step type="p:load">
   <p:output port="result" sequence="true" content-types="*/*"/>
   <p:option name="href" required="true" as="xs:anyURI"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="content-type" as="xs:string" />
-  <p:option name="document-properties" as="map(xs:QName, item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="content-type" as="xs:string?"/>
+  <p:option name="document-properties" as="map(xs:QName, item()*)?"/>
 </p:declare-step>
 
 <para><error code="D0064">It is a <glossterm>dynamic error</glossterm> if

--- a/steps/src/main/xml/steps/make-absolute-uris.xml
+++ b/steps/src/main/xml/steps/make-absolute-uris.xml
@@ -8,8 +8,8 @@ result document.</para>
 <p:declare-step type="p:make-absolute-uris">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="base-uri" as="xs:anyURI"/>
+  <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
+  <p:option name="base-uri" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/namespace-rename.xml
+++ b/steps/src/main/xml/steps/namespace-rename.xml
@@ -7,9 +7,9 @@ use of a namespace in a document to a new IRI value.</para>
  <p:declare-step type="p:namespace-rename">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="from" as="xs:anyURI"/>
-   <p:option name="to" as="xs:anyURI"/>
-   <p:option name="apply-to" select="'all'" as="xs:token" e:type="all|elements|attributes"/>
+   <p:option name="from" required="true" as="xs:anyURI"/>
+   <p:option name="to" required="true" as="xs:anyURI"/>
+   <p:option name="apply-to" as="xs:token" select="'all'" values="('all','elements','attributes')"/>
 </p:declare-step>
 
 <para>The value of the <option>from</option> option

--- a/steps/src/main/xml/steps/pack.xml
+++ b/steps/src/main/xml/steps/pack.xml
@@ -8,9 +8,9 @@ fashion.</para>
    <p:input port="source" content-types="application/xml text/xml */*+xml" sequence="true" primary="true"/>
    <p:input port="alternate" sequence="true" content-types="application/xml"/>
    <p:output port="result" sequence="true"/>
-   <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
+   <p:option name="wrapper" required="true" as="#QName"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/parameters.xml
+++ b/steps/src/main/xml/steps/parameters.xml
@@ -6,7 +6,7 @@ as a <tag>c:param-set</tag> document.</para>
 
 <p:declare-step type="p:parameters">
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="parameters" as="map(xs:QName,item())"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>Each parameter in the <option>parameters</option> map is converted into a

--- a/steps/src/main/xml/steps/rename.xml
+++ b/steps/src/main/xml/steps/rename.xml
@@ -7,10 +7,10 @@ processing-instruction targets in a document.</para>
 <p:declare-step type="p:rename">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="new-name" required="true" as="xs:QName"/>
-  <p:option name="new-prefix" as="xs:NCName"/>
-  <p:option name="new-namespace" as="xs:anyURI"/>
+  <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
+  <p:option name="new-name" required="true" as="#QName"/>
+  <p:option name="new-prefix" as="xs:NCName?"/>
+  <p:option name="new-namespace" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option must be an

--- a/steps/src/main/xml/steps/replace.xml
+++ b/steps/src/main/xml/steps/replace.xml
@@ -9,7 +9,7 @@ its primary input with the document element of the
    <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
    <p:input port="replacement" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option

--- a/steps/src/main/xml/steps/set-attributes.xml
+++ b/steps/src/main/xml/steps/set-attributes.xml
@@ -8,7 +8,7 @@ matching elements.</para>
    <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
    <p:input port="attributes" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
 </p:declare-step>
 
  <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/set-properties.xml
+++ b/steps/src/main/xml/steps/set-properties.xml
@@ -7,7 +7,7 @@ properties on the source document.</para>
 <p:declare-step type="p:set-properties">
    <p:input port="source" content-types="*/*"/>
    <p:output port="result" content-types="*/*"/>
-   <p:option name="properties" required="true" as="map(xs:QName,item())"/>
+   <p:option name="properties" required="true" as="map(xs:QName,item()*)"/>
    <p:option name="merge" default="false()" as="xs:boolean"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/split-sequence.xml
+++ b/steps/src/main/xml/steps/split-sequence.xml
@@ -8,8 +8,8 @@ documents and divides it into two sequences.</para>
   <p:input port="source" content-types="application/xml text/xml */*+xml" sequence="true"/>
   <p:output port="matched" sequence="true" primary="true" content-types="application/xml"/>
   <p:output port="not-matched" sequence="true" content-types="application/xml"/>
-  <p:option name="initial-only" select="false()" as="xs:boolean"/>
-  <p:option name="test" required="true" as="xs:string" e:type="XPathExpression"/>
+  <p:option name="initial-only" as="xs:boolean" select="false()"/>
+  <p:option name="test" required="true" as="#XPathExpression"/>
 </p:declare-step>
 
  <para>The value of the <option>test</option> option <rfc2119>must</rfc2119> be an XPathExpression.</para>

--- a/steps/src/main/xml/steps/string-replace.xml
+++ b/steps/src/main/xml/steps/string-replace.xml
@@ -8,8 +8,8 @@ with the string result of evaluating an XPath expression.</para>
 <p:declare-step type="p:string-replace">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
-   <p:option name="replace" required="true" as="xs:string" e:type="XPathExpression"/>
+   <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
+   <p:option name="replace" required="true" as="#XPathExpression"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/tee.xml
+++ b/steps/src/main/xml/steps/tee.xml
@@ -9,9 +9,9 @@ version of) its input to a URI. The step outputs its input unchanged.</para>
   <p:declare-step type="p:tee">
     <p:input port="source" content-types="*/*" sequence="true"/>
     <p:output port="result" sequence="true" content-types="*/*"/>
-    <p:option name="href" required="true" as="xs:anyURI"/>        
+    <p:option name="href" required="true" as="xs:anyURI"/>
     <p:option name="serialization" as="map(xs:QName,item()*)?"/>
-    <p:option name="enable" as="xs:boolean" select="true()"/>   
+    <p:option name="enable" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
 <para>The value of the <option>href</option> option <rfc2119>must</rfc2119> be an <type>anyURI</type>. If it is
@@ -28,7 +28,7 @@ specified location.</error></para>
 <para>The <option>serialization</option> option is provided to control the
 serialization of content when it is stored. Serialization is described in
 <biblioref linkend="xproc30"/>.</para>
-  
+
   <para>If the <option>enabled</option> option is false, no attempt to store the document will be made. The step will
     act exactly like a <tag>p:identity</tag> step. The values for <option>href</option> and
       <option>serialization</option> will be ignored.</para>

--- a/steps/src/main/xml/steps/unescape-markup.xml
+++ b/steps/src/main/xml/steps/unescape-markup.xml
@@ -10,10 +10,10 @@ is the reverse of the <tag>p:escape-markup</tag> step.</para>
 <p:declare-step type="p:unescape-markup">
   <p:input port="source" content-types="application/xml text/xml */*+xml text/*"/>
   <p:output port="result" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="namespace" as="xs:anyURI"/>
-  <p:option name="content-type" select="'application/xml'" as="xs:string"/>
-  <p:option name="encoding" as="xs:string"/>
-  <p:option name="charset" as="xs:string"/>
+  <p:option name="namespace" as="xs:anyURI?"/>
+  <p:option name="content-type" as="xs:string" select="'application/xml'"/>
+  <p:option name="encoding" as="xs:string?"/>
+  <p:option name="charset" as="xs:string?"/>
 </p:declare-step>
 
 <para>The value of the <option>namespace</option> option

--- a/steps/src/main/xml/steps/unwrap.xml
+++ b/steps/src/main/xml/steps/unwrap.xml
@@ -7,7 +7,7 @@ children.</para>
 <p:declare-step type="p:unwrap">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
 </p:declare-step>
 
  <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/uuid.xml
+++ b/steps/src/main/xml/steps/uuid.xml
@@ -8,8 +8,8 @@ the <port>source</port> document.</para>
 <p:declare-step type="p:uuid">
   <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="version" as="xs:integer"/>
+  <p:option name="match" as="#XSLTSelectionPattern" select="'/*'"/>
+  <p:option name="version" as="xs:integer?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option must be an

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -8,10 +8,10 @@ documents.</para>
 <p:declare-step type="p:wrap-sequence">
    <p:input port="source" content-types="application/xml */*+xml text/*" sequence="true"/>
    <p:output port="result" sequence="true" content-types="application/xml"/>
-   <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
-   <p:option name="group-adjacent" as="xs:string" e:type="XPathExpression"/>
+   <p:option name="wrapper" required="true" as="#QName"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
+   <p:option name="group-adjacent" as="#XPathExpression?"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/wrap.xml
+++ b/steps/src/main/xml/steps/wrap.xml
@@ -7,11 +7,11 @@
 <p:declare-step type="p:wrap">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
-   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
-   <p:option name="group-adjacent" as="xs:string" e:type="XPathExpression"/>
+   <p:option name="wrapper" required="true" as="#QName"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
+   <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
+   <p:option name="group-adjacent" as="#XPathExpression?"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/www-form-urlencode.xml
+++ b/steps/src/main/xml/steps/www-form-urlencode.xml
@@ -8,8 +8,8 @@ injects it into the <port>source</port> document.</para>
 <p:declare-step type="p:www-form-urlencode">
   <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="match" required="true" as="#XSLTSelectionPattern"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option must be an
@@ -22,7 +22,7 @@ When parameters are encoded into name/value pairs,
 The namespace name is ignored and no prefix or colon appears in the name.
 </para>
 
-<para><impl>The order of the parameters is
+<para><impl>The order of the parameters
 is <glossterm>implementation-dependent</glossterm>.</impl></para>
 
 <para>The matched nodes are specified with the match pattern in the

--- a/steps/src/main/xml/steps/xinclude.xml
+++ b/steps/src/main/xml/steps/xinclude.xml
@@ -6,8 +6,8 @@
 <p:declare-step type="p:xinclude">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="fixup-xml-base" select="'false'" as="xs:boolean"/>
-  <p:option name="fixup-xml-lang" select="'false'" as="xs:boolean"/>
+  <p:option name="fixup-xml-base" as="xs:boolean" select="false()"/>
+  <p:option name="fixup-xml-lang" as="xs:boolean" select="false()"/>
 </p:declare-step>
 
 <para>The value of the <option>fixup-xml-base</option> option <rfc2119>must</rfc2119> be a

--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -6,13 +6,13 @@
 <p:declare-step type="p:xslt">
   <p:input port="source" content-types="application/xml text/xml */*+xml" sequence="true" primary="true"/>
   <p:input port="stylesheet" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
   <p:output port="result" primary="true" sequence="true" content-types="*/*"/>
   <p:output port="secondary" sequence="true"/>
-  <p:option name="initial-mode" as="xs:QName"/>
-  <p:option name="template-name" as="xs:QName"/>
-  <p:option name="output-base-uri" as="xs:anyURI"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item())?"/>
+  <p:option name="initial-mode" as="#QName?"/>
+  <p:option name="template-name" as="#QName?"/>
+  <p:option name="output-base-uri" as="xs:anyURI?"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>If present, the value of the <option>initial-mode</option>

--- a/tools/xsl/dbspec.xsl
+++ b/tools/xsl/dbspec.xsl
@@ -18,7 +18,6 @@
 
 <xsl:import href="docbook.xsl"/>
 <xsl:import href="ml-macro.xsl"/>
-<xsl:include href="elemsyntax.xsl"/>
 <xsl:include href="rngsyntax.xsl"/>
 <xsl:include href="xprocns.xsl"/>
 

--- a/tools/xsl/library-to-rnc.xsl
+++ b/tools/xsl/library-to-rnc.xsl
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 		xmlns:p="http://www.w3.org/ns/xproc"
-		xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
 		xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 version="2.0">
 
@@ -73,31 +72,22 @@
   <xsl:variable name="name" select="@name"/>
   <xsl:variable name="type" as="xs:string+">
     <xsl:choose>
-      <xsl:when test="not(@as) and not(@e:type)">
+      <xsl:when test="@values">
+        <xsl:variable name="text" select="replace(@values, '^\s*\(\s*(.*)\s*\)\s*$', '$1')"/>
+	<xsl:for-each select="tokenize($text,'\s*,\s*')">
+	  <xsl:if test="position()&gt;1">|</xsl:if>
+          <xsl:value-of select="."/>
+	</xsl:for-each>
+      </xsl:when>
+      <xsl:when test="not(@as)">
 	<xsl:message>
           <xsl:text>Warning: no type for option: </xsl:text>
           <xsl:value-of select="$name"/>
         </xsl:message>
 	<xsl:value-of select="'xsd:string'"/>
       </xsl:when>
-      <xsl:when test="not(@e:type)">
-	<xsl:value-of select="replace(@as, 'xs:', 'xsd:')"/>
-      </xsl:when>
-      <xsl:when test="contains(@e:type,'|')">
-	<xsl:for-each select="tokenize(@e:type,'\|')">
-	  <xsl:if test="position()&gt;1">|</xsl:if>
-	  <xsl:choose>
-	    <xsl:when test="starts-with(.,'xsd:')">
-	      <xsl:value-of select="."/>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:value-of select="concat('&quot;',.,'&quot;')"/>
-	    </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:for-each>
-      </xsl:when>
       <xsl:otherwise>
-	<xsl:value-of select="@e:type"/>
+	<xsl:value-of select="replace(replace(@as, 'xs:', 'xsd:'), '#', '')"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/tools/xsl/pipeline-library.xsl
+++ b/tools/xsl/pipeline-library.xsl
@@ -27,7 +27,7 @@
 <xsl:template match="p:declare-step" mode="copystep">
   <xsl:element name="{name(.)}" namespace="{namespace-uri(.)}">
     <xsl:copy-of select="@name|@port"/>
-    <xsl:copy-of select="@*[not(name(.) = 'e:type' or name(.) = 'name' or name(.) = 'port')]"/>
+    <xsl:copy-of select="@*[not(name(.) = 'name' or name(.) = 'port')]"/>
     <xsl:attribute name="xml:id" select="substring-after(@type,':')"/>
     <xsl:apply-templates mode="copystep"/>
   </xsl:element>
@@ -36,7 +36,7 @@
 <xsl:template match="*" mode="copystep">
   <xsl:element name="{name(.)}" namespace="{namespace-uri(.)}">
     <xsl:copy-of select="@name|@port"/>
-    <xsl:copy-of select="@*[not(name(.) = 'e:type' or name(.) = 'name' or name(.) = 'port')]"/>
+    <xsl:copy-of select="@*[not(name(.) = 'name' or name(.) = 'port')]"/>
     <xsl:apply-templates mode="copystep"/>
   </xsl:element>
 </xsl:template>

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -250,12 +250,21 @@
 	  <xsl:variable name="rngpat" select="$schema/rng:grammar/rng:define[@name=$pattern]"/>
 	  <xsl:choose>
 	    <xsl:when test="$rngpat/@sa:model">
-	      <xsl:value-of select="$rngpat/@sa:model"/>
+              <xsl:choose>
+                <xsl:when test="starts-with($rngpat/@sa:model, 'p:')">
+	          <xsl:value-of select="substring-after($rngpat/@sa:model, 'p:')"/>
+                </xsl:when>
+                <xsl:otherwise>
+	          <xsl:value-of select="$rngpat/@sa:model"/>
+                </xsl:otherwise>
+              </xsl:choose>
 	    </xsl:when>
 	    <xsl:otherwise>
 	      <xsl:message>
 		<xsl:text>Warning: unsupported ref in attribute: </xsl:text>
 		<xsl:value-of select="@name"/>
+                <xsl:text>: </xsl:text>
+                <xsl:value-of select="rng:ref/@name"/>
 	      </xsl:message>
 	    </xsl:otherwise>
 	  </xsl:choose>

--- a/tools/xsl/xprocns.xsl
+++ b/tools/xsl/xprocns.xsl
@@ -103,44 +103,6 @@
 	  <xsl:with-param name="len" select="sum($lengths)"/>
 	</xsl:call-template>
       </code>
-
-      <xsl:variable name="type" as="xs:string*">
-	<xsl:choose xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax">
-	  <xsl:when test="not(@as) and not(@e:type)">
-	    <xsl:message>Warning: no e:type!!!</xsl:message>
-	    <xsl:value-of select="'string'"/>
-	  </xsl:when>
-          <xsl:when test="not(@e:type)"/>
-	  <xsl:when test="contains(@e:type,'|')">
-	    <xsl:for-each select="tokenize(@e:type,'\|')">
-	      <xsl:if test="position()&gt;1">|</xsl:if>
-	      <xsl:choose>
-		<xsl:when test="starts-with(.,'xsd:')">
-		  <xsl:value-of select="substring-after(., 'xsd:')"/>
-		</xsl:when>
-		<xsl:otherwise>
-		  <xsl:value-of select="concat('&quot;',.,'&quot;')"/>
-		</xsl:otherwise>
-	      </xsl:choose>
-	    </xsl:for-each>
-	  </xsl:when>
-	  <xsl:otherwise>
-	    <xsl:value-of select="replace(@e:type,'xsd:','')"/>
-	  </xsl:otherwise>
-	</xsl:choose>
-      </xsl:variable>
-
-      <xsl:variable name="typestr" as="xs:string">
-	<xsl:value-of select="$type" separator=" "/>
-      </xsl:variable>
-
-      <xsl:if test="exists($type)">
-        <code class="comment">&lt;!--&#160;</code>
-        <span class="opt-type">
-	  <xsl:value-of select="$typestr"/>
-        </span>
-        <code class="comment">&#160;--&gt;</code>
-      </xsl:if>
     </xsl:if>
   </span>
 </xsl:template>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3216,92 +3216,6 @@ begins.</para>
 </section>
 </section>
 
-<section xml:id="qname-options">
-<title>QNames as option values</title>
-
-<para>Some steps have options whose values are QNames, for example
-“<tag class="attribute">attribute-name</tag>” on
-<tag>p:add-attribute</tag>. If these attributes had a required type of
-<type>xs:QName</type>, they would be tedious to specify. As a
-convenience for pipeline authors, the declared type of these options
-is <type>xs:anyAtomicType</type>.</para>
-
-<orderedlist>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:QName</type> then that value is used.
-</para>
-</listitem>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:string</type> (or a type derived from
-<type>xs:string</type>), the QName is constructed by following the
-<link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
-production rules</link> in <biblioref linkend="xpath31"/>. That is, it
-can be written as a local-name only, as a prefix plus local-name, or as
-a URI qualified name (using the <code>Q{namespace}local-name</code> syntax).
-<error code="D0061">It is a 
-<glossterm>dynamic error</glossterm> if the string value is not syntactically an
-EQName.</error>
-<error code="D0069">It is a 
-<glossterm>dynamic error</glossterm> if the string value contains a colon and
-the designated prefix is not declared in the in-scope namespaces.</error>
-</para>
-</listitem>
-<listitem>
-<para><error code="D0068">It is a <glossterm>dynamic error</glossterm>
-if the supplied value is neither an instance of <type>xs:QName</type>
-nor an instance of <type>xs:string</type>.</error>
-</para>
-</listitem>
-</orderedlist> 
-
-<para>Steps with a QName-valued option also often provide two
-additional attributes to separately identify a prefix and a namespace URI.
-Although their names vary from step to step, in this section
-they’re identified as the <code>qname-value</code>,
-<code>prefix-value</code>, and <code>namespace-value</code>
-attributes. The rules described here apply regardless of their actual
-names.</para>
-
-<para>When <code>prefix-value</code> and <code>namespace-value</code>
-attributes are available, several additional co-constraints apply:</para>
-
-<orderedlist>
-<listitem>
-<para>If the supplied value of the name is an <code>xs:QName</code>, you may not specify
-the <code>prefix-value</code> or <code>namespace-value</code>.
-<error code="D0066">It is a <glossterm>dynamic error</glossterm>
-to separately specify a prefix or namespace URI if the supplied value
-has the type <code>xs:QName</code>.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the string value of the <code>qname-value</code> attribute
-contains a colon, you may not specify a <code>prefix-value</code> or
-<code>namespace-value</code>.
-<error code="D0034">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix or namespace URI if the QName value contains a colon.</error>
-</para>
-</listitem>
-<listitem>
-<para>If you specify a <code>prefix-value</code>, you must also specify
-a namespace (either with the <code>namespace-value</code> or through a
-URI qualified name).
-<error code="D0070">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix without also specifying a namespace URI.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the specified value is of type <code>xs:QName</code> or is
-a URI qualified name, you may not specify a <code>namespace-value</code>.
-<error code="D0067">It is a <glossterm>dynamic error</glossterm>
-to separately specify a namespace URI if the value is a URI qualified name.</error>
-</para>
-</listitem>
-</orderedlist>
-</section>
-
 <section xml:id="syntax-summaries"><title>Syntax Summaries</title>
 
 <para>The description of each element in the pipeline namespace is
@@ -3428,7 +3342,7 @@ are allowed anywhere, and attributes that are
     </para>
   </listitem>
   <listitem>
-    <para><type>XPathExpression</type>, <type>XSLTSelectionPattern</type>:
+    <para><type>#XPathExpression</type>, <type>#XSLTSelectionPattern</type>:
     As a string per <biblioref linkend="xmlschema-2"/>, including
     whitespace normalization, and the further requirement to be a
     conformant Expression per <biblioref linkend="xpath31"/> or selection
@@ -5024,11 +4938,9 @@ the name of a static variable or option.</error>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>.
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5191,12 +5103,31 @@ the name of a static variable or option.</error>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">values</tag></term>
+<listitem>
+<para>A list of acceptable values may be specified in the <tag
+class="attribute">values</tag> attribute. If specified, the value
+of the <tag class="attribute">values</tag> attribute
+<rfc2119>must</rfc2119> be a list of atomic values expressed as an XPath sequence,
+for example: <code>('one', 'two', 'three')</code>.
+<error code="S0101">It is a <glossterm>static error</glossterm> if the
+values list is not an XPath sequence of atomic values.</error>
+</para>
+<para>The values list is an additional constraint on the acceptable values
+for the option. The option value must satisfy the <tag class="attribute">as</tag>
+type, if one is provided, and must be equal to (XPath “<code>eq</code>”) one of the listed
+<tag class="attribute">values</tag>.
+It is possible to combine <tag class="attribute">as</tag> and
+<tag class="attribute">values</tag> in ways that exclude all
+actual values (for example, <code>as="xs:integer"</code> and
+<code>values="(1.5,’pi’)"</code>). Doing so will make it impossible
+to specify a value for the option.</para>
 </listitem>
 </varlistentry>
 <varlistentry><term><tag class="attribute">static</tag></term>
@@ -5323,11 +5254,9 @@ name as part of the same step invocation.</error></para>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5497,11 +5426,14 @@ static.</para>
 </section>
 
 <section xml:id="varopt-types">
-<title>Variable and option types</title>
+<title>XProc sequence type</title>
 
-<para>Variables and options may declare that they have a sequence type.
-<error code="S0096">It is a <glossterm>static error</glossterm> if
-the sequence type is not syntactically valid.</error></para>
+<para>Variables and options may declare that they have a type using an
+XProc sequence type. <error code="S0096">It is a <glossterm>static
+error</glossterm> if the sequence type is not syntactically
+valid.</error> The sequence type <literal>item()*</literal> is assumed if
+no explicit type is provided.
+</para>
 
 <para>If a variable or option declares a type, the supplied value 
  of the variable or option is converted to the required type, 
@@ -5510,15 +5442,116 @@ the sequence type is not syntactically valid.</error></para>
  the supplied value of a variable or option cannot be converted 
  to the required type.</error></para>
 
-<para> If no sequence type is specified explicitly, <literal>item()*</literal> 
-is assumed as default type.</para>
+<para>XProc extends the syntax of sequence types slightly.
+The type of a variable or
+option in XProc is either an XPath sequence type or a single token
+identified by a leading “<code>#</code>” sign (optionally followed by
+an occurrence indicator).</para>
 
- <para>If the sequence type is a map with <type>xs:QName</type> keys
-(<type>map(xs:QName, ...)</type>), the
-<function>p:force-qname-keys</function> function is automatically applied to
-the value. This makes it possible to pass in maps using (easier to
-write) <type>xs:string</type> type keys that are converted
-automatically into the required <type>xs:QName</type> keys.</para>
+<para>This specification defines five such tokens: <type>#RegularExpression</type>,
+<type>#XSLTSelectionPattern</type>, <type>#XPathExpression</type>,
+<type>#XProcSequenceType</type>, and
+<type>#QName</type>. The first four are treated as <type>xs:string</type> for the purpose
+of atomization.
+They simply allow a pipeline author to document that an option is expected to be
+a regular expression, XSLT selection pattern, XPath expression, or an XProc sequence type.</para>
+
+<para>The <type>#QName</type> token is treated as <type>xs:anyAtomicType</type> for the purpose
+of atomization.
+This type assures that the option value is ultimately an <type>xs:QName</type>, but
+allows the processor to parse the lexical value in a more convenient manner for
+pipeline authors.</para>
+
+<para>Some steps have options whose values are QNames, for example
+“<tag class="attribute">attribute-name</tag>” on
+<tag>p:add-attribute</tag>. If these attributes had a required type of
+<type>xs:QName</type>, they would be tedious to specify. As a
+convenience for pipeline authors, the declared type of these options
+is <type>#QName</type>.</para>
+
+<orderedlist>
+<listitem>
+<para>If the value supplied for the option is an instance of
+<type>xs:QName</type> then that value is used.
+</para>
+</listitem>
+<listitem>
+<para>If the value supplied for the option is an instance of
+<type>xs:string</type> (or a type derived from
+<type>xs:string</type>), the QName is constructed by following the
+<link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
+production rules</link> in <biblioref linkend="xpath31"/>. That is, it
+can be written as a local-name only, as a prefix plus local-name, or as
+a URI qualified name (using the <code>Q{namespace}local-name</code> syntax).
+<error code="D0061">It is a 
+<glossterm>dynamic error</glossterm> if the string value is not syntactically an
+EQName.</error>
+<error code="D0069">It is a 
+<glossterm>dynamic error</glossterm> if the string value contains a colon and
+the designated prefix is not declared in the in-scope namespaces.</error>
+</para>
+</listitem>
+<listitem>
+<para><error code="D0068">It is a <glossterm>dynamic error</glossterm>
+if the supplied value is neither an instance of <type>xs:QName</type>
+nor an instance of <type>xs:string</type>.</error>
+</para>
+</listitem>
+</orderedlist> 
+
+<para>Steps with a QName-valued option also often provide two
+additional attributes to separately identify a prefix and a namespace URI.
+Although their names vary from step to step, in this section
+they’re identified as the <code>qname-value</code>,
+<code>prefix-value</code>, and <code>namespace-value</code>
+attributes. The rules described here apply regardless of their actual
+names.</para>
+
+<para>When <code>prefix-value</code> and <code>namespace-value</code>
+attributes are available, several additional co-constraints apply:</para>
+
+<orderedlist>
+<listitem>
+<para>If the supplied value of the name is an <code>xs:QName</code>, you may not specify
+the <code>prefix-value</code> or <code>namespace-value</code>.
+<error code="D0066">It is a <glossterm>dynamic error</glossterm>
+to separately specify a prefix or namespace URI if the supplied value
+has the type <code>xs:QName</code>.</error>
+</para>
+</listitem>
+<listitem>
+<para>If the string value of the <code>qname-value</code> attribute
+contains a colon, you may not specify a <code>prefix-value</code> or
+<code>namespace-value</code>.
+<error code="D0034">It is a <glossterm>dynamic error</glossterm>
+to specify a prefix or namespace URI if the QName value contains a colon.</error>
+</para>
+</listitem>
+<listitem>
+<para>If you specify a <code>prefix-value</code>, you must also specify
+a namespace (either with the <code>namespace-value</code> or through a
+URI qualified name).
+<error code="D0070">It is a <glossterm>dynamic error</glossterm>
+to specify a prefix without also specifying a namespace URI.</error>
+</para>
+</listitem>
+<listitem>
+<para>If the specified value is of type <code>xs:QName</code> or is
+a URI qualified name, you may not specify a <code>namespace-value</code>.
+<error code="D0067">It is a <glossterm>dynamic error</glossterm>
+to separately specify a namespace URI if the value is a URI qualified name.</error>
+</para>
+</listitem>
+</orderedlist>
+
+<para>As an additional convenience, if the specified sequence type is
+a map with <type>xs:QName</type> keys
+(<type>map(xs:QName, …)</type>),
+the <function>p:force-qname-keys</function> function is
+automatically applied to the value. This makes it possible to pass in
+maps using (easier to write) <type>xs:string</type> type keys that are
+converted automatically into the required <type>xs:QName</type>
+keys in a manner analgous to <type>#QName</type> values.</para>
 </section>
 
 <!-- ============================================================ -->


### PR DESCRIPTION
(This is #637 refactored to use #type instead of p:type)

Fix #534
Fix #613

Support new types (#XSLTSelectionPattern, #XPathExpression, #XPathSequenceType, #RegularExpression, and #QName). Support new values attribute for enumerating values.

Updates step signatures to make optional options have a type that would allow empty sequence.

Tweaked schemas and tools as necessary.