### PR TITLE
Fixing copy and paste problem

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4012,8 +4012,8 @@ not. Each output of the <tag>p:choose</tag> is declared to produce a
 sequence if that output is declared to produce a sequence in any of
 its subpipelines.
 Similarly, the content types that can appear on the port are the union
-of the content types that might be produced by the initial subpipeline and
-any of the recovery subpipelines.
+of the content types that might be produced by any of the <tag>p:when</tag> 
+or the <tag>p:otherwise</tag>.
 </para>
 
 <para>The <tag>p:choose</tag> can specify the context node against


### PR DESCRIPTION
Fixed a copy and paste problem in p:choose because a p:choose does not have an initial subpipeline and no recovery subpipelines.