### PR TITLE
Static errors are, uh, static

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1083,6 +1083,9 @@ See <xref linkend="external-docs"/> for further discussion.</para>
 <para>The results of XProc extension functions may differ during static analysis,
 as described in the description of each function.</para>
 
+<para>Any errors that occur while evaluating expressions during static analysis will
+be raised statically.</para>
+
 </section>
 
 <section xml:id="dynamic-evaluation">


### PR DESCRIPTION
Fix #542 

I compared what we say to the list that @xml-project outlined in the issue and I didn't see anything new. I did add a sentence to that section to clarify that they are raised statically.

Is there more to do?
