### PR TITLE
Trying to resolve #833

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -2460,7 +2460,7 @@ Variable names are always expressed as
 
       <para>If a variable or option declares a type, the supplied value of the variable or option is converted to the
         required type, using the function conversion rules specified by XPath 3.1. <error code="D0036">It is a
-            <glossterm>dynamic error</glossterm> if the supplied value of a variable or option cannot be converted to
+            <glossterm>dynamic error</glossterm> if the supplied or defaulted value of a variable or option cannot be converted to
           the required type.</error></para>
       
     </section>
@@ -5349,7 +5349,7 @@ which will be evaluated to provide the default value for the option.
 expression on the <tag>p:declare-step</tag> that defines the step
 signature. It must be a statically valid expression at that point.
 Consequently, if it contains variable references, they can only be
-references to preceding options on the step.
+references to preceding options on the step or to in-scope static variables.
 <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
 XPath expression makes reference to the context item, size, or position when
 the context item is undefined.</error></para>


### PR DESCRIPTION
This was rather simple, but with the following note:

I mention "in-scope static variables".  I couldn't find in the core spec a specification of what the scope of a static variable was (from discussions: could be in an encompassing step, in a library, etc.). It's not defined yet. Since the jury on this is still out (#505) I think its safe to just mention it here as "in-scope", with the expectation we're going to write this down somewhere soon...