### PR TITLE
Attempt to fix 671

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4031,9 +4031,7 @@ outputs not declared in the subpipline actually selected.</para>
 <para>As a convenience to authors, it is not an error if some
 subpipelines declare outputs that can produce sequences and some do
 not. Each output of the <tag>p:choose</tag> is declared to produce a
-sequence if that output is declared to produce a sequence in any of
-its subpipelines.
-Similarly, the content types that can appear on the port are the union
+sequence. The content types that can appear on the port are the union
 of the content types that might be produced by any of the <tag>p:when</tag> 
 or the <tag>p:otherwise</tag>.
 </para>
@@ -4214,11 +4212,9 @@ returned.</para>
 <para>As a convenience to authors, it is not an error if an output
 port can produce a sequence in the initial subpipeline but not in the
 recovery subpipeline, or vice versa. Each output of the
-<tag>p:try</tag> is declared to produce a sequence if that output is
-declared to produce a sequence in either of its subpipelines.
-Similarly, the content types that can appear on the port are the union
-of the content types that might be produced by the initial subpipeline and
-any of the recovery subpipelines.
+<tag>p:try</tag> is declared to produce a sequence. The content types 
+that can appear on the port are the union of the content types that 
+might be produced by the initial subpipeline and any of the recovery subpipelines.
 </para>
 
 <para>A pipeline author can cause an error to occur with the


### PR DESCRIPTION
Fixing issue #671 by stating, that any output port of p:try/p:choose is a sequence port.

close #671 