### PR TITLE
Fix 648

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3992,10 +3992,6 @@ not. Each output of the <tag>p:choose</tag> is declared to produce a
 sequence if that output is declared to produce a sequence in any of
 its subpipelines.</para>
 
-<para><error code="D0004">It is a <glossterm>dynamic
-error</glossterm> if no <glossterm>subpipeline</glossterm> is selected
-by the <tag>p:choose</tag> and no default is provided.</error></para>
-
 <para>The <tag>p:choose</tag> can specify the context node against
 which the XPath expressions that occur on each branch are evaluated.
 The context node is specified as a <glossterm>connection</glossterm>


### PR DESCRIPTION
Attempt to fix #648 Since p:otherwise was already optional in the syntax box, simply removing error XD0004 solves this problem.