### PR TITLE
Attempt to fix 839

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1523,8 +1523,11 @@ system properties, which are all in the XProc namespace:</para>
 <rfc2119>must</rfc2119> be in a namespace and <rfc2119>must not</rfc2119> be
 in the XProc namespace.</para>
 
-<para><impl>The value of the <function>p:system-property</function> function during
-static analysis is <glossterm>implementation-defined</glossterm>.</impl></para>
+<para>The <function>p:system-property</function> function behaves normally during static 
+analysis. <impl>It is <glossterm>implementation-defined</glossterm> which additional
+system properties are available during static analysis.</impl> If an additional system
+property is not available during static analysis, an empty string <rfc2119>must</rfc2119>
+be returned.</para>
 
       </section>
       <section xml:id="f.step-available">


### PR DESCRIPTION
Attempt to fix #839 to make sure that only additional system properties (defined by implementation) may not be visible during static analysis. All properties defined in the specs must be visible and can therefor be used in @use-when.