### PR TITLE
Address two extant FIXME: comments in the spec

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -225,7 +225,7 @@ ImportFunctions =
       global.attributes,
       href.attr,
       content-type.attr?,
-      attribute namespace { xsd:anyURI }?,
+      attribute namespace { xsd:anyURI+ }?,
       (Documentation|PipeInfo)*
    }
 

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -224,6 +224,8 @@ ImportFunctions =
       common.attributes,
       global.attributes,
       href.attr,
+      content-type.attr?,
+      attribute namespace { xsd:anyURI }?,
       (Documentation|PipeInfo)*
    }
 

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -245,6 +245,14 @@
 	<xsl:when test="rng:data">
 	  <xsl:apply-templates/>
 	</xsl:when>
+	<xsl:when test="rng:oneOrMore/rng:data">
+	  <xsl:apply-templates/>
+          <xsl:text>+</xsl:text>
+	</xsl:when>
+	<xsl:when test="rng:zeroOrMore/rng:data">
+	  <xsl:apply-templates/>
+          <xsl:text>*</xsl:text>
+	</xsl:when>
 	<xsl:when test="rng:ref">
 	  <xsl:variable name="pattern" select="rng:ref/@name"/>
 	  <xsl:variable name="rngpat" select="$schema/rng:grammar/rng:define[@name=$pattern]"/>
@@ -291,6 +299,7 @@
 	    <xsl:text> (</xsl:text>
 	    <xsl:value-of select="ancestor::rng:element/@name"/>
 	    <xsl:text>)</xsl:text>
+            <xsl:sequence select="."/>
 	  </xsl:message>
 	</xsl:otherwise>
       </xsl:choose>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1091,7 +1091,10 @@ be raised statically.</para>
 <section xml:id="dynamic-evaluation">
 <title>Dynamic evaluation of the pipeline</title>
 
-<para>FIXME: write an introduction.</para>
+<para>Dynamic evaluation of the pipeline occurs when it begins to process documents.
+The processor evaluates any expressions necessary to provide all of the input documents
+and options required. The step processes the input documents and produces outputs which
+flow through the pipeline.</para>
 
     <section xml:id="environment">
       <title>Environment</title>
@@ -5649,9 +5652,45 @@ See also <xref linkend="handling-imports"
 
 <section xml:id="p.import-functions"><title>p:import-functions</title>
 
-<para>FIXME: T.B.D.</para>
+<para>An <tag>p:import-functions</tag> element identifies a library of externally
+defined functions to be imported into the pipeline. After the functions have been
+imported, they are available in the processor XPath context.</para>
 
 <e:rng-pattern name="ImportFunctions"/>
+
+<variablelist>
+<varlistentry><term><tag class="attribute">href</tag></term>
+<listitem><para>The <tag class="attribute">href</tag> attribute
+identifies the URI of the function library. <error code="S0103">It is
+a <glossterm>static error</glossterm> if the URI of a
+<tag>p:import-functions</tag> element cannot be retrieved or if, once
+retrieved, it points to a library that the processor cannot
+import.</error>
+</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">content-type</tag></term>
+<listitem>
+<para>The <tag class="attribute">content-type</tag> specifies what kind of library
+is expected at the URI. If the processor does not understand libraries of that type, it
+is free to raise <code>err:XS0103</code> immediately.
+</para>
+</listitem>
+</varlistentry>
+<varlistentry><term><tag class="attribute">namespace</tag></term>
+<listitem>
+<para>If a <tag class="attribute">namespace</tag> is specified, then only functions
+in that namespace will be loaded.
+</para>
+</listitem>
+</varlistentry>
+</variablelist>
+
+<para>The ability to import functions is optional. <impl>Whether or not a processor
+can import functions, and if it can, what kinds of function libraries it can import
+from is <glossterm>implementation-defined</glossterm>.</impl>
+</para>
+
 </section>
 
 <!-- ============================================================ -->

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5732,7 +5732,7 @@ but detects that the particuar library requested is somehow ill-formed
 imports, etc.).
 </para>
 
