### PR TITLE
Point to test-suite.xproc.rog

### DIFF
--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -138,18 +138,18 @@ XProc 1.0 and a 3.0 implementation is being developed.</p>
 <div id="testsuite">
 <h2>Test suite</h2>
 
-<p>A <a href="https://xproc.github.io/3.0-test-suite/">test suite</a>
+<p>A <a href="http://test-suite.xproc.org/">test suite</a>
 is being developed to improve the reliability and interoperability
 of XProc 3.0 implementations. There are several ways to view the
 test suite, including:</p>
 
 <dl>
-<dt><a href="https://xproc.github.io/3.0-test-suite/alphabetical.html">Alphabetically</a></dt>
+<dt><a href="http://test-suite.xproc.org/alphabetical.html">Alphabetically</a></dt>
 <dd>
 <p>All of the tests in alphabetical order.</p>
 </dd>
 
-<dt><a href="https://xproc.github.io/3.0-test-suite/implementation.html">Implementation
+<dt><a href="http://test-suite.xproc.org/implementation.html">Implementation
 reports</a></dt>
 <dd>
 <p>Tracks implementation results against the test suite.</p>


### PR DESCRIPTION
I finally got around to giving the 3.0 test-suite a proper domain name.

It takes 24ish hours before github will let me convert it to https, but I will.
