### PR TITLE
Make 'href' required on c:entry

### DIFF
--- a/src/main/schema/core30.rnc
+++ b/src/main/schema/core30.rnc
@@ -950,7 +950,7 @@ VocabArchive =
 VocabEntry =
    element c:entry {
       attribute name { text },
-      attribute href { xsd:anyURI }?,
+      attribute href { xsd:anyURI },
       attribute comment { text }?,
       attribute method { text }?,
       attribute level { text }?,


### PR DESCRIPTION
This fix will make the href attribute required and that should show up in the next steps build.