### PR TITLE
Switch to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-dist: trusty
+dist: xenial
 language: java
+jdk: openjdk12
 install: true
 script: ./gradlew --stacktrace
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     classpath group: 'org.docbook', name: 'docbook-schemas', version: '5.1-1'
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-print', version: '1.1.5'
     classpath group: 'com.xmlcalabash', name: 'xmlcalabash1-gradle', version: '1.3.5'
-    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.23-98'
+    classpath group: 'com.xmlcalabash', name: 'xmlcalabash', version: '1.1.27-99'
     classpath group: 'org.xmlresolver', name: 'xmlresolver', version: '1.0.1'
   }
 }
@@ -82,7 +82,7 @@ def getenv(String name) {
 }
 
 def deltaxml() {
-  def dxml = new File("deltaxml")
+  def dxml = file("deltaxml")
   if (dxml.exists() && dxml.isDirectory()) {
     return "diff"
   } else {
@@ -175,7 +175,7 @@ task overview(dependsOn: [ "xproc_schemas", "spec_schemas",
   input("source", "overview/build/source.xml")
   output("result", "build/dist/overview/index.html")
 
-  param("schemaext.schema", new File("build/schema/dbspec.rng"))
+  param("schemaext.schema", file("build/schema/dbspec.rng"))
   param("travis", getenv("TRAVIS"))
   param("travis-commit", getenv("TRAVIS_COMMIT"))
   param("travis-build-number", getenv("TRAVIS_BUILD_NUMBER"))
@@ -184,10 +184,10 @@ task overview(dependsOn: [ "xproc_schemas", "spec_schemas",
   param("travis-branch", getenv("TRAVIS_BRANCH"))
   param("travis-tag", getenv("TRAVIS_TAG"))
 
-  option("style", new File("tools/xsl/xproc-specs.xsl"))
+  option("style", file("tools/xsl/xproc-specs.xsl"))
   option("diff", deltaxml())
   option("specid", "overview")
-  option("diffloc", new File("build/dist/overview/diff.html").getAbsolutePath())
+  //option("diffloc", "../../build/dist/overview/diff.html")
 
   pipeline "tools/xpl/formatspec.xpl"
 }
@@ -216,7 +216,7 @@ task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
   input("source", "xproc/build/source.xml")
   output("result", "build/dist/xproc/index.html")
 
-  param("schemaext.schema", new File("build/schema/dbspec.rng"))
+  param("schemaext.schema", file("build/schema/dbspec.rng"))
   param("travis", getenv("TRAVIS"))
   param("travis-commit", getenv("TRAVIS_COMMIT"))
   param("travis-build-number", getenv("TRAVIS_BUILD_NUMBER"))
@@ -225,11 +225,11 @@ task xproc(dependsOn: [ "xproc_schemas", "spec_schemas",
   param("travis-branch", getenv("TRAVIS_BRANCH"))
   param("travis-tag", getenv("TRAVIS_TAG"))
 
-  option("style", new File("tools/xsl/xproc-specs.xsl"))
+  option("style", file("tools/xsl/xproc-specs.xsl"))
   option("diff", deltaxml())
   option("specid", "xproc")
-  option("diffloc", new File("build/dist/xproc/diff.html").getAbsolutePath())
-  option("lcdiffloc", new File("build/dist/xproc/lcdiff.html").getAbsolutePath())
+  //option("diffloc", file("build/dist/xproc/diff.html"))
+  //option("lcdiffloc", file("build/dist/xproc/lcdiff.html"))
 
   pipeline "tools/xpl/formatspec.xpl"
 }
@@ -242,7 +242,7 @@ task xproc_pdf_xform(dependsOn: [ "xproc" ], type: DocBookTask) {
   input("source", "xproc/build/source.xml")
   output("result", "build/dist/xproc/pdfhtml.html")
 
-  param("schemaext.schema", new File("build/schema/dbspec.rng"))
+  param("schemaext.schema", "../../build/schema/dbspec.rng")
   param("travis", getenv("TRAVIS"))
   param("travis-commit", getenv("TRAVIS_COMMIT"))
   param("travis-build-number", getenv("TRAVIS_BUILD_NUMBER"))
@@ -251,8 +251,8 @@ task xproc_pdf_xform(dependsOn: [ "xproc" ], type: DocBookTask) {
   param("travis-branch", getenv("TRAVIS_BRANCH"))
   param("travis-tag", getenv("TRAVIS_TAG"))
 
-  option("style", new File("tools/xsl/xproc-pdf.xsl"))
-  option("postprocess", new File("tools/xsl/post-pdf.xsl"))
+  option("style", file("tools/xsl/xproc-pdf.xsl"))
+  option("postprocess", file("tools/xsl/post-pdf.xsl"))
 
   pipeline "tools/xpl/pdfspec.xpl"
 }
@@ -266,7 +266,7 @@ task xproc_pdf(dependsOn: [ "xproc_pdf_xform" ], type: XMLCalabashTask) {
   outputs.file "build/dist/xproc/xproc.pdf"
 
   option("css", "src/main/css/print.css")
-  option("pdf", new File("build/dist/xproc/xproc.pdf").getAbsolutePath())
+  option("pdf", file("build/dist/xproc/xproc.pdf"))
 
   pipeline "tools/xpl/css-format.xpl"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR attempts to switch the build system to use OpenJDK12. That seems to be what's recommended these days. We've lost diffs again for the time being, alas.