### PR TITLE
Restructuring of variables and options section

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -2468,289 +2468,208 @@ expression such that it returns the string values:</para>
 </section>
 </section>
 
-<section xml:id="options">
-<title>Options</title>
+  <section xml:id="variables-options-background">
+    <title>Variables and Options</title>
 
-<para>Some steps accept options. Options are name/value pairs. The value
-of an option is the default value specified in its declaration, or
-a value provided by the caller of the step (overriding the default).
-If it has neither a default value nor a provided value, its value is
-the empty sequence.</para>
+    <section xml:id="variables">
+      <title>Variables</title>
 
-<para><termdef xml:id="dt-option">An <firstterm>option</firstterm> is
-a name/value pair. The name <rfc2119>must</rfc2119> be an <link
-xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
-name</link>. The value may be any XPath data model value.</termdef>
-Option names are always expressed as literal values, pipelines cannot
-construct option names dynamically. </para>
+      <para>Variables are name/value pairs. Pipeline authors can create variables to hold computed values.</para>
 
-<para><impl>How outside values are specified for pipeline options on
-the pipeline initially invoked by the processor is
-<glossterm>implementation-defined</glossterm>.</impl> In other words,
-the command line options, APIs, or other mechanisms available to
-specify such options values are outside the scope of this
-specification.</para>
-
-<para>Some steps require a set of name/value pairs for the operations
-they perform. For example, an XSLT stylesheet might have required
-parameters or an XQuery query might have external variables.
-In the XProc Step Library, the standard way to pass such values to
-the step is to use an option named “<literal>parameters</literal>”
-whose value is a map.</para>
-</section>
-
-<section xml:id="variables">
-<title>Variables</title>
-
-<para>Variables are name/value pairs. Pipeline authors can create
-variables to hold computed values.</para>
-
-<para><termdef xml:id="dt-variable">A <firstterm>variable</firstterm>
-is a name/value pair. The name <rfc2119>must</rfc2119> be an <link
-xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
-name</link>. The value may be any XPath data model value.</termdef>
-</para>
-
-<para>The names of variables and options are not distinct and are lexically
-scoped. <termdef xml:id="dt-shadow">We say that a variable
-<firstterm baseform="shadow">shadows</firstterm> another variable
-(or option) if it has the same name and appears later in the same lexical
-scope.</termdef></para>
-
-<para>Consider this pipeline:</para>
-
-<programlisting language="xml"><xi:include href="../../../build/examples/shadow.txt" parse="text"/></programlisting>
-
-<para>If no overriding value is provided for <varname>$bname</varname> at runtime,
-the pipeline will produce three messages: “NAME1=1”, “NAME2=2”, and “NAME3=7”.
-(If an overriding value is provided at runtime, “NAME1” will have that value,
-“NAME2” will have one more than that value, and “NAME3” will have the value 7.
-</para>
-
-<section xml:id="statics">
-<title>Static Options and Variables</title>
-
-<para>A <tag>p:option</tag> or <tag>p:variable</tag> that is a
-<emphasis>direct child</emphasis> of <tag>p:declare-step</tag> may be
-declared “static”. Options and variables that are the direct
-children of <tag>p:library</tag> <rfc2119>must</rfc2119> be declared
-static.</para>
-
-<para>The values of static options and variables are computed during
-<link linkend="initiating">static analysis</link>.</para>
-</section>
-
-<section xml:id="varopt-types">
-<title>Variable and option types</title>
-
-<para>Variables and options may declare that they have a type using the
-<tag class="attribute">as</tag> attribute. The attribute value <rfc2119>must</rfc2119>
-be an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-<error code="S0096">It is a <glossterm>static
-error</glossterm> if the sequence type is not syntactically
-valid.</error> The sequence type <literal>item()*</literal> is assumed if
-no explicit type is provided.
-</para>
-
-<para>If a variable or option declares a type, the supplied value 
- of the variable or option is converted to the required type, 
- using the function conversion rules specified by XPath 3.1.
- <error code="D0036">It is a <glossterm>dynamic error</glossterm> if 
- the supplied value of a variable or option cannot be converted 
- to the required type.</error></para>
-
-<para>Some steps have options whose values are QNames, for example
-“<tag class="attribute">attribute-name</tag>” on
-<tag>p:add-attribute</tag>. If the type
-<type>xs:QName</type> was strictly enforced, they would be tedious to specify. As a
-convenience for pipeline authors, the values of variables or options
-declared with the type <type>xs:QName</type> are processed specially.
-The type <type>xs:QName</type> is treated as <type>xs:anyAtomicType</type> for the purpose
-of atomization. The value (or values) are converted to <type>xs:QName</type>s:</para>
-
-<orderedlist>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:QName</type> then that value is used.
-</para>
-</listitem>
-<listitem>
-<para>If the value supplied for the option is an instance of
-<type>xs:string</type> (or a type derived from
-<type>xs:string</type>), the QName is constructed by following the
-<link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
-production rules</link> in <biblioref linkend="xpath31"/>. That is, it
-can be written as a local-name only, as a prefix plus local-name, or as
-a URI qualified name (using the <code>Q{namespace}local-name</code> syntax).
-<error code="D0061">It is a 
-<glossterm>dynamic error</glossterm> if the string value is not syntactically an
-EQName.</error>
-<error code="D0069">It is a 
-<glossterm>dynamic error</glossterm> if the string value contains a colon and
-the designated prefix is not declared in the in-scope namespaces.</error>
-</para>
-</listitem>
-<listitem>
-<para><error code="D0068">It is a <glossterm>dynamic error</glossterm>
-if the supplied value is neither an instance of <type>xs:QName</type>
-nor an instance of <type>xs:string</type>.</error>
-</para>
-</listitem>
-</orderedlist> 
-
-<!--
-<para>Steps with a QName-valued option also often provide two
-additional attributes to separately identify a prefix and a namespace URI.
-Although their names vary from step to step, in this section
-they’re identified as the <code>qname-value</code>,
-<code>prefix-value</code>, and <code>namespace-value</code>
-attributes. The rules described here apply regardless of their actual
-names.</para>
-
-<para>When <code>prefix-value</code> and <code>namespace-value</code>
-attributes are available, several additional co-constraints apply:</para>
-
-<orderedlist>
-<listitem>
-<para>If the supplied value of the name is an <code>xs:QName</code>, you may not specify
-the <code>prefix-value</code> or <code>namespace-value</code>.
-<error code="D0066">It is a <glossterm>dynamic error</glossterm>
-to separately specify a prefix or namespace URI if the supplied value
-has the type <code>xs:QName</code>.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the string value of the <code>qname-value</code> attribute
-contains a colon, you may not specify a <code>prefix-value</code> or
-<code>namespace-value</code>.
-<error code="D0034">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix or namespace URI if the QName value contains a colon.</error>
-</para>
-</listitem>
-<listitem>
-<para>If you specify a <code>prefix-value</code>, you must also specify
-a namespace (either with the <code>namespace-value</code> or through a
-URI qualified name).
-<error code="D0070">It is a <glossterm>dynamic error</glossterm>
-to specify a prefix without also specifying a namespace URI.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the specified value is of type <code>xs:QName</code> or is
-a URI qualified name, you may not specify a <code>namespace-value</code>.
-<error code="D0067">It is a <glossterm>dynamic error</glossterm>
-to separately specify a namespace URI if the value is a URI qualified name.</error>
-</para>
-</listitem>
-</orderedlist>
--->
-
-<para>As an additional convenience, if the specified sequence type of an option
-or a variable is a map with <type>xs:QName</type> keys
-(<type>map(xs:QName, …)</type>), the supplied map value is processed specially.
-This makes it possible to pass in maps using (easier to write) <type>xs:string</type> 
-type keys that are converted automatically into the required <type>xs:QName</type>
-keys in a manner analogous to <type>#QName</type> values.</para>
-<para>Every key/value pair in a map supplied to a variable or an option with sequence
-type <type>map(xs:QName, …)</type> is processed as follows:</para>
-  <itemizedlist>
-    <listitem>
-      <para>If the entry's key is of type <type>xs:QName</type>, the entry
-        is left unchanged.</para>
-    </listitem>
-    <listitem>
-      <para>If the entry's key is an instance of type <type>xs:string</type> 
-        (or a type derived from <type>xs:string</type>) it is
-        transformed into an <type>xs:Qname</type> using the <link
-          xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName"
-          >XPath EQName production rules</link>. That is, it can be written
-        as a local-name only, as a prefix plus local-name or as a URI plus
-        local-name (using the <code>Q{}</code> syntax).</para>
       <para>
-        <error code="D0061">It is a <glossterm>dynamic error</glossterm>
-          if <code>$key</code> is of type <type>xs:string</type> and cannot be converted into a <type>xs:Qname</type>.</error>
+        <termdef xml:id="dt-variable">A <firstterm>variable</firstterm> is a name/value pair. The name
+            <rfc2119>must</rfc2119> be an <link xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
+            name</link>. The value may be any XPath data model value.</termdef>
       </para>
-    </listitem>
-    <listitem>
-      <para>If the entry's key is of any other type, the entry is ignored
-        and will be removed from the map.</para>
-    </listitem>
-  </itemizedlist>
-</section>
 
-<!-- ============================================================ -->
+      <para>The names of variables and options are not distinct and are lexically scoped. <termdef xml:id="dt-shadow">We
+          say that a variable <firstterm baseform="shadow">shadows</firstterm> another variable (or option) if it has
+          the same name and appears later in the same lexical scope.</termdef></para>
 
-<section xml:id="opt-bindings"><title>Namespaces on variables and options</title>
+      <para>Consider this pipeline:</para>
 
-<para>Variable and option values carry with them not only
-their literal or computed string value but also a set of namespaces.
-To see why this is necessary, consider the following
-step:</para><programlisting language="xml"><xi:include
-href="../../../build/examples/opns-1.txt" parse="text"/></programlisting><para>The
-<tag>p:delete</tag> step will delete elements that match the
-expression “<literal>html:div</literal>”, but that expression can only
-be correctly interpreted if there's a namespace binding for the prefix
-“<literal>html</literal>” so that binding has to travel with the
-option.</para>
+      <programlisting language="xml"><xi:include href="../../../build/examples/shadow.txt" parse="text"/></programlisting>
 
-<para>The default namespace bindings associated with a variable or
-option value are computed as follows:</para><orderedlist>
+      <para>If no overriding value is provided for <varname>$bname</varname> at runtime, the pipeline will produce three
+        messages: “NAME1=1”, “NAME2=2”, and “NAME3=7”. (If an overriding value is provided at runtime, “NAME1” will have
+        that value, “NAME2” will have one more than that value, and “NAME3” will have the value 7. </para>
 
-<listitem>
-<para>If the <tag class="attribute">select</tag> attribute was used to
-specify the value and it consisted of a single
-<literal>VariableReference</literal> (per <biblioref
-linkend="xpath31"/>), then the namespace bindings from the referenced
-option or variable are used.</para>
-</listitem>
-          <listitem>
-            <para>If the <tag class="attribute">select</tag> attribute was used to specify the value
-              and it evaluated to a node-set, then the in-scope namespaces from the first node in
-              the selected node-set (or, if it's not an element, its parent) are used.</para>
-            <para>The expression is evaluated in the appropriate context, See <xref
-                linkend="xpath-context"/>.</para>
-          </listitem>
-          <listitem>
-            <para>Otherwise, the in-scope namespaces from the element providing the value are used.
-              (For options specified using <link linkend="option-shortcut">syntactic
-                shortcuts</link>, the step element itself is providing the value.)</para>
-          </listitem>
-        </orderedlist><para>The default namespace is never included in the namespace bindings for a
-          variable or option value. Unqualified names are always in
-          no-namespace.</para>
-<para>Unfortunately, in more complex situations, there may be no
-          single variable or option that can reliably be expected to have the correct set
-          of namespace bindings. Consider this
-          pipeline:</para><programlisting language="xml"><xi:include href="../../../build/examples/opns-2.txt" parse="text"/></programlisting><para>It
-          defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements that
-          occur inside of XHTML div elements. It might be used as
-          follows:</para>
+    </section>
 
-<programlisting language="xml"><xi:include href="../../../build/examples/opns-3.txt" parse="text"/></programlisting>
+    <section xml:id="options">
+      <title>Options</title>
 
-<para>In this case, the <varname>match</varname> option passed to the
-<tag>p:delete</tag> step needs <emphasis>both</emphasis> the namespace
-binding of “<literal>h</literal>” specified in the
-<tag>ex:delete-in-div</tag> pipeline definition
-<emphasis>and</emphasis> the namespace binding of
-“<literal>html</literal>” specified in the <varname>divchild</varname>
-option on the call of that pipeline. It's not sufficient to provide
-just one of the sets of bindings.</para>
+      <para>Some steps accept options. Options are name/value pairs. The value of an option is the default value
+        specified in its declaration, or a value provided by the caller of the step (overriding the default). If it has
+        neither a default value nor a provided value, its value is the empty sequence.</para>
 
-<para>If pipeline authors cannot arrange for all of the necessary namespace
-bindings to be in scope, then EQNames can be used to remove the dependency
-on namespace bindings:</para>
+      <para><termdef xml:id="dt-option">An <firstterm>option</firstterm> is a name/value pair. The name
+            <rfc2119>must</rfc2119> be an <link xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
+            name</link>. The value may be any XPath data model value.</termdef> Option names are always expressed as
+        literal values, pipelines cannot construct option names dynamically. </para>
 
-<programlisting language="xml"><xi:include href="../../../build/examples/opns-4.txt" parse="text"/></programlisting>
+      <para><impl>How outside values are specified for pipeline options on the pipeline initially invoked by the
+          processor is <glossterm>implementation-defined</glossterm>.</impl> In other words, the command line options,
+        APIs, or other mechanisms available to specify such options values are outside the scope of this
+        specification.</para>
 
-<para>In this example, the expression will match “<literal>p</literal>”
-elements in the XHTML namespace irrespective of any bindings that may or may
-not be in scope.</para>
+      <para>Some steps require a set of name/value pairs for the operations they perform. For example, an XSLT
+        stylesheet might have required parameters or an XQuery query might have external variables. In the XProc Step
+        Library, the standard way to pass such values to the step is to use an option named
+          “<literal>parameters</literal>” whose value is a map.</para>
+    </section>
 
-</section>
-</section>
+    <section xml:id="statics">
+      <title>Static Options and Variables</title>
+
+      <para>Any <tag>p:variable</tag> that is part of the prologue of a step (as a direct child of
+          <tag>p:declare-step</tag> declared before the start of the sub-pipeline) <rfc2119>must</rfc2119> be declared
+        “static”. Any <tag>p:variable</tag> that is part of the sub-pipeline of a step <rfc2119>must not</rfc2119> be
+        declared “static”.</para>
+      <para>A <tag>p:option</tag> may be declared “static”. </para>
+      <para>Options and variables that are the direct children of <tag>p:library</tag>
+        <rfc2119>must</rfc2119> be declared static.</para>
+
+      <para>The values of static options and variables are computed during <link linkend="initiating">static
+          analysis</link>.</para>
+    </section>
+
+    <section xml:id="varopt-types">
+      <title>Variable and option types</title>
+
+      <para>Variables and options may declare that they have a type using the <tag class="attribute">as</tag> attribute.
+        The attribute value <rfc2119>must</rfc2119> be an <biblioref linkend="xpath31"/>
+        <link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>. <error code="S0096">It
+          is a <glossterm>static error</glossterm> if the sequence type is not syntactically valid.</error> The sequence
+        type <literal>item()*</literal> is assumed if no explicit type is provided. </para>
+
+      <para>If a variable or option declares a type, the supplied value of the variable or option is converted to the
+        required type, using the function conversion rules specified by XPath 3.1. <error code="D0036">It is a
+            <glossterm>dynamic error</glossterm> if the supplied value of a variable or option cannot be converted to
+          the required type.</error></para>
+      
+    </section>
+    
+    <section xml:id="qname-handling">
+      <title>QName handling</title>
+      
+      <para>Some steps have options whose values are QNames, for example “<tag class="attribute">attribute-name</tag>”
+        on <tag>p:add-attribute</tag>. If the type <type>xs:QName</type> was strictly enforced, they would be tedious to
+        specify. As a convenience for pipeline authors, the values of variables or options declared with the type
+        <type>xs:QName</type> are processed specially. The type <type>xs:QName</type> is treated as
+        <type>xs:anyAtomicType</type> for the purpose of atomization. The value (or values) are converted to
+        <type>xs:QName</type>s:</para>
+      
+      <orderedlist>
+        <listitem>
+          <para>If the value supplied for the option is an instance of <type>xs:QName</type> then that value is used.
+          </para>
+        </listitem>
+        <listitem>
+          <para>If the value supplied for the option is an instance of <type>xs:string</type> (or a type derived from
+            <type>xs:string</type>), the QName is constructed by following the <link
+              xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName production rules</link> in
+            <biblioref linkend="xpath31"/>. That is, it can be written as a local-name only, as a prefix plus
+            local-name, or as a URI qualified name (using the <code>Q{namespace}local-name</code> syntax). <error
+              code="D0061">It is a <glossterm>dynamic error</glossterm> if the string value is not syntactically an
+              EQName.</error>
+            <error code="D0069">It is a <glossterm>dynamic error</glossterm> if the string value contains a colon and
+              the designated prefix is not declared in the in-scope namespaces.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <error code="D0068">It is a <glossterm>dynamic error</glossterm> if the supplied value is neither an
+              instance of <type>xs:QName</type> nor an instance of <type>xs:string</type>.</error>
+          </para>
+        </listitem>
+      </orderedlist>
+      
+      <para>As an additional convenience, if the specified sequence type of an option or a variable is a map with
+        <type>xs:QName</type> keys (<type>map(xs:QName, …)</type>), the supplied map value is processed specially.
+        This makes it possible to pass in maps using (easier to write) <type>xs:string</type> type keys that are
+        converted automatically into the required <type>xs:QName</type> keys in a manner analogous to
+        <type>#QName</type> values.</para>
+      <para>Every key/value pair in a map supplied to a variable or an option with sequence type <type>map(xs:QName,
+        …)</type> is processed as follows:</para>
+      <itemizedlist>
+        <listitem>
+          <para>If the entry's key is of type <type>xs:QName</type>, the entry is left unchanged.</para>
+        </listitem>
+        <listitem>
+          <para>If the entry's key is an instance of type <type>xs:string</type> (or a type derived from
+            <type>xs:string</type>) it is transformed into an <type>xs:Qname</type> using the <link
+              xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">XPath EQName production rules</link>. That
+            is, it can be written as a local-name only, as a prefix plus local-name or as a URI plus local-name (using
+            the <code>Q{}</code> syntax).</para>
+          <para>
+            <error code="D0061">It is a <glossterm>dynamic error</glossterm> if the entry's key is of type
+              <type>xs:string</type> and cannot be converted into a <type>xs:Qname</type>.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>If the entry's key is of any other type, the entry is ignored and will be removed from the map.</para>
+        </listitem>
+      </itemizedlist>
+    </section>
+
+    <section xml:id="opt-bindings">
+      <title>Namespaces on variables and options</title>
+
+      <para>Variable and option values carry with them not only their literal or computed string value but also a set of
+        namespaces. To see why this is necessary, consider the following step:</para>
+      <programlisting language="xml"><xi:include href="../../../build/examples/opns-1.txt" parse="text"/></programlisting>
+      <para>The <tag>p:delete</tag> step will delete elements that match the expression “<literal>html:div</literal>”,
+        but that expression can only be correctly interpreted if there's a namespace binding for the prefix
+          “<literal>html</literal>” so that binding has to travel with the option.</para>
+
+      <para>The default namespace bindings associated with a variable or option value are computed as follows:</para>
+      <orderedlist>
+
+        <listitem>
+          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value and it consisted of a
+            single <literal>VariableReference</literal> (per <biblioref linkend="xpath31"/>), then the namespace
+            bindings from the referenced option or variable are used.</para>
+        </listitem>
+        <listitem>
+          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value and it evaluated to a
+            node-set, then the in-scope namespaces from the first node in the selected node-set (or, if it's not an
+            element, its parent) are used.</para>
+          <para>The expression is evaluated in the appropriate context, See <xref linkend="xpath-context"/>.</para>
+        </listitem>
+        <listitem>
+          <para>Otherwise, the in-scope namespaces from the element providing the value are used. (For options specified
+            using <link linkend="option-shortcut">syntactic shortcuts</link>, the step element itself is providing the
+            value.)</para>
+        </listitem>
+      </orderedlist>
+      <para>The default namespace is never included in the namespace bindings for a variable or option value.
+        Unqualified names are always in no-namespace.</para>
+      <para>Unfortunately, in more complex situations, there may be no single variable or option that can reliably be
+        expected to have the correct set of namespace bindings. Consider this pipeline:</para>
+      <programlisting language="xml"><xi:include href="../../../build/examples/opns-2.txt" parse="text"/></programlisting>
+      <para>It defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements that occur inside of
+        XHTML div elements. It might be used as follows:</para>
+
+      <programlisting language="xml"><xi:include href="../../../build/examples/opns-3.txt" parse="text"/></programlisting>
+
+      <para>In this case, the <varname>match</varname> option passed to the <tag>p:delete</tag> step needs
+          <emphasis>both</emphasis> the namespace binding of “<literal>h</literal>” specified in the
+          <tag>ex:delete-in-div</tag> pipeline definition <emphasis>and</emphasis> the namespace binding of
+          “<literal>html</literal>” specified in the <varname>divchild</varname> option on the call of that pipeline.
+        It's not sufficient to provide just one of the sets of bindings.</para>
+
+      <para>If pipeline authors cannot arrange for all of the necessary namespace bindings to be in scope, then EQNames
+        can be used to remove the dependency on namespace bindings:</para>
+
+      <programlisting language="xml"><xi:include href="../../../build/examples/opns-4.txt" parse="text"/></programlisting>
+
+      <para>In this example, the expression will match “<literal>p</literal>” elements in the XHTML namespace
+        irrespective of any bindings that may or may not be in scope.</para>
+
+    </section>
+
+  </section>
 
     <section xml:id="security-considerations">
       <title>Security Considerations</title>


### PR DESCRIPTION
Based on #673 I did some editing on the variables and options section to make it more consistent and logical. Mostly changes on the section structure.

- The QName handling section is still part of the options and variables overarching section. @xml-project suggested it should be taken out and become a section of its own. I suggest we leave it here for now, taking it out is now easy if we decide to.
- I also edited the section on static variables and options which I think was incorrect. 