### PR TITLE
Make versions xs:decimal, remove out-of-date reference

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -60,7 +60,7 @@ required.attr = attribute required { xsd:boolean }
 sequence.attr = attribute sequence { xsd:boolean }
 primary.attr = attribute primary { xsd:boolean }
 select.attr = attribute select { XPathExpression }
-xpath-version.attr = attribute xpath-version { text }
+xpath-version.attr = attribute xpath-version { xsd:decimal }
 psvi-required.attr = attribute psvi-required { xsd:boolean }
 document-properties.attr = attribute document-properties { PropertyMap }
 serialization.attr = attribute serialization { SerializationMap }
@@ -164,7 +164,7 @@ message.attr = attribute message { text }
 ]
 p_message.attr = attribute p:message { text }
 
-version.attr = attribute version { "3.0" }
+version.attr = attribute version { xsd:decimal }
 
 common.attributes = xmlid.attr?, xmlbase.attr?, extension.attr*
 

--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -232,6 +232,18 @@
   </ss:group>
 </xsl:template>
 
+<xsl:template match="rng:attribute[@name='version']" priority="20">
+  <xsl:param name="schema" tunnel="yes"/>
+  <xsl:param name="repeat" select="''"/>
+  <xsl:param name="avt" select="()"/>
+
+  <!-- A totally special case: allow the version attribute to be of type xs:decimal,
+       but display its fixed value as "3.0" without the quotation marks that make
+       it look like a string. -->
+
+  <ss:attribute name="{@name}" optional="{$repeat}" avt="false" type="3.0"/>
+</xsl:template>
+
 <xsl:template match="rng:attribute[@name]" priority="10">
   <xsl:param name="schema" tunnel="yes"/>
   <xsl:param name="repeat" select="''"/>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5490,9 +5490,7 @@ any namespace provided that the expanded-QName of the value has a
 non-null namespace URI. <error code="S0025">It is a <glossterm>static
 error</glossterm> if the expanded-QName value of the <tag
 class="attribute">type</tag> attribute is in no namespace or in the
-XProc namespace.</error> Except as described in <xref
-linkend="versioning-considerations"/>, the XProc namespace
-<rfc2119>must not</rfc2119> be used in the type of steps. Neither
+XProc namespace.</error> Neither
 users nor implementers may define additional steps in the XProc
 namespace.
 </para>


### PR DESCRIPTION
Fix #768.

1. Change version attribute types to xs:decimal.
2. Hack the presentation stylesheet so that version is shown as 3.0 without quotation marks.
3. Remove the no-longer-relevant reference to the versioning considerations from the `p:declare-step`s `type` attribute.
 