### PR TITLE
Fixing typos

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1676,9 +1676,9 @@ return them unchanged, to silently omit them, or to raise an error. It
 <rfc2119>must not</rfc2119> return <literal>?</literal> and
 <literal>#</literal> escaped though.</para>
 
-<para>If the <parameter>$basedir</parameter> argument is omitted or is the empty sequence, the current working directory should be used
-    if available. The <parameter>$basedir</parameter> argument or the current working directory need only be considered if the
-      <parameter>$filepath</parameter> is determined to be a relative path or URI.</para>
+<para>If the <parameter>basedir</parameter> argument is omitted or is the empty sequence, the current working directory should be used
+    if available. The <parameter>basedir</parameter> argument or the current working directory need only be considered if the
+      <parameter>filepath</parameter> is determined to be a relative path or URI.</para>
   <note xml:id="note-urify-encoding">
     <para>Sometimes file names are created in an encoding that does not match the system’s locale. This function does not aim at
       solving these issues. Implementations should not try to correct apparent errors that originate from garbled encodings


### PR DESCRIPTION
Fixing typos resulting in $$parameter-name