### PR TITLE
Fix RELAX NG grammar problems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -584,6 +584,8 @@ task xproc30_rng(type: XMLCalabashTask,
 }
 
 task xproc30_rnc(dependsOn: [ "xproc30_rng" ], type: JavaExec) {
+  inputs.file "build/xproc30.rng"
+  outputs.file "build/xproc30.rnc"
   classpath = configurations.tools
   main = 'com.thaiopensource.relaxng.translate.Driver'
   args = ["build/xproc30.rng", "build/xproc30.rnc"]
@@ -628,8 +630,13 @@ task xproc_rng(dependsOn: [ "xproc_rnc" ], type: JavaExec) {
   args = ["build/xproc.rnc", "build/xproc.rng"]
 }
 
-task xproc_schemas(dependsOn: [ "xproc30_rnc", "xproc30_rng", "xproc10_rng", "xproc_rng" ]) {
-  // nop
+task xproc_schemas(dependsOn: [ "xproc30_rnc", "xproc30_rng", "xproc10_rng", "xproc_rng" ],
+                   type: JavaExec) {
+  inputs.file "tools/xpl/smoke-test.xpl"
+
+  classpath = configurations.tools
+  main = 'com.thaiopensource.relaxng.util.Driver'
+  args = ["-i", "-c", "build/xproc.rnc", "tools/xpl/smoke-test.xpl" ]
 }
 
 // ======================================================================

--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -225,7 +225,7 @@ ImportFunctions =
       global.attributes,
       href.attr,
       content-type.attr?,
-      attribute namespace { xsd:anyURI+ }?,
+      attribute namespace { text }?,
       (Documentation|PipeInfo)*
    }
 
@@ -668,7 +668,9 @@ Try =
       common.attributes,
       global.attributes,
       step.attributes,
-      ((Output*, Subpipeline, ((Catch+, Finally?)|(Catch*, Finally))) & (Documentation|PipeInfo)*)
+      ((Output|Documentation|PipeInfo)*,
+        Subpipeline,
+        (((Catch+, Finally?)|(Catch*, Finally)) & (Documentation|PipeInfo)*))
    }
 
 [

--- a/steps/src/main/xml/steps/directory-list.xml
+++ b/steps/src/main/xml/steps/directory-list.xml
@@ -12,8 +12,8 @@
   <p:output port="result" content-type="application/xml"/>
   <p:option name="path" required="true" as="xs:anyURI"/>
   <p:option name="detailed" as="xs:boolean" select="false()"/>
-  <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
-  <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
+  <p:option name="include-filter" as="xs:string" e:type="RegularExpression"/>
+  <p:option name="exclude-filter" as="xs:string" e:type="RegularExpression"/>
 </p:declare-step>
 
 <para><impl>Conformant processors <rfc2119>must</rfc2119> support directory paths whose
@@ -36,7 +36,7 @@ see <xref linkend="dir-list-details"/>.</para>
 
 <para>If present, the value of the <option>include-filter</option>
 or <option>exclude-filter</option>
-option <rfc2119>must</rfc2119> be a list of regular expression as specified in
+option <rfc2119>must</rfc2119> be a whitespace separated list of regular expressions as specified in
 <biblioref linkend="xpath31-functions"/>, section 7.61 “<literal>Regular Expression
 Syntax</literal>”.</para>
 

--- a/steps/src/main/xml/steps/load-directory-list.xml
+++ b/steps/src/main/xml/steps/load-directory-list.xml
@@ -13,8 +13,8 @@
 <p:declare-step type="p:load-directory-list">
   <p:output port="result" content-type="application/xml"/>
   <p:option name="path" required="true" as="xs:anyURI"/>
-  <p:option name="include-filter" as="xs:string*" e:type="RegularExpression"/>
-  <p:option name="exclude-filter" as="xs:string*" e:type="RegularExpression"/>
+  <p:option name="include-filter" as="xs:string" e:type="RegularExpression"/>
+  <p:option name="exclude-filter" as="xs:string" e:type="RegularExpression"/>
 </p:declare-step>
 
 <para><impl>Conformant processors <rfc2119>must</rfc2119> support directory paths whose
@@ -33,7 +33,7 @@ environment in which the pipeline is run.</error></para>
 
 <para>If present, the value of the <option>include-filter</option>
 or <option>exclude-filter</option>
-option <rfc2119>must</rfc2119> be a regular expression as specified in
+option <rfc2119>must</rfc2119> be a whitespace separated list of regular expressions as specified in
 <biblioref linkend="xpath31-functions"/>,section 7.61 “<literal>Regular Expression
 Syntax</literal>”.</para>
 

--- a/tools/xpl/smoke-test.xpl
+++ b/tools/xpl/smoke-test.xpl
@@ -1,0 +1,10 @@
+<p:declare-step xmlns:p="http://www.w3.org/ns/xproc"
+                name="main" version="3.0">
+  <!-- This pipeline does nothing, it's just a smoke test for
+       the RELAX NG validator. -->
+  <p:input port="source"/>
+  <p:output port="result"/>
+  <p:identity>
+    <p:with-input port="source" pipe="source"/>
+  </p:identity>
+</p:declare-step>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5840,7 +5840,8 @@ determines the type of the library is <glossterm>implementation-defined</glosste
 </varlistentry>
 <varlistentry><term><tag class="attribute">namespace</tag></term>
 <listitem>
-<para>If a <tag class="attribute">namespace</tag> is specified, it provides a list
+<para>If a <tag class="attribute">namespace</tag> is specified, it must be a whitespace
+separated list
 of namespace URIs. Only functions
 in those namespaces will be loaded.
 </para>


### PR DESCRIPTION
1. You can't have repeating string data types (xsd:string* or xsd:anyURI*)
2. The content model for `p:try` was invalid
3. I added a smoke-test so that future schema problems will cause the build to fail.
