### PR TITLE
Support values attribute, xs:QName value rules

### DIFF
--- a/src/main/resources/css/xproc.css
+++ b/src/main/resources/css/xproc.css
@@ -1,3 +1,11 @@
+p code {
+    font-size: 120%;
+}
+
+p.element-syntax code {
+    font-size: 100%;
+}
+
 dl.toc             { margin-top: 0;
                      margin-bottom: 0
 }

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -387,6 +387,7 @@ Option =
    element option {
       name.qname.attr,
       as.attr?,
+      attribute values { text }?,
       static.attr?,
       required.attr?,
       select.attr?,
@@ -403,6 +404,7 @@ StaticOption =
    element option {
       name.qname.attr,
       as.attr?,
+      attribute values { text }?,
       attribute static { "true" },
       select.attr,
       common.attributes,

--- a/step-validation/src/main/xml/specification.xml
+++ b/step-validation/src/main/xml/specification.xml
@@ -135,7 +135,7 @@ processing to the <port>source</port> document.</para>
   <p:input port="schema" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" primary="true" content-types="application/xml"/>
   <p:output port="report" sequence="true" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
   <p:option name="phase" select="'#ALL'" as="xs:string"/>
   <p:option name="assert-valid" select="true()" as="xs:boolean"/>
 </p:declare-step>
@@ -184,8 +184,8 @@ validity assessment to the <port>source</port> input.</para>
   <p:option name="use-location-hints" select="false()" as="xs:boolean"/>
   <p:option name="try-namespaces" select="false()" as="xs:boolean"/>
   <p:option name="assert-valid" select="true()" as="xs:boolean"/>
-  <p:option name="mode" select="'strict'" as="xs:token" e:type="strict|lax"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="mode" select="'strict'" as="xs:token" values="('strict','lax')"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>The values of the <option>use-location-hints</option>,

--- a/step-xquery/src/main/xml/specification.xml
+++ b/step-xquery/src/main/xml/specification.xml
@@ -75,8 +75,8 @@ provided on the <port>source</port> port.</para>
            sequence="true" primary="true"/>
   <p:input port="query" content-types="application/xml */*+xml text/*"/>
   <p:output port="result" sequence="true" content-types="*/*"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>If a sequence of documents is provided on the

--- a/step-xsl-formatter/src/main/xml/specification.xml
+++ b/step-xsl-formatter/src/main/xml/specification.xml
@@ -74,8 +74,8 @@ port.</para>
 <p:declare-step type="p:xsl-formatter">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="*/*"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="content-type" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="content-type" as="xs:string?"/>
 </p:declare-step>
 
 <para>The content-type of the output is controlled by the

--- a/steps/src/main/xml/steps/add-attribute.xml
+++ b/steps/src/main/xml/steps/add-attribute.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.add-attribute">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.add-attribute">
 <title>p:add-attribute</title>
 
 <para>The <code>p:add-attribute</code> step adds a single attribute to
@@ -20,10 +24,10 @@ with the specified value.
 <p:declare-step type="p:add-attribute">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+  <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
   <p:option name="attribute-name" required="true" as="xs:QName"/>
-  <p:option name="attribute-prefix" as="xs:NCName"/>
-  <p:option name="attribute-namespace" as="xs:anyURI"/>
+  <p:option name="attribute-prefix" as="xs:NCName?"/>
+  <p:option name="attribute-namespace" as="xs:anyURI?"/>
   <p:option name="attribute-value" required="true" as="xs:string"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/add-xml-base.xml
+++ b/steps/src/main/xml/steps/add-xml-base.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.add-xml-base">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.add-xml-base">
 
 <title>p:add-xml-base</title>
 
@@ -11,8 +14,8 @@ by the options on this step.</para>
 <p:declare-step type="p:add-xml-base">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="all" select="false()" as="xs:boolean"/>
-   <p:option name="relative" select="true()" as="xs:boolean"/>
+   <p:option name="all" as="xs:boolean" select="false()"/>
+   <p:option name="relative" as="xs:boolean" select="true()"/>
 </p:declare-step>
 
  <para>The value of the <option>all</option> option

--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.cast-content-type">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.cast-content-type">
 <title>p:cast-content-type</title>
 
 <para>The <tag>p:cast-content-type</tag> step changes the media type
@@ -8,7 +12,7 @@ of its input.</para>
    <p:input port="source" content-types="*/*"/>
    <p:output port="result" content-types="*/*"/>
    <p:option name="content-type" required="true" as="xs:string"/>
-   <p:option name="parameters" as="map(*)?"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>The input document is transformed from one media type to another.

--- a/steps/src/main/xml/steps/compare.xml
+++ b/steps/src/main/xml/steps/compare.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.compare">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.compare">
 <title>p:compare</title>
 
 <para>The <code>p:compare</code> step compares two documents for
@@ -9,9 +12,9 @@ equality.</para>
    <p:input port="alternate" content-types="*/*"/>
    <p:output port="result" content-types="application/xml"/>
    <p:output port="differences" content-types="*/*" sequence="true"/>
-   <p:option name="method" as="xs:QName"/>
-   <p:option name="fail-if-not-equal" select="false()" as="xs:boolean"/>
-   <p:option name="parameters" as="map(xs:QName,item())"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+   <p:option name="method" as="xs:QName?"/>
+   <p:option name="fail-if-not-equal" as="xs:boolean" select="false()"/>
 </p:declare-step>
 
 <para>This step takes single documents on each of two ports and

--- a/steps/src/main/xml/steps/count.xml
+++ b/steps/src/main/xml/steps/count.xml
@@ -11,7 +11,7 @@ sequence.</para>
 <p:declare-step type="p:count">
    <p:input port="source" content-types="*/*" sequence="true"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="limit" select="0" as="xs:integer"/>
+   <p:option name="limit" as="xs:integer" select="0"/>
 </p:declare-step>
 
 <para>If the <tag feature="p-count-limit" class="attribute">limit</tag> option is specified

--- a/steps/src/main/xml/steps/delete.xml
+++ b/steps/src/main/xml/steps/delete.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.delete">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.delete">
 <title>p:delete</title>
 
 <para>The <code>p:delete</code> step deletes items specified by a match

--- a/steps/src/main/xml/steps/directory-list.xml
+++ b/steps/src/main/xml/steps/directory-list.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.directory-list">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.directory-list">
 <title>p:directory-list</title>
 
   <para>The <code>p:directory-list</code> step produces a list of the contents
@@ -7,7 +11,7 @@
 <p:declare-step type="p:directory-list">
   <p:output port="result" content-type="application/xml"/>
   <p:option name="path" required="true" as="xs:anyURI"/>
-  <p:option name="detailed" select="false()" as="xs:boolean"/>
+  <p:option name="detailed" as="xs:boolean" select="false()"/>
   <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
   <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
 </p:declare-step>

--- a/steps/src/main/xml/steps/error.xml
+++ b/steps/src/main/xml/steps/error.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.error">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.error">
 <title>p:error</title>
 
 <para>The <code>p:error</code> step generates a <glossterm role="unwrapped">dynamic error</glossterm> using the input provided
@@ -7,7 +10,7 @@ to the step.</para>
 <p:declare-step type="p:error">
     <p:input port="source" sequence="true" content-types="application/xml text/xml */*+xml text/*"/>
     <p:output port="result" sequence="true" content-types="application/xml text/xml */*+xml text/*"/>
-    <p:option name="code" required="true" as="xs:anyAtomicType"/>
+    <p:option name="code" required="true" as="xs:QName"/>
     <p:option name="code-prefix" as="xs:NCName?"/>
     <p:option name="code-namespace" as="xs:anyURI?"/>
 </p:declare-step>

--- a/steps/src/main/xml/steps/file-head.xml
+++ b/steps/src/main/xml/steps/file-head.xml
@@ -1,6 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
-  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc"
-  xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-head">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-head">
   <title>p:file-head</title>
 
   <para>The <code>p:file-head</code> step returns lines from the beginning of a text file.</para>
@@ -9,6 +11,7 @@
     <title>Editorial Note</title>
     <para>TBD: This is an almost direct port from EXProc. Details might still change.</para>
     <para>Check and amend the error codes.</para>
+    <para>Norm, offline at the moment, asks: why does this step return XML instead of text?</para>
   </note>
 
   <p:declare-step type="p:file-head">

--- a/steps/src/main/xml/steps/file-tempfile.xml
+++ b/steps/src/main/xml/steps/file-tempfile.xml
@@ -1,6 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
-  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc"
-  xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-tempfile">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-tempfile">
   <title>p:file-tempfile</title>
 
   <para>The <code>p:file-tempfile</code> step creates a temporary file.</para>
@@ -15,11 +17,11 @@
 
   <p:declare-step type="p:file-tempfile">
     <p:output port="result" primary="true" content-types="application/xml"/>
-    <p:option name="href" required="false" as="xs:anyURI"/>
-    <p:option name="suffix" required="false" as="xs:string"/>
-    <p:option name="prefix" required="false" as="xs:string"/>
-    <p:option name="delete-on-exit" required="false" as="xs:boolean" select="false()"/>
-    <p:option name="fail-on-error" required="false" as="xs:boolean" select="true()"/>
+    <p:option name="href" as="xs:anyURI?"/>
+    <p:option name="suffix" as="xs:string?"/>
+    <p:option name="prefix" as="xs:string?"/>
+    <p:option name="delete-on-exit" as="xs:boolean" select="false()"/>
+    <p:option name="fail-on-error" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
   <para>The <tag>p:file-tempfile</tag> creates a temporary file. The temporary file is guaranteed not to already exist

--- a/steps/src/main/xml/steps/file-touch.xml
+++ b/steps/src/main/xml/steps/file-touch.xml
@@ -1,6 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
-  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc"
-  xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-touch">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.file-touch">
   <title>p:file-touch</title>
 
   <para>The <code>p:file-touch</code> step updates the modification timestamp of a file.</para>
@@ -14,8 +15,8 @@
   <p:declare-step type="p:file-touch">
     <p:output port="result" primary="true" content-types="application/xml"/>
     <p:option name="href" required="true" as="xs:anyURI"/>
-    <p:option name="timestamp" required="false" as="xs:dateTime"/>
-    <p:option name="fail-on-error" required="false" as="xs:boolean" select="true()"/>
+    <p:option name="timestamp" as="xs:dateTime?"/>
+    <p:option name="fail-on-error" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
   <para>The <tag>p:file-touch</tag> step updates the modification timestamp of the fiel specified in the
@@ -28,7 +29,7 @@
 
   <para>If the <option>timestamp</option> option is set, the file's timestamp is set to this value. Otherwise the file's
     timestamp is set to the current system's date and time.</para>
-  
+
   <para>If an error occurs and <option>fail-on-error</option> is <code>false</code>, the step returns a
       <tag>c:error</tag> element which may contain additional, implementation-defined, information about the nature of
     the error.</para>

--- a/steps/src/main/xml/steps/filter.xml
+++ b/steps/src/main/xml/steps/filter.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.filter">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.filter">
 <title>p:filter</title>
 
 <para>The <code>p:filter</code> step selects portions of the source document

--- a/steps/src/main/xml/steps/hash.xml
+++ b/steps/src/main/xml/steps/hash.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.hash">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.hash">
 <title>p:hash</title>
 
 <para>The <tag>p:hash</tag> step generates a hash, or digital “fingerprint”,
@@ -7,11 +11,11 @@ for some value and injects it into the <port>source</port> document.</para>
 <p:declare-step type="p:hash">
   <p:input port="source" primary="true" content-types="*/*"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
   <p:option name="value" required="true" as="xs:string"/>
   <p:option name="algorithm" required="true" as="xs:QName"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>The value of the <option>algorithm</option> option must be a QName.

--- a/steps/src/main/xml/steps/identity.xml
+++ b/steps/src/main/xml/steps/identity.xml
@@ -1,11 +1,14 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.identity">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.identity">
 <title>p:identity</title>
 
 <para>The <code>p:identity</code> step makes a verbatim copy of its input
 available on its output.</para>
 
 <p:declare-step type="p:identity">
-  <p:input port="source" content-types="*/*" sequence="true"/>
+  <p:input port="source" sequence="true" content-types="*/*"/>
   <p:output port="result" sequence="true" content-types="*/*"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/in-scope-names.xml
+++ b/steps/src/main/xml/steps/in-scope-names.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.in-scope-names">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.in-scope-names">
 <title>p:in-scope-names</title>
 
 <para>The <code>p:in-scope-names</code> step exposes all of the
@@ -6,7 +9,7 @@ in-scope variables and options as a set of parameters in a
 <tag>c:param-set</tag> document.</para>
 
 <p:declare-step type="p:in-scope-names">
-  <p:output port="result" primary="false" content-types="application/xml"/>
+  <p:output port="result" content-types="application/xml"/>
 </p:declare-step>
 
 <para>Each in-scope variable and option is converted into a

--- a/steps/src/main/xml/steps/insert.xml
+++ b/steps/src/main/xml/steps/insert.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.insert">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.insert">
 <title>p:insert</title>
 
 <para>The <code>p:insert</code> step inserts the
@@ -10,8 +14,8 @@ port's document relative to the matching elements in the
    <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
    <p:input port="insertion" sequence="true" content-types="application/xml text/* */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-   <p:option name="position" required="true" as="xs:token" e:type="first-child|last-child|before|after"/>
+   <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
+   <p:option name="position" required="true" as="xs:token" values="('first-child','last-child','before','after')"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option
@@ -46,8 +50,8 @@ the following list:
 if the match pattern matches anything other than an element or a document
 node and the value of the <option>position</option> option is
 “<literal>first-child</literal>” or
-“<literal>last-child</literal>”.</error> <error code="C0024">It is a 
-<glossterm>dynamic error</glossterm> if the match pattern matches a document 
+“<literal>last-child</literal>”.</error> <error code="C0024">It is a
+<glossterm>dynamic error</glossterm> if the match pattern matches a document
 node and the value of the <option>position</option> is “<literal>before</literal>” or
 “<literal>after</literal>”.</error></para>
 

--- a/steps/src/main/xml/steps/label-elements.xml
+++ b/steps/src/main/xml/steps/label-elements.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.label-elements">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.label-elements">
 <title>p:label-elements</title>
 
 <para>The <code>p:label-elements</code> step generates a label for each matched
@@ -7,12 +11,12 @@ element and stores that label in the specified attribute.</para>
 <p:declare-step type="p:label-elements">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="attribute" select="'xml:id'" as="xs:QName"/>
-  <p:option name="attribute-prefix" as="xs:NCName"/>
-  <p:option name="attribute-namespace" as="xs:anyURI"/>
-  <p:option name="label" select="'concat(&#34;_&#34;,$p:index)'" as="xs:string" e:type="XPathExpression"/>
-  <p:option name="match" select="'*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="replace" select="'true'" as="xs:boolean"/>
+  <p:option name="attribute" as="xs:QName" select="'xml:id'"/>
+  <p:option name="attribute-prefix" as="xs:NCName?"/>
+  <p:option name="attribute-namespace" as="xs:anyURI?"/>
+  <p:option name="label" as="xs:string" select="'concat(&#34;_&#34;,$p:index)'" e:type="XPathExpression"/>
+  <p:option name="match" as="xs:string" select="'*'" e:type="XSLTSelectionPattern"/>
+  <p:option name="replace" as="xs:boolean" select="true()"/>
 </p:declare-step>
 
 <para>The value of the <option>attribute</option> option

--- a/steps/src/main/xml/steps/load-directory-list.xml
+++ b/steps/src/main/xml/steps/load-directory-list.xml
@@ -1,6 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
-  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc"
-  xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.load-directory-list">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.load-directory-list">
 <title>p:load-directory-list</title>
 
   <para>The <code>p:load-directory-list</code> step has no inputs but produces as its result a sequence of documents
@@ -31,8 +33,8 @@ environment in which the pipeline is run.</error></para>
 
 <para>If present, the value of the <option>include-filter</option>
 or <option>exclude-filter</option>
-option <rfc2119>must</rfc2119> be a regular expression as specified in 
-    <biblioref linkend="xpath31-functions"/>,section 7.61 “<literal>Regular Expression
+option <rfc2119>must</rfc2119> be a regular expression as specified in
+<biblioref linkend="xpath31-functions"/>,section 7.61 “<literal>Regular Expression
 Syntax</literal>”.</para>
 
 <para>If the <option>include-filter</option> pattern matches a

--- a/steps/src/main/xml/steps/load.xml
+++ b/steps/src/main/xml/steps/load.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.load">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.load">
 <title>p:load</title>
 
 <para>The <code>p:load</code> step has no inputs but produces as its
@@ -7,13 +10,13 @@ result a document (or documents) specified by an IRI.</para>
 <p:declare-step type="p:load">
   <p:output port="result" sequence="true" content-types="*/*"/>
   <p:option name="href" required="true" as="xs:anyURI"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
-  <p:option name="content-type" as="xs:string" />
-  <p:option name="document-properties" as="map(xs:QName, item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
+  <p:option name="content-type" as="xs:string?"/>
+  <p:option name="document-properties" as="map(xs:QName, item()*)?"/>
 </p:declare-step>
 
 <para><error code="D0064">It is a <glossterm>dynamic error</glossterm> if
-the <option>href</option> URI is not a valid <type>xs:anyURI</type>.</error> 
+the <option>href</option> URI is not a valid <type>xs:anyURI</type>.</error>
 If the <option>href</option> is relative, it is made absolute
 against the base URI of the element on which it is specified
 (<tag>p:with-option</tag> or <tag>p:load</tag> in the case of a
@@ -79,7 +82,7 @@ the loaded content is not a well-formed XML document.</error></para>
 
 <para>If the <option>dtd-validate</option> parameter is <literal>true</literal>,
 then DTD validation must be performed when parsing the document.
-<error code="D0023">It is a <glossterm>dynamic error</glossterm> if a DTD validation 
+<error code="D0023">It is a <glossterm>dynamic error</glossterm> if a DTD validation
 is performed and either the document is not valid or no DTD is found.</error>
 <error code="D0043">It is a <glossterm>dynamic error</glossterm>
 if the <option>dtd-validate</option> parameter is <literal>true</literal> and

--- a/steps/src/main/xml/steps/make-absolute-uris.xml
+++ b/steps/src/main/xml/steps/make-absolute-uris.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.make-absolute-uris">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.make-absolute-uris">
 <title>p:make-absolute-uris</title>
 
 <para>The <code>p:make-absolute-uris</code> step makes an element or
@@ -9,7 +13,7 @@ result document.</para>
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="base-uri" as="xs:anyURI"/>
+  <p:option name="base-uri" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/namespace-rename.xml
+++ b/steps/src/main/xml/steps/namespace-rename.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.namespace-rename">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.namespace-rename">
 <title>p:namespace-rename</title>
 
 <para>The <code>p:namespace-rename</code> step renames any namespace declaration or
@@ -7,9 +11,9 @@ use of a namespace in a document to a new IRI value.</para>
  <p:declare-step type="p:namespace-rename">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="from" as="xs:anyURI"/>
-   <p:option name="to" as="xs:anyURI"/>
-   <p:option name="apply-to" select="'all'" as="xs:token" e:type="all|elements|attributes"/>
+   <p:option name="from" required="true" as="xs:anyURI"/>
+   <p:option name="to" required="true" as="xs:anyURI"/>
+   <p:option name="apply-to" as="xs:token" select="'all'" values="('all','elements','attributes')"/>
 </p:declare-step>
 
 <para>The value of the <option>from</option> option
@@ -32,7 +36,8 @@ and attributes will be renamed.</para>
 
 <para><error code="C0014">It is a <glossterm>dynamic error</glossterm>
 if the XML namespace (<uri>http://www.w3.org/XML/1998/namespace</uri>)
-or the XMLNS namespace (<uri>http://www.w3.org/2000/xmlns/</uri>) is
+or the
+XMLNS namespace (<uri>http://www.w3.org/2000/xmlns/</uri>) is
 the value of either the <option>from</option> option or the
 <option>to</option> option.</error></para>
 

--- a/steps/src/main/xml/steps/pack.xml
+++ b/steps/src/main/xml/steps/pack.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.pack">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.pack">
 <title>p:pack</title>
 
 <para>The <code>p:pack</code> step merges two document sequences in a pair-wise
@@ -9,8 +13,8 @@ fashion.</para>
    <p:input port="alternate" sequence="true" content-types="application/xml"/>
    <p:output port="result" sequence="true"/>
    <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/parameters.xml
+++ b/steps/src/main/xml/steps/parameters.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.parameters">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.parameters">
 <title>p:parameters</title>
 
 <para>The <code>p:parameters</code> step exposes a set of parameters
@@ -6,7 +10,7 @@ as a <tag>c:param-set</tag> document.</para>
 
 <p:declare-step type="p:parameters">
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="parameters" as="map(xs:QName,item())"/>
+   <p:option name="parameters" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>Each parameter in the <option>parameters</option> map is converted into a

--- a/steps/src/main/xml/steps/rename.xml
+++ b/steps/src/main/xml/steps/rename.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.rename">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.rename">
 <title>p:rename</title>
 
 <para>The <code>p:rename</code> step renames elements, attributes, or
@@ -7,10 +11,10 @@ processing-instruction targets in a document.</para>
 <p:declare-step type="p:rename">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+  <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
   <p:option name="new-name" required="true" as="xs:QName"/>
-  <p:option name="new-prefix" as="xs:NCName"/>
-  <p:option name="new-namespace" as="xs:anyURI"/>
+  <p:option name="new-prefix" as="xs:NCName?"/>
+  <p:option name="new-namespace" as="xs:anyURI?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option must be an

--- a/steps/src/main/xml/steps/replace.xml
+++ b/steps/src/main/xml/steps/replace.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.replace">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.replace">
 <title>p:replace</title>
 
 <para>The <code>p:replace</code> step replaces matching nodes in

--- a/steps/src/main/xml/steps/set-attributes.xml
+++ b/steps/src/main/xml/steps/set-attributes.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.set-attributes">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.set-attributes">
 <title>p:set-attributes</title>
 
 <para>The <tag>p:set-attributes</tag> step sets attributes on
@@ -8,7 +12,7 @@ matching elements.</para>
    <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
    <p:input port="attributes" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
 </p:declare-step>
 
  <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/set-properties.xml
+++ b/steps/src/main/xml/steps/set-properties.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.set-properties">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.set-properties">
 <title>p:set-properties</title>
 
 <para>The <tag>p:set-properties</tag> step sets document
@@ -7,7 +11,7 @@ properties on the source document.</para>
 <p:declare-step type="p:set-properties">
    <p:input port="source" content-types="*/*"/>
    <p:output port="result" content-types="*/*"/>
-   <p:option name="properties" required="true" as="map(xs:QName,item())"/>
+   <p:option name="properties" required="true" as="map(xs:QName,item()*)"/>
    <p:option name="merge" default="false()" as="xs:boolean"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/split-sequence.xml
+++ b/steps/src/main/xml/steps/split-sequence.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.split-sequence">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.split-sequence">
 <title>p:split-sequence</title>
 
 <para>The <tag>p:split-sequence</tag> step accepts a sequence of
@@ -8,7 +12,7 @@ documents and divides it into two sequences.</para>
   <p:input port="source" content-types="application/xml text/xml */*+xml" sequence="true"/>
   <p:output port="matched" sequence="true" primary="true" content-types="application/xml"/>
   <p:output port="not-matched" sequence="true" content-types="application/xml"/>
-  <p:option name="initial-only" select="false()" as="xs:boolean"/>
+  <p:option name="initial-only" as="xs:boolean" select="false()"/>
   <p:option name="test" required="true" as="xs:string" e:type="XPathExpression"/>
 </p:declare-step>
 

--- a/steps/src/main/xml/steps/string-replace.xml
+++ b/steps/src/main/xml/steps/string-replace.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.string-replace">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.string-replace">
 <title>p:string-replace</title>
 
 <para>The <tag>p:string-replace</tag> step matches nodes in the

--- a/steps/src/main/xml/steps/tee.xml
+++ b/steps/src/main/xml/steps/tee.xml
@@ -1,6 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#"
-  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc"
-  xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.tee">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.tee">
 <title>p:tee</title>
 
 <para>The <tag>p:tee</tag> step stores (a possibly serialized
@@ -9,9 +11,9 @@ version of) its input to a URI. The step outputs its input unchanged.</para>
   <p:declare-step type="p:tee">
     <p:input port="source" content-types="*/*" sequence="true"/>
     <p:output port="result" sequence="true" content-types="*/*"/>
-    <p:option name="href" required="true" as="xs:anyURI"/>        
+    <p:option name="href" required="true" as="xs:anyURI"/>
     <p:option name="serialization" as="map(xs:QName,item()*)?"/>
-    <p:option name="enable" as="xs:boolean" select="true()"/>   
+    <p:option name="enable" as="xs:boolean" select="true()"/>
   </p:declare-step>
 
 <para>The value of the <option>href</option> option <rfc2119>must</rfc2119> be an <type>anyURI</type>. If it is
@@ -28,7 +30,7 @@ specified location.</error></para>
 <para>The <option>serialization</option> option is provided to control the
 serialization of content when it is stored. Serialization is described in
 <biblioref linkend="xproc30"/>.</para>
-  
+
   <para>If the <option>enabled</option> option is false, no attempt to store the document will be made. The step will
     act exactly like a <tag>p:identity</tag> step. The values for <option>href</option> and
       <option>serialization</option> will be ignored.</para>

--- a/steps/src/main/xml/steps/unescape-markup.xml
+++ b/steps/src/main/xml/steps/unescape-markup.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unescape-markup">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unescape-markup">
 <title>p:unescape-markup</title>
 
 <para>The <tag>p:unescape-markup</tag> step takes the string value of
@@ -10,10 +14,10 @@ is the reverse of the <tag>p:escape-markup</tag> step.</para>
 <p:declare-step type="p:unescape-markup">
   <p:input port="source" content-types="application/xml text/xml */*+xml text/*"/>
   <p:output port="result" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="namespace" as="xs:anyURI"/>
-  <p:option name="content-type" select="'application/xml'" as="xs:string"/>
-  <p:option name="encoding" as="xs:string"/>
-  <p:option name="charset" as="xs:string"/>
+  <p:option name="namespace" as="xs:anyURI?"/>
+  <p:option name="content-type" as="xs:string" select="'application/xml'"/>
+  <p:option name="encoding" as="xs:string?"/>
+  <p:option name="charset" as="xs:string?"/>
 </p:declare-step>
 
 <para>The value of the <option>namespace</option> option

--- a/steps/src/main/xml/steps/unwrap.xml
+++ b/steps/src/main/xml/steps/unwrap.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unwrap">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.unwrap">
 <title>p:unwrap</title>
 
 <para>The <tag>p:unwrap</tag> step replaces matched elements with their
@@ -7,7 +11,7 @@ children.</para>
 <p:declare-step type="p:unwrap">
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
-   <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
+   <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
 </p:declare-step>
 
  <para>The value of the <option>match</option> option <rfc2119>must</rfc2119> be an

--- a/steps/src/main/xml/steps/uuid.xml
+++ b/steps/src/main/xml/steps/uuid.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.uuid">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.uuid">
 <title>p:uuid</title>
 
 <para>The <tag>p:uuid</tag> step generates a
@@ -8,8 +12,8 @@ the <port>source</port> document.</para>
 <p:declare-step type="p:uuid">
   <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="match" select="'/*'" as="xs:string" e:type="XSLTSelectionPattern"/>
-  <p:option name="version" as="xs:integer"/>
+  <p:option name="match" as="xs:string" select="'/*'" e:type="XSLTSelectionPattern"/>
+  <p:option name="version" as="xs:integer?"/>
 </p:declare-step>
 
 <para>The value of the <option>match</option> option must be an

--- a/steps/src/main/xml/steps/wrap-sequence.xml
+++ b/steps/src/main/xml/steps/wrap-sequence.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.wrap-sequence">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.wrap-sequence">
 <title>p:wrap-sequence</title>
 
 <para>The <tag>p:wrap-sequence</tag> step accepts a sequence of
@@ -9,9 +13,9 @@ documents.</para>
    <p:input port="source" content-types="application/xml */*+xml text/*" sequence="true"/>
    <p:output port="result" sequence="true" content-types="application/xml"/>
    <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
-   <p:option name="group-adjacent" as="xs:string" e:type="XPathExpression"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
+   <p:option name="group-adjacent" as="xs:string?" e:type="XPathExpression"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/wrap.xml
+++ b/steps/src/main/xml/steps/wrap.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.wrap">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.wrap">
 <title>p:wrap</title>
 
 <para>The <tag>p:wrap</tag> step wraps matching nodes in the
@@ -8,10 +12,10 @@
    <p:input port="source" content-types="application/xml text/xml */*+xml"/>
    <p:output port="result" content-types="application/xml"/>
    <p:option name="wrapper" required="true" as="xs:QName"/>
-   <p:option name="wrapper-prefix" as="xs:NCName"/>
-   <p:option name="wrapper-namespace" as="xs:anyURI"/>
+   <p:option name="wrapper-prefix" as="xs:NCName?"/>
+   <p:option name="wrapper-namespace" as="xs:anyURI?"/>
    <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
-   <p:option name="group-adjacent" as="xs:string" e:type="XPathExpression"/>
+   <p:option name="group-adjacent" as="xs:string?" e:type="XPathExpression"/>
 </p:declare-step>
 
 <para>The value of the <option>wrapper</option> option

--- a/steps/src/main/xml/steps/www-form-urlencode.xml
+++ b/steps/src/main/xml/steps/www-form-urlencode.xml
@@ -1,4 +1,8 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.www-form-urlencode">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.www-form-urlencode">
 <title>p:www-form-urlencode</title>
 
 <para>The <tag>p:www-form-urlencode</tag> step encodes a set of parameter
@@ -8,7 +12,7 @@ injects it into the <port>source</port> document.</para>
 <p:declare-step type="p:www-form-urlencode">
   <p:input port="source" primary="true" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
+  <p:option name="parameters" as="map(xs:QName,item()*)?"/>
   <p:option name="match" required="true" as="xs:string" e:type="XSLTSelectionPattern"/>
 </p:declare-step>
 
@@ -22,7 +26,7 @@ When parameters are encoded into name/value pairs,
 The namespace name is ignored and no prefix or colon appears in the name.
 </para>
 
-<para><impl>The order of the parameters is
+<para><impl>The order of the parameters
 is <glossterm>implementation-dependent</glossterm>.</impl></para>
 
 <para>The matched nodes are specified with the match pattern in the

--- a/steps/src/main/xml/steps/xinclude.xml
+++ b/steps/src/main/xml/steps/xinclude.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.xinclude">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.xinclude">
 <title>p:xinclude</title>
 
 <para>The <tag>p:xinclude</tag> step applies <biblioref linkend="xinclude"/> processing to the <port>source</port> document.</para>
@@ -6,8 +9,8 @@
 <p:declare-step type="p:xinclude">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="fixup-xml-base" select="'false'" as="xs:boolean"/>
-  <p:option name="fixup-xml-lang" select="'false'" as="xs:boolean"/>
+  <p:option name="fixup-xml-base" as="xs:boolean" select="false()"/>
+  <p:option name="fixup-xml-lang" as="xs:boolean" select="false()"/>
 </p:declare-step>
 
 <para>The value of the <option>fixup-xml-base</option> option <rfc2119>must</rfc2119> be a

--- a/steps/src/main/xml/steps/xslt.xml
+++ b/steps/src/main/xml/steps/xslt.xml
@@ -1,4 +1,7 @@
-<section xmlns="http://docbook.org/ns/docbook" xmlns:cs="http://www.w3.org/XML/XProc/2006/04/components#" xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:p="http://www.w3.org/ns/xproc" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.xslt">
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:p="http://www.w3.org/ns/xproc"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink" xml:id="c.xslt">
 <title>p:xslt</title>
 
 <para>The <tag>p:xslt</tag> step applies an XSLT stylesheet to a document.</para>
@@ -6,13 +9,13 @@
 <p:declare-step type="p:xslt">
   <p:input port="source" content-types="application/xml text/xml */*+xml" sequence="true" primary="true"/>
   <p:input port="stylesheet" content-types="application/xml text/xml */*+xml"/>
-  <p:option name="parameters" as="map(xs:QName,item())"/>
   <p:output port="result" primary="true" sequence="true" content-types="*/*"/>
   <p:output port="secondary" sequence="true"/>
-  <p:option name="initial-mode" as="xs:QName"/>
-  <p:option name="template-name" as="xs:QName"/>
-  <p:option name="output-base-uri" as="xs:anyURI"/>
-  <p:option name="version" as="xs:string"/>
+  <p:option name="parameters" as="map(xs:QName,item())?"/>
+  <p:option name="initial-mode" as="xs:QName?"/>
+  <p:option name="template-name" as="xs:QName?"/>
+  <p:option name="output-base-uri" as="xs:anyURI?"/>
+  <p:option name="version" as="xs:string?"/>
 </p:declare-step>
 
 <para>If present, the value of the <option>initial-mode</option>

--- a/tools/xsl/library-to-rnc.xsl
+++ b/tools/xsl/library-to-rnc.xsl
@@ -73,31 +73,22 @@
   <xsl:variable name="name" select="@name"/>
   <xsl:variable name="type" as="xs:string+">
     <xsl:choose>
-      <xsl:when test="not(@as) and not(@e:type)">
+      <xsl:when test="@values">
+        <xsl:variable name="text" select="replace(@values, '^\s*\(\s*(.*)\s*\)\s*$', '$1')"/>
+	<xsl:for-each select="tokenize($text,'\s*,\s*')">
+	  <xsl:if test="position()&gt;1">|</xsl:if>
+          <xsl:value-of select="."/>
+	</xsl:for-each>
+      </xsl:when>
+      <xsl:when test="not(@as)">
 	<xsl:message>
           <xsl:text>Warning: no type for option: </xsl:text>
           <xsl:value-of select="$name"/>
         </xsl:message>
 	<xsl:value-of select="'xsd:string'"/>
       </xsl:when>
-      <xsl:when test="not(@e:type)">
-	<xsl:value-of select="replace(@as, 'xs:', 'xsd:')"/>
-      </xsl:when>
-      <xsl:when test="contains(@e:type,'|')">
-	<xsl:for-each select="tokenize(@e:type,'\|')">
-	  <xsl:if test="position()&gt;1">|</xsl:if>
-	  <xsl:choose>
-	    <xsl:when test="starts-with(.,'xsd:')">
-	      <xsl:value-of select="."/>
-	    </xsl:when>
-	    <xsl:otherwise>
-	      <xsl:value-of select="concat('&quot;',.,'&quot;')"/>
-	    </xsl:otherwise>
-	  </xsl:choose>
-	</xsl:for-each>
-      </xsl:when>
       <xsl:otherwise>
-	<xsl:value-of select="@e:type"/>
+	<xsl:value-of select="replace(replace(@as, 'xs:', 'xsd:'), '#', '')"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:variable>

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -256,6 +256,8 @@
 	      <xsl:message>
 		<xsl:text>Warning: unsupported ref in attribute: </xsl:text>
 		<xsl:value-of select="@name"/>
+                <xsl:text>: </xsl:text>
+                <xsl:value-of select="rng:ref/@name"/>
 	      </xsl:message>
 	    </xsl:otherwise>
 	  </xsl:choose>

--- a/tools/xsl/xprocns.xsl
+++ b/tools/xsl/xprocns.xsl
@@ -108,22 +108,9 @@
 	<xsl:choose xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax">
 	  <xsl:when test="not(@as) and not(@e:type)">
 	    <xsl:message>Warning: no e:type!!!</xsl:message>
-	    <xsl:value-of select="'string'"/>
+	    <xsl:value-of select="'item()*'"/>
 	  </xsl:when>
           <xsl:when test="not(@e:type)"/>
-	  <xsl:when test="contains(@e:type,'|')">
-	    <xsl:for-each select="tokenize(@e:type,'\|')">
-	      <xsl:if test="position()&gt;1">|</xsl:if>
-	      <xsl:choose>
-		<xsl:when test="starts-with(.,'xsd:')">
-		  <xsl:value-of select="substring-after(., 'xsd:')"/>
-		</xsl:when>
-		<xsl:otherwise>
-		  <xsl:value-of select="concat('&quot;',.,'&quot;')"/>
-		</xsl:otherwise>
-	      </xsl:choose>
-	    </xsl:for-each>
-	  </xsl:when>
 	  <xsl:otherwise>
 	    <xsl:value-of select="replace(@e:type,'xsd:','')"/>
 	  </xsl:otherwise>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -2512,6 +2512,205 @@ the pipeline will produce three messages: “NAME1=1”, “NAME2=2”, and “N
 (If an overriding value is provided at runtime, “NAME1” will have that value,
 “NAME2” will have one more than that value, and “NAME3” will have the value 7.
 </para>
+
+<section xml:id="statics">
+<title>Static Options and Variables</title>
+
+<para>A <tag>p:option</tag> or <tag>p:variable</tag> that is a
+<emphasis>direct child</emphasis> of <tag>p:declare-step</tag> may be
+declared “static”. Options and variables that are the direct
+children of <tag>p:library</tag> <rfc2119>must</rfc2119> be declared
+static.</para>
+
+<para>The values of static options and variables are computed during
+<link linkend="initiating">static analysis</link>.</para>
+</section>
+
+<section xml:id="varopt-types">
+<title>Variable and option types</title>
+
+<para>Variables and options may declare that they have a type using the
+<tag class="attribute">as</tag> attribute. The attribute value <rfc2119>must</rfc2119>
+be an
+<biblioref linkend="xpath31"/>
+<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
+<error code="S0096">It is a <glossterm>static
+error</glossterm> if the sequence type is not syntactically
+valid.</error> The sequence type <literal>item()*</literal> is assumed if
+no explicit type is provided.
+</para>
+
+<para>If a variable or option declares a type, the supplied value 
+ of the variable or option is converted to the required type, 
+ using the function conversion rules specified by XPath 3.1.
+ <error code="D0036">It is a <glossterm>dynamic error</glossterm> if 
+ the supplied value of a variable or option cannot be converted 
+ to the required type.</error></para>
+
+<para>Some steps have options whose values are QNames, for example
+“<tag class="attribute">attribute-name</tag>” on
+<tag>p:add-attribute</tag>. If the type
+<type>xs:QName</type> was strictly enforced, they would be tedious to specify. As a
+convenience for pipeline authors, the values of variables or options
+declared with the type <type>xs:QName</type> are processed specially.
+The type <type>xs:QName</type> is treated as <type>xs:anyAtomicType</type> for the purpose
+of atomization. The value (or values) are converted to <type>xs:QName</type>s:</para>
+
+<orderedlist>
+<listitem>
+<para>If the value supplied for the option is an instance of
+<type>xs:QName</type> then that value is used.
+</para>
+</listitem>
+<listitem>
+<para>If the value supplied for the option is an instance of
+<type>xs:string</type> (or a type derived from
+<type>xs:string</type>), the QName is constructed by following the
+<link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
+production rules</link> in <biblioref linkend="xpath31"/>. That is, it
+can be written as a local-name only, as a prefix plus local-name, or as
+a URI qualified name (using the <code>Q{namespace}local-name</code> syntax).
+<error code="D0061">It is a 
+<glossterm>dynamic error</glossterm> if the string value is not syntactically an
+EQName.</error>
+<error code="D0069">It is a 
+<glossterm>dynamic error</glossterm> if the string value contains a colon and
+the designated prefix is not declared in the in-scope namespaces.</error>
+</para>
+</listitem>
+<listitem>
+<para><error code="D0068">It is a <glossterm>dynamic error</glossterm>
+if the supplied value is neither an instance of <type>xs:QName</type>
+nor an instance of <type>xs:string</type>.</error>
+</para>
+</listitem>
+</orderedlist> 
+
+<para>Steps with a QName-valued option also often provide two
+additional attributes to separately identify a prefix and a namespace URI.
+Although their names vary from step to step, in this section
+they’re identified as the <code>qname-value</code>,
+<code>prefix-value</code>, and <code>namespace-value</code>
+attributes. The rules described here apply regardless of their actual
+names.</para>
+
+<para>When <code>prefix-value</code> and <code>namespace-value</code>
+attributes are available, several additional co-constraints apply:</para>
+
+<orderedlist>
+<listitem>
+<para>If the supplied value of the name is an <code>xs:QName</code>, you may not specify
+the <code>prefix-value</code> or <code>namespace-value</code>.
+<error code="D0066">It is a <glossterm>dynamic error</glossterm>
+to separately specify a prefix or namespace URI if the supplied value
+has the type <code>xs:QName</code>.</error>
+</para>
+</listitem>
+<listitem>
+<para>If the string value of the <code>qname-value</code> attribute
+contains a colon, you may not specify a <code>prefix-value</code> or
+<code>namespace-value</code>.
+<error code="D0034">It is a <glossterm>dynamic error</glossterm>
+to specify a prefix or namespace URI if the QName value contains a colon.</error>
+</para>
+</listitem>
+<listitem>
+<para>If you specify a <code>prefix-value</code>, you must also specify
+a namespace (either with the <code>namespace-value</code> or through a
+URI qualified name).
+<error code="D0070">It is a <glossterm>dynamic error</glossterm>
+to specify a prefix without also specifying a namespace URI.</error>
+</para>
+</listitem>
+<listitem>
+<para>If the specified value is of type <code>xs:QName</code> or is
+a URI qualified name, you may not specify a <code>namespace-value</code>.
+<error code="D0067">It is a <glossterm>dynamic error</glossterm>
+to separately specify a namespace URI if the value is a URI qualified name.</error>
+</para>
+</listitem>
+</orderedlist>
+
+<para>As an additional convenience, if the specified sequence type is
+a map with <type>xs:QName</type> keys
+(<type>map(xs:QName, …)</type>),
+the <function>p:force-qname-keys</function> function is
+automatically applied to the value. This makes it possible to pass in
+maps using (easier to write) <type>xs:string</type> type keys that are
+converted automatically into the required <type>xs:QName</type>
+keys in a manner analgous to <type>#QName</type> values.</para>
+</section>
+
+<!-- ============================================================ -->
+
+<section xml:id="opt-bindings"><title>Namespaces on variables and options</title>
+
+<para>Variable and option values carry with them not only
+their literal or computed string value but also a set of namespaces.
+To see why this is necessary, consider the following
+step:</para><programlisting language="xml"><xi:include
+href="../../../build/examples/opns-1.txt" parse="text"/></programlisting><para>The
+<tag>p:delete</tag> step will delete elements that match the
+expression “<literal>html:div</literal>”, but that expression can only
+be correctly interpreted if there's a namespace binding for the prefix
+“<literal>html</literal>” so that binding has to travel with the
+option.</para>
+
+<para>The default namespace bindings associated with a variable or
+option value are computed as follows:</para><orderedlist>
+
+<listitem>
+<para>If the <tag class="attribute">select</tag> attribute was used to
+specify the value and it consisted of a single
+<literal>VariableReference</literal> (per <biblioref
+linkend="xpath31"/>), then the namespace bindings from the referenced
+option or variable are used.</para>
+</listitem>
+          <listitem>
+            <para>If the <tag class="attribute">select</tag> attribute was used to specify the value
+              and it evaluated to a node-set, then the in-scope namespaces from the first node in
+              the selected node-set (or, if it's not an element, its parent) are used.</para>
+            <para>The expression is evaluated in the appropriate context, See <xref
+                linkend="xpath-context"/>.</para>
+          </listitem>
+          <listitem>
+            <para>Otherwise, the in-scope namespaces from the element providing the value are used.
+              (For options specified using <link linkend="option-shortcut">syntactic
+                shortcuts</link>, the step element itself is providing the value.)</para>
+          </listitem>
+        </orderedlist><para>The default namespace is never included in the namespace bindings for a
+          variable or option value. Unqualified names are always in
+          no-namespace.</para>
+<para>Unfortunately, in more complex situations, there may be no
+          single variable or option that can reliably be expected to have the correct set
+          of namespace bindings. Consider this
+          pipeline:</para><programlisting language="xml"><xi:include href="../../../build/examples/opns-2.txt" parse="text"/></programlisting><para>It
+          defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements that
+          occur inside of XHTML div elements. It might be used as
+          follows:</para>
+
+<programlisting language="xml"><xi:include href="../../../build/examples/opns-3.txt" parse="text"/></programlisting>
+
+<para>In this case, the <varname>match</varname> option passed to the
+<tag>p:delete</tag> step needs <emphasis>both</emphasis> the namespace
+binding of “<literal>h</literal>” specified in the
+<tag>ex:delete-in-div</tag> pipeline definition
+<emphasis>and</emphasis> the namespace binding of
+“<literal>html</literal>” specified in the <varname>divchild</varname>
+option on the call of that pipeline. It's not sufficient to provide
+just one of the sets of bindings.</para>
+
+<para>If pipeline authors cannot arrange for all of the necessary namespace
+bindings to be in scope, then EQNames can be used to remove the dependency
+on namespace bindings:</para>
+
+<programlisting language="xml"><xi:include href="../../../build/examples/opns-4.txt" parse="text"/></programlisting>
+
+<para>In this example, the expression will match “<literal>p</literal>”
+elements in the XHTML namespace irrespective of any bindings that may or may
+not be in scope.</para>
+
+</section>
 </section>
 
     <section xml:id="security-considerations">
@@ -3214,92 +3413,6 @@ is meaningless or inconvenient, some other mechanism may be used.
 <rfc2119>should</rfc2119> do so before execution of the step
 begins.</para>
 </section>
-</section>
-
-<section xml:id="qname-options">
-<title>QNames as option values</title>
-
-<para>Some steps have options whose values are QNames, for example
-“<tag class="attribute">attribute-name</tag>” on
-<tag>p:add-attribute</tag>. If these attributes had a required type of
-<type>xs:QName</type>, they would be tedious to specify. As a
-convenience for pipeline authors, the declared type of these options
-is <type>xs:anyAtomicType</type>.</para>
-
-<orderedlist>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:QName</type> then that value is used.
-</para>
-</listitem>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:string</type> (or a type derived from
-<type>xs:string</type>), the QName is constructed by following the
-<link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
-production rules</link> in <biblioref linkend="xpath31"/>. That is, it
-can be written as a local-name only, as a prefix plus local-name, or as
-a URI qualified name (using the <code>Q{namespace}local-name</code> syntax).
-<error code="D0061">It is a 
-<glossterm>dynamic error</glossterm> if the string value is not syntactically an
-EQName.</error>
-<error code="D0069">It is a 
-<glossterm>dynamic error</glossterm> if the string value contains a colon and
-the designated prefix is not declared in the in-scope namespaces.</error>
-</para>
-</listitem>
-<listitem>
-<para><error code="D0068">It is a <glossterm>dynamic error</glossterm>
-if the supplied value is neither an instance of <type>xs:QName</type>
-nor an instance of <type>xs:string</type>.</error>
-</para>
-</listitem>
-</orderedlist> 
-
-<para>Steps with a QName-valued option also often provide two
-additional attributes to separately identify a prefix and a namespace URI.
-Although their names vary from step to step, in this section
-they’re identified as the <code>qname-value</code>,
-<code>prefix-value</code>, and <code>namespace-value</code>
-attributes. The rules described here apply regardless of their actual
-names.</para>
-
-<para>When <code>prefix-value</code> and <code>namespace-value</code>
-attributes are available, several additional co-constraints apply:</para>
-
-<orderedlist>
-<listitem>
-<para>If the supplied value of the name is an <code>xs:QName</code>, you may not specify
-the <code>prefix-value</code> or <code>namespace-value</code>.
-<error code="D0066">It is a <glossterm>dynamic error</glossterm>
-to separately specify a prefix or namespace URI if the supplied value
-has the type <code>xs:QName</code>.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the string value of the <code>qname-value</code> attribute
-contains a colon, you may not specify a <code>prefix-value</code> or
-<code>namespace-value</code>.
-<error code="D0034">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix or namespace URI if the QName value contains a colon.</error>
-</para>
-</listitem>
-<listitem>
-<para>If you specify a <code>prefix-value</code>, you must also specify
-a namespace (either with the <code>namespace-value</code> or through a
-URI qualified name).
-<error code="D0070">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix without also specifying a namespace URI.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the specified value is of type <code>xs:QName</code> or is
-a URI qualified name, you may not specify a <code>namespace-value</code>.
-<error code="D0067">It is a <glossterm>dynamic error</glossterm>
-to separately specify a namespace URI if the value is a URI qualified name.</error>
-</para>
-</listitem>
-</orderedlist>
 </section>
 
 <section xml:id="syntax-summaries"><title>Syntax Summaries</title>
@@ -5024,11 +5137,9 @@ the name of a static variable or option.</error>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>.
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5191,12 +5302,31 @@ the name of a static variable or option.</error>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">values</tag></term>
+<listitem>
+<para>A list of acceptable values may be specified in the <tag
+class="attribute">values</tag> attribute. If specified, the value
+of the <tag class="attribute">values</tag> attribute
+<rfc2119>must</rfc2119> be a list of atomic values expressed as an XPath sequence,
+for example: <code>('one', 'two', 'three')</code>.
+<error code="S0101">It is a <glossterm>static error</glossterm> if the
+values list is not an XPath sequence of atomic values.</error>
+</para>
+<para>The values list is an additional constraint on the acceptable values
+for the option. The option value must satisfy the <tag class="attribute">as</tag>
+type, if one is provided, and must be equal to (XPath “<code>eq</code>”) one of the listed
+<tag class="attribute">values</tag>.
+It is possible to combine <tag class="attribute">as</tag> and
+<tag class="attribute">values</tag> in ways that exclude all
+actual values (for example, <code>as="xs:integer"</code> and
+<code>values="(1.5,’pi’)"</code>). Doing so will make it impossible
+to specify a value for the option.</para>
 </listitem>
 </varlistentry>
 <varlistentry><term><tag class="attribute">static</tag></term>
@@ -5323,11 +5453,9 @@ name as part of the same step invocation.</error></para>
 </varlistentry>
 <varlistentry><term><tag class="attribute">as</tag></term>
 <listitem>
-<para>The type of the value may be specified in the <tag
-class="attribute">as</tag> attribute using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-See <xref linkend="varopt-types"/>
+<para>The type of the value may be specified in the
+<tag class="attribute">as</tag> attribute using an
+XProc sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5482,119 +5610,9 @@ specify a value for an option that is declared static.</error>
       and extension atomic steps.</para>
   </section>
 </section>
-
-<section xml:id="statics">
-<title>Static Options and Variables</title>
-
-<para>A <tag>p:option</tag> or <tag>p:variable</tag> that is a
-<emphasis>direct child</emphasis> of <tag>p:declare-step</tag> may be
-declared “static”. Options and variables that are the direct
-children of <tag>p:library</tag> <rfc2119>must</rfc2119> be declared
-static.</para>
-
-<para>The values of static options and variables are computed during
-<link linkend="initiating">static analysis</link>.</para>
-</section>
-
-<section xml:id="varopt-types">
-<title>Variable and option types</title>
-
-<para>Variables and options may declare that they have a sequence type.
-<error code="S0096">It is a <glossterm>static error</glossterm> if
-the sequence type is not syntactically valid.</error></para>
-
-<para>If a variable or option declares a type, the supplied value 
- of the variable or option is converted to the required type, 
- using the function conversion rules specified by XPath 3.1.
- <error code="D0036">It is a <glossterm>dynamic error</glossterm> if 
- the supplied value of a variable or option cannot be converted 
- to the required type.</error></para>
-
-<para> If no sequence type is specified explicitly, <literal>item()*</literal> 
-is assumed as default type.</para>
-
- <para>If the sequence type is a map with <type>xs:QName</type> keys
-(<type>map(xs:QName, ...)</type>), the
-<function>p:force-qname-keys</function> function is automatically applied to
-the value. This makes it possible to pass in maps using (easier to
-write) <type>xs:string</type> type keys that are converted
-automatically into the required <type>xs:QName</type> keys.</para>
 </section>
 
 <!-- ============================================================ -->
-
-<section xml:id="opt-bindings"><title>Namespaces on variables and options</title>
-
-<para>Variable and option values carry with them not only
-their literal or computed string value but also a set of namespaces.
-To see why this is necessary, consider the following
-step:</para><programlisting language="xml"><xi:include
-href="../../../build/examples/opns-1.txt" parse="text"/></programlisting><para>The
-<tag>p:delete</tag> step will delete elements that match the
-expression “<literal>html:div</literal>”, but that expression can only
-be correctly interpreted if there's a namespace binding for the prefix
-“<literal>html</literal>” so that binding has to travel with the
-option.</para>
-
-<para>The default namespace bindings associated with a variable or
-option value are computed as follows:</para><orderedlist>
-
-<listitem>
-<para>If the <tag class="attribute">select</tag> attribute was used to
-specify the value and it consisted of a single
-<literal>VariableReference</literal> (per <biblioref
-linkend="xpath31"/>), then the namespace bindings from the referenced
-option or variable are used.</para>
-</listitem>
-          <listitem>
-            <para>If the <tag class="attribute">select</tag> attribute was used to specify the value
-              and it evaluated to a node-set, then the in-scope namespaces from the first node in
-              the selected node-set (or, if it's not an element, its parent) are used.</para>
-            <para>The expression is evaluated in the appropriate context, See <xref
-                linkend="xpath-context"/>.</para>
-          </listitem>
-          <listitem>
-            <para>Otherwise, the in-scope namespaces from the element providing the value are used.
-              (For options specified using <link linkend="option-shortcut">syntactic
-                shortcuts</link>, the step element itself is providing the value.)</para>
-          </listitem>
-        </orderedlist><para>The default namespace is never included in the namespace bindings for a
-          variable or option value. Unqualified names are always in
-          no-namespace.</para>
-<para>Unfortunately, in more complex situations, there may be no
-          single variable or option that can reliably be expected to have the correct set
-          of namespace bindings. Consider this
-          pipeline:</para><programlisting language="xml"><xi:include href="../../../build/examples/opns-2.txt" parse="text"/></programlisting><para>It
-          defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements that
-          occur inside of XHTML div elements. It might be used as
-          follows:</para>
-
-<programlisting language="xml"><xi:include href="../../../build/examples/opns-3.txt" parse="text"/></programlisting>
-
-<para>In this case, the <varname>match</varname> option passed to the
-<tag>p:delete</tag> step needs <emphasis>both</emphasis> the namespace
-binding of “<literal>h</literal>” specified in the
-<tag>ex:delete-in-div</tag> pipeline definition
-<emphasis>and</emphasis> the namespace binding of
-“<literal>html</literal>” specified in the <varname>divchild</varname>
-option on the call of that pipeline. It's not sufficient to provide
-just one of the sets of bindings.</para>
-
-<para>If pipeline authors cannot arrange for all of the necessary namespace
-bindings to be in scope, then EQNames can be used to remove the dependency
-on namespace bindings:</para>
-
-<programlisting language="xml"><xi:include href="../../../build/examples/opns-4.txt" parse="text"/></programlisting>
-
-<para>In this example, the expression will match “<literal>p</literal>”
-elements in the XHTML namespace irrespective of any bindings that may or may
-not be in scope.</para>
-  
-  
-
-</section>
-    </section>
-    <!-- ============================================================ -->
 
 <section xml:id="p.declare-step">
 <title>p:declare-step</title>


### PR DESCRIPTION
(This is #637 refactored per the editor's call on 15 Nov)

Fix #534
Fix #613

Support new values attribute for enumerating values. Identify special parsing rules that apply to variables and options of type `xs:QName`.

Updates step signatures to make optional options have a type that would allow empty sequence.

Tweaked schemas and tools as necessary.