### PR TITLE
Added two media types to text media types

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -563,8 +563,10 @@ text media type.
 <termdef xml:id="dt-text-media-type">Media types of the form
 “<literal>text/<replaceable>something</replaceable></literal>”
 are <firstterm baseform="text media type">text media types</firstterm> with the
-exception of “<literal>text/xml</literal>” which is an XML media type.
-and “<literal>text/html</literal>” which is an HTML media type.
+exception of “<literal>text/xml</literal>” which is an XML media type,
+and “<literal>text/html</literal>” which is an HTML media type. Additionally the
+media types “<literal>application/relax-ng-compact-syntax</literal>” and 
+“<literal>application/xquery</literal>” are also text media types.
 </termdef>
 </para>
 


### PR DESCRIPTION
Attempt to fix steps issues 

- https://github.com/xproc/3.0-steps/issues/183
- https://github.com/xproc/3.0-steps/issues/184

by adding "application/relax-ng-compact-syntax" and "application/xquery" to the list of text media types.