### PR TITLE
Fixed type of option serialization on steps

### DIFF
--- a/steps/src/main/xml/steps/escape-markup.xml
+++ b/steps/src/main/xml/steps/escape-markup.xml
@@ -10,7 +10,7 @@ serialized.</para>
 <p:declare-step type="p:escape-markup">
   <p:input port="source" content-types="application/xml text/xml */*+xml"/>
   <p:output port="result" content-types="application/xml"/>
-  <p:option name="serialization" as="map(xs:string,xs:anyAtomicType)?"/>
+  <p:option name="serialization" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>This step supports the standard serialization options as

--- a/steps/src/main/xml/steps/http-request.xml
+++ b/steps/src/main/xml/steps/http-request.xml
@@ -12,7 +12,7 @@ including an entity body (content) for the request.</para>
 <p:declare-step type="p:http-request">
   <p:input port="source" content-types="*/*"/>
   <p:output port="result" sequence="true" content-types="*/*"/>
-  <p:option name="serialization" as="map(xs:string,xs:anyAtomicType)?"/>
+  <p:option name="serialization" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>The <option>serialization</option> option is provided to control the

--- a/steps/src/main/xml/steps/store.xml
+++ b/steps/src/main/xml/steps/store.xml
@@ -9,7 +9,7 @@ location of the stored document.</para>
   <p:input port="source" content-types="*/*"/>
   <p:output port="result" content-types="application/xml" primary="true"/>
   <p:option name="href" required="true" as="xs:anyURI"/>
-  <p:option name="serialization" as="map(xs:string,xs:anyAtomicType)?"/>
+  <p:option name="serialization" as="map(xs:QName,item()*)?"/>
 </p:declare-step>
 
 <para>The value of the <option>href</option> option


### PR DESCRIPTION
Fixed type of @serialization on 

- p:escape-markup
- p:http-request
- p:store

from `xs:string,xs:anyAtomicType)?` to `map(xs:QName,item()*)?`