### PR TITLE
Changed definition of text documents

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -565,9 +565,12 @@ text media type.
 are <firstterm baseform="text media type">text media types</firstterm> with the
 exception of “<literal>text/xml</literal>” which is an XML media type,
 and “<literal>text/html</literal>” which is an HTML media type. Additionally the
-media types “<literal>application/relax-ng-compact-syntax</literal>” and 
+  media types “<literal>application/javascript</literal>”, 
+“<literal>application/relax-ng-compact-syntax</literal>”, and
 “<literal>application/xquery</literal>” are also text media types.
-</termdef>
+</termdef> <impl>It is <glossterm>implementation-defined</glossterm>
+whether other media types not mentioned in this document are treated
+as text media types as well.</impl>
 </para>
 
 <para>When a text document is serialized, it <rfc2119>should</rfc2119> be serialized using the

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -563,8 +563,10 @@ text media type.
 <termdef xml:id="dt-text-media-type">Media types of the form
 “<literal>text/<replaceable>something</replaceable></literal>”
 are <firstterm baseform="text media type">text media types</firstterm> with the
-exception of “<literal>text/xml</literal>” which is an XML media type.
-and “<literal>text/html</literal>” which is an HTML media type.
+exception of “<literal>text/xml</literal>” which is an XML media type,
+and “<literal>text/html</literal>” which is an HTML media type. Additionally the
+media types “<literal>application/relax-ng-compact-syntax</literal>” and 
+“<literal>application/xquery</literal>” are also text media types.
 </termdef>
 </para>
 


### PR DESCRIPTION
In order to fix step issue 183 I added "application/javascript", "application/xquery" and "application/relax-ng-compact-syntax" to the definition of text documents.
As requested by @ndw I also added a sentence saying that implementations may add additional media types.