-<para>Imported functions must be unique (they must have the same name, namespace, and
+<para>Imported functions must be unique (they must not have the same name, namespace, and
 arity). <error code="S0105">It is a <glossterm>static error</glossterm> if a function
 imported from a library has the same name and arity as a function already imported.</error>
 </para>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1770,6 +1770,29 @@ return them unchanged, to silently omit them, or to raise an error. It
   </simplesect>
 </section>
 
+<section xml:id="f.function-library-importable">
+<title>Function library importable</title>
+
+<para>The <function>p:function-library-importable</function> function
+reports whether or not function libraries of a particular type can be imported.
+</para>
+
+<methodsynopsis>
+<type>xs:boolean</type>
+<methodname>p:function-library-importable</methodname>
+<methodparam><type>xs:string</type><parameter>library-type</parameter></methodparam>
+</methodsynopsis>
+
+<para>The <varname>$library-type</varname> string is interpreted as a content type.
+If the processor understands
+(<foreignphrase>i.e.</foreignphrase> if <tag>p:import-functions</tag> understands)
+how to load function libraries of that type, this function returns
+<literal>true()</literal>, otherewise it returns <literal>false()</literal>.
+</para>
+
+<para>The <function>p:function-library-importable</function> function behaves
+normally during static analysis.</para>
+</section>
 
 <section xml:id="other-xpath-extension-functions">
   <title>Other XPath Extension Functions</title>
@@ -5672,15 +5695,16 @@ import.</error>
 <varlistentry><term><tag class="attribute">content-type</tag></term>
 <listitem>
 <para>The <tag class="attribute">content-type</tag> specifies what kind of library
-is expected at the URI. If the processor does not understand libraries of that type, it
-is free to raise <code>err:XS0103</code> immediately.
+is expected at the URI. <impl>If no type is specified, the way that the processor
+determines the type of the library is <glossterm>implementation-defined</glossterm>.</impl>
 </para>
 </listitem>
 </varlistentry>
 <varlistentry><term><tag class="attribute">namespace</tag></term>
 <listitem>
-<para>If a <tag class="attribute">namespace</tag> is specified, then only functions
-in that namespace will be loaded.
+<para>If a <tag class="attribute">namespace</tag> is specified, it provides a list
+of namespace URIs. Only functions
+in those namespaces will be loaded.
 </para>
 </listitem>
 </varlistentry>
@@ -5688,8 +5712,31 @@ in that namespace will be loaded.
 
 <para>The ability to import functions is optional. <impl>Whether or not a processor
 can import functions, and if it can, what kinds of function libraries it can import
-from is <glossterm>implementation-defined</glossterm>.</impl>
+from is <glossterm>implementation-defined</glossterm>.</impl> Pipeline authors can
+use <function>p:function-library-importable</function> to test whether or not a particular
+kind of library can be loaded.
 </para>
+
+<para>Importing functions from a library implies loading and processing that library
+according to its conventions (loading imports, resolving dependencies, etc.).
+<error code="S0104">It is a <glossterm>static error</glossterm> if the processor
+cannot load the function library.</error> This may occur because the format is
+unknown, because it is a version of the library that the processor does
+not recognize, or if it’s uninterpretable for any other reason.
+<error code="S0106">It is a
+<glossterm>static error</glossterm> if the processor detects that a
+particular library is unloadable.</error> This may occur
+if the processor is, in principle, able to load libraries of the specified format,
+but detects that the particuar library requested is somehow ill-formed
+(syntactically invalid, has unsatisfiable dependencies or circular
+imports, etc.).
+</para>
+
+<para>Imported functions must be unique (they must have the same name, namespace, and
+arity). <error code="S0105">It is a <glossterm>static error</glossterm> if a function
+imported from a library has the same name and arity as a function already imported.</error>
+</para>
+
 
 </section>
 


### PR DESCRIPTION
The first is practically editorial, the second is `p:import-functions`!

How we managed to close the issue about that before we wrote any prose, I couldn't say. This is a bit minimal, but at least it beats "FIXME".
