### PR TITLE
Fix 645: Remove @name on p:when/p:otherwise

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -596,7 +596,6 @@ Choose =
 ]
 When =
    element when {
-   	  name.ncname.attr?,
       attribute test { XPathExpression },
       [ sa:avt = "true" ]
          collection.attr?,
@@ -613,8 +612,7 @@ When =
 ]
 Otherwise =
    element otherwise {
-    	name.ncname.attr?,
-      common.attributes,
+    	common.attributes,
       global.attributes,
       ((Output|Documentation|PipeInfo)*, Subpipeline)
    }


### PR DESCRIPTION
Fix #645 by removing @name from p:when/p:otherwise