### PR TITLE
Attempt to fix issue 670

### DIFF
--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -73,15 +73,9 @@ If the input document is an XML representation of JSON as defined in
 <biblioref linkend="xpath31-functions"/>,
 implementations <rfc2119>must</rfc2119> use <function>fn:xml-to-json</function>
 by default. If the input document has a <tag>c:param-set</tag> document element,
-a map <rfc2119>must</rfc2119> be returned, that represents the document's 
-<tag>c:param</tag> elements. All other nodes are ignored. <error code="D0037">It is 
-a <glossterm>dynamic error</glossterm> if any of the <tag>c:param</tag> 
-elements are invalid.</error>
+a map <rfc2119>must</rfc2119> be returned that represents the document's 
+<tag>c:param</tag> elements.
 </para>
-   <note xml:id="ednote-what-is-valid" role="editorial">
-      <title>Editorial Note</title>
-      <para>Must tie down what “valid” means wrt the c:param element.</para>
-   </note>
 </listitem>
 
 <listitem xml:id="c.data">

--- a/steps/src/main/xml/steps/cast-content-type.xml
+++ b/steps/src/main/xml/steps/cast-content-type.xml
@@ -71,9 +71,17 @@ XML into JSON. <impl>The precise nature of the conversion from XML to JSON
 is <glossterm>implementation-defined</glossterm>.</impl>
 If the input document is an XML representation of JSON as defined in
 <biblioref linkend="xpath31-functions"/>,
-implementations <rfc2119>should</rfc2119> use <function>fn:xml-to-json</function>
-by default.
+implementations <rfc2119>must</rfc2119> use <function>fn:xml-to-json</function>
+by default. If the input document has a <tag>c:param-set</tag> document element,
+a map <rfc2119>must</rfc2119> be returned, that represents the document's 
+<tag>c:param</tag> elements. All other nodes are ignored. <error code="D0037">It is 
+a <glossterm>dynamic error</glossterm> if any of the <tag>c:param</tag> 
+elements are invalid.</error>
 </para>
+   <note xml:id="ednote-what-is-valid" role="editorial">
+      <title>Editorial Note</title>
+      <para>Must tie down what “valid” means wrt the c:param element.</para>
+   </note>
 </listitem>
 
 <listitem xml:id="c.data">

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1957,48 +1957,6 @@ specified.</para>
 normally during static analysis.</para>
 </section>
 
-<section xml:id="f.make-map">
-<title>Make Map</title>
-
-<para>XProc uses maps to pass parameters to steps. Sometimes
-it is convenient to represent these maps as XML documents. This function
-reads such an XML document and produces a map.</para>
-
-<methodsynopsis>
-<type>map(xs:QName,item())</type>
-<methodname>p:make-map</methodname>
-<methodparam><type>item()</type><parameter>param-set</parameter></methodparam>
-</methodsynopsis>
-
-<para>The map returned contains (exclusively) the parameters that are
-represented by the <parameter>param-set</parameter> item.</para>
-
-<para>The <parameter>param-set</parameter> provided
-<rfc2119>must</rfc2119> be a <tag>c:param-set</tag> element or a
-document. If it is a document, <tag>c:param-set</tag>
-<rfc2119>must</rfc2119> be the document element.
-<error code="D0035">It is a <glossterm>dynamic error</glossterm>
-if the element (or document element) passed to
-<function>p:make-map</function> is not a <tag>c:param-set</tag>
-element.</error></para>
-
-<para>Only <tag>c:param</tag> children of the <tag>c:param-set</tag>
-element are considered, all other nodes are ignored. The parameters
-represented by those <tag>c:param</tag> children
-are added to the map that is returned.
-<error code="D0037">It is a <glossterm>dynamic error</glossterm>
-if any of the <tag>c:param</tag> elements are invalid.</error>
-</para>
-
-<note xml:id="ednote-what-is-valid" role="editorial">
-<title>Editorial Note</title>
-<para>Must tie down what “valid” means wrt the c:param element.</para>
-</note>
-
-<para>The <function>p:make-map</function> function behaves
-normally during static analysis.</para>
-</section>
-
 <section xml:id="f.document-properties">
 <title>Document properties</title>
 


### PR DESCRIPTION
#670

- Removed function "p:make-map()"
- Added conversion from c:param-set to map to p:cast-content-type (XML -> JSON section)
- Made use of fn:xml-to-json required (I think this represents our current consensus, doesn't it?)
- Removed editorial note
- Removed error XD0037 because all possible errors are covered in the section on `c:param-set`, so the additional error is not necessary.