### PR TITLE
Fix another markup problem

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1013,12 +1013,13 @@ performing a static analysis of all XPath expressions, and detecting static erro
 evaluation</firstterm> consists of tasks which, in general,
 cannot be performed out until a source document is available.</termdef></para>
 
-<para><error code="S0107">It is a <glossterm>static error</glossterm> if any static 
-XPath error is encountered during the static analysis of an expression, e.g. because 
-the expression is not syntactically valid, contains reference to unknown variables, or makes use of 
-undeclared functions.</error> Type errors even if they are determined during static
-analysis <rfc2119>must</rfc2119> be reported as <glossterm>dynamic error</glossterm> by
-the XProc processor.</para>
+<para><error code="S0107">It is a <glossterm>static error</glossterm> in XProc
+if any XPath expression contains a static error (error in expression syntax,
+references to unknown variables or functions, etc.).</error>
+Type errors, even if they are determined during static
+analysis, <rfc2119>must not</rfc2119> be raised statically by
+the XProc processor.
+</para>
 
 <para><impl>There may be an <glossterm>implementation-defined</glossterm>
 mechanism for providing default values for static


### PR DESCRIPTION
Sorry I missed this in the earlier PR. There was a markup error (a glossterm'd static-error that wasn't in an error element) and that made me look more closely at the paragraph.

I've reworded it slightly to improve the English.

I have a question though, why is the case of type errors being called out specifically here. We have a rule that says dynamic errors can be raised statically if the processor can prove they will always occur, does that rule not apply to type errors? If not, why not? 