### PR TITLE
Attempt to resolve #788

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1,96 +1,86 @@
 <?xml-model href="../../schema/dbspec.rng"
   type="application/xml"
   schematypens="http://relaxng.org/ns/structure/1.0" ?>
-<specification xmlns="http://docbook.org/ns/docbook"
-               xmlns:xlink="http://www.w3.org/1999/xlink"
-               xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
-               xmlns:xi="http://www.w3.org/2001/XInclude"
-               xml:id='xproc'
-               class="ed"
-               version="5.0-extension w3c-xproc">
-<info>
-<title>XProc 3.0: An XML Pipeline Language</title>
-<!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
-<copyright><year>2018</year><year>2019</year><holder>@@FIXME:</holder></copyright>
+<specification xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax" xmlns:xi="http://www.w3.org/2001/XInclude"
+  xml:id="xproc" class="ed" version="5.0-extension w3c-xproc">
+  <info>
+    <title>XProc 3.0: An XML Pipeline Language</title>
+    <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
+    <copyright>
+      <year>2018</year>
+      <year>2019</year>
+      <holder>@@FIXME:</holder>
+    </copyright>
 
-<bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
-<authorgroup>
-  <author>
-    <personname>Norman Walsh</personname>
-  </author>
-  <author>
-    <personname>Achim Berndzen</personname>
-  </author>
-  <author>
-    <personname>Gerrit Imsieke</personname>
-  </author>
-  <author>
-    <personname>Erik Siegel</personname>
-  </author>
-</authorgroup>
-<abstract>
-<para>This specification describes the syntax and semantics of
-<citetitle>XProc 3.0: An XML Pipeline Language</citetitle>, a language for
-describing operations to be performed on documents.</para>
+    <bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+    <authorgroup>
+      <author>
+        <personname>Norman Walsh</personname>
+      </author>
+      <author>
+        <personname>Achim Berndzen</personname>
+      </author>
+      <author>
+        <personname>Gerrit Imsieke</personname>
+      </author>
+      <author>
+        <personname>Erik Siegel</personname>
+      </author>
+    </authorgroup>
+    <abstract>
+      <para>This specification describes the syntax and semantics of <citetitle>XProc 3.0: An XML
+          Pipeline Language</citetitle>, a language for describing operations to be performed on
+        documents.</para>
 
-<para>An XML Pipeline specifies a sequence of operations to be
-performed on documents. Pipelines generally accept
-documents as input and produce documents as output.
-Pipelines are made up of simple steps which
-perform atomic operations on documents and constructs such as
-conditionals, iterations, and exception handlers which control which
-steps are executed.</para>
-</abstract>
+      <para>An XML Pipeline specifies a sequence of operations to be performed on documents.
+        Pipelines generally accept documents as input and produce documents as output. Pipelines are
+        made up of simple steps which perform atomic operations on documents and constructs such as
+        conditionals, iterations, and exception handlers which control which steps are
+        executed.</para>
+    </abstract>
 
-<legalnotice role="status">
+    <legalnotice role="status">
 
-<para><emphasis>This section describes the status of this document at
-the time of its publication. Other documents may supersede this
-document.</emphasis></para>
+      <para>
+        <emphasis>This section describes the status of this document at the time of its publication.
+          Other documents may supersede this document.</emphasis>
+      </para>
 
-<note role="editorial">
-<para>This draft is the “editor’s working draft” and may include changes made
-after the “last call” draft that was announced at XML Prague, 2019.</para>
-<para>The
-<link xlink:href="http://spec.xproc.org/lastcall-2019-02/head/xproc/">last call draft</link>
-is stable and will not change.
-</para>
-</note>
+      <note role="editorial">
+        <para>This draft is the “editor’s working draft” and may include changes made after the
+          “last call” draft that was announced at XML Prague, 2019.</para>
+        <para>The <link xlink:href="http://spec.xproc.org/lastcall-2019-02/head/xproc/">last call
+            draft</link> is stable and will not change. </para>
+      </note>
 
-<para>This document is derived from
-<link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:
-An XML Pipeline Language</link> published by the W3C.</para>
-</legalnotice>
-</info>
+      <para>This document is derived from <link
+          xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc: An XML Pipeline
+          Language</link> published by the W3C.</para>
+    </legalnotice>
+  </info>
 
-<section xml:id="introduction">
-<title>Introduction</title>
+  <section xml:id="introduction">
+    <title>Introduction</title>
 
-<para>An XML Pipeline specifies a sequence of operations to be
-performed on a collection of input documents. Pipelines take documents
-(XML, JSON, text, images, etc.)
-as their input and produce documents as their output.</para>
+    <para>An XML Pipeline specifies a sequence of operations to be performed on a collection of
+      input documents. Pipelines take documents (XML, JSON, text, images, etc.) as their input and
+      produce documents as their output.</para>
 
-<para>A <glossterm>pipeline</glossterm> consists of steps. Like
-pipelines, steps take documents as their inputs and
-produce documents as their outputs. The inputs of a step
-come from the web, from the pipeline document, from the inputs to the
-pipeline itself, or from the outputs of other steps in the pipeline.
-The outputs from a step are consumed by other steps, are outputs of
-the pipeline as a whole, or are discarded.</para>
+    <para>A <glossterm>pipeline</glossterm> consists of steps. Like pipelines, steps take documents
+      as their inputs and produce documents as their outputs. The inputs of a step come from the
+      web, from the pipeline document, from the inputs to the pipeline itself, or from the outputs
+      of other steps in the pipeline. The outputs from a step are consumed by other steps, are
+      outputs of the pipeline as a whole, or are discarded.</para>
 
-<para>There are two kinds of steps:
-<glossterm baseform="atomic step">atomic steps</glossterm> and
-<glossterm baseform="compound step">compound steps</glossterm>.
-Atomic steps carry out a single operation and have no substructure as
-far as the pipeline is concerned. Compound steps control the execution
-of other steps, which they include in the form of one or more
-subpipelines.</para>
+    <para>There are two kinds of steps: <glossterm baseform="atomic step">atomic steps</glossterm>
+      and <glossterm baseform="compound step">compound steps</glossterm>. Atomic steps carry out a
+      single operation and have no substructure as far as the pipeline is concerned. Compound steps
+      control the execution of other steps, which they include in the form of one or more
+      subpipelines.</para>
 
-<para><biblioref linkend="steps30"/>
-defines a standard library of steps. Pipeline implementations
-<rfc2119>may</rfc2119> support additional types of steps as well.
-</para>
+    <para><biblioref linkend="steps30"/> defines a standard library of steps. Pipeline
+      implementations <rfc2119>may</rfc2119> support additional types of steps as well. </para>
 
     <para>The media type for pipeline documents is <literal>application/xml</literal>. Often,
       pipeline documents are identified by the extension <filename class="extension"
@@ -100,86 +90,78 @@ defines a standard library of steps. Pipeline implementations
         <rfc2119>recommended</rfc2119> are to be interpreted as described in <biblioref
         linkend="rfc2119"/>.</para>
 
-<section xml:id="intro-examples">
-<title>Pipeline examples</title>
+    <section xml:id="intro-examples">
+      <title>Pipeline examples</title>
 
-<para><xref linkend="fig-xival"/> is a graphical representation of a
-simple pipeline that performs XInclude processing and validation on a
-document.</para>
+      <para><xref linkend="fig-xival"/> is a graphical representation of a simple pipeline that
+        performs XInclude processing and validation on a document.</para>
 
-<figure xml:id="fig-xival">
-  <title>A simple, linear XInclude/Validate pipeline</title>
-  <mediaobject>
-    <alt>A simple, linear XInclude/Validate pipeline</alt>
-    <imageobject>
-      <imagedata fileref="graphics/sch-xinclude-validate-pipeline.png"/>
-    </imageobject>
-  </mediaobject>
-</figure>
-<para>This is a pipeline that consists of two atomic steps, XInclude and Validate with XML
-  Schema. The pipeline itself has two inputs, “source” (a source document) and “schemas” (a
-  sequence of W3C XML Schemas). The XInclude step reads the pipeline input “source” and produces
-  a result document. The Validate with XML Schema step reads the pipeline input “schemas” and
-  the result of the XInclude step and produces its own result document. The result of the
-  validation, “result”, is the result of the pipeline. (For consistency across the step
-  vocabulary, the standard input is usually named “source” and the standard output is
-  usually named “result”.) </para>
-<para>The pipeline document determines how the steps are connected together inside the pipeline,
-  that is, how the output of one step becomes the input of another.</para>
-<para>The pipeline document for this pipeline is shown in <xref linkend="ex1"/>.</para>
+      <figure xml:id="fig-xival">
+        <title>A simple, linear XInclude/Validate pipeline</title>
+        <mediaobject>
+          <alt>A simple, linear XInclude/Validate pipeline</alt>
+          <imageobject>
+            <imagedata fileref="graphics/sch-xinclude-validate-pipeline.png"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+      <para>This is a pipeline that consists of two atomic steps, XInclude and Validate with XML
+        Schema. The pipeline itself has two inputs, “source” (a source document) and “schemas” (a
+        sequence of W3C XML Schemas). The XInclude step reads the pipeline input “source” and
+        produces a result document. The Validate with XML Schema step reads the pipeline input
+        “schemas” and the result of the XInclude step and produces its own result document. The
+        result of the validation, “result”, is the result of the pipeline. (For consistency across
+        the step vocabulary, the standard input is usually named “source” and the standard output is
+        usually named “result”.) </para>
+      <para>The pipeline document determines how the steps are connected together inside the
+        pipeline, that is, how the output of one step becomes the input of another.</para>
+      <para>The pipeline document for this pipeline is shown in <xref linkend="ex1"/>.</para>
 
-<example xml:id="ex1">
-<title>A simple, linear XInclude/Validate pipeline</title>
-<programlisting language="xml"
-><xi:include href="../../../build/examples/fig1.txt" parse="text"/></programlisting>
-</example>
+      <example xml:id="ex1">
+        <title>A simple, linear XInclude/Validate pipeline</title>
+        <programlisting language="xml"><xi:include href="../../../build/examples/fig1.txt" parse="text"/></programlisting>
+      </example>
 
-<para><xref linkend="ex1"/> is very verbose. It makes
-all of the connections seen in the figure explicit. In practice,
-pipelines do not have to be this verbose. By default, where inputs and
-outputs are connected between sequential sibling steps, they do not
-have to be made explicit.</para>
+      <para><xref linkend="ex1"/> is very verbose. It makes all of the connections seen in the
+        figure explicit. In practice, pipelines do not have to be this verbose. By default, where
+        inputs and outputs are connected between sequential sibling steps, they do not have to be
+        made explicit.</para>
 
-<para>The same pipeline, using XProc defaults, is shown in <xref
-linkend="ex1-abbr"/>.</para>
+      <para>The same pipeline, using XProc defaults, is shown in <xref linkend="ex1-abbr"/>.</para>
 
-<example xml:id="ex1-abbr">
-<title>A simple, linear XInclude/Validate pipeline (simplified)</title>
-<programlisting language="xml"
-><xi:include href="../../../build/examples/fig1-abbr.txt" parse="text"/></programlisting>
-</example>
+      <example xml:id="ex1-abbr">
+        <title>A simple, linear XInclude/Validate pipeline (simplified)</title>
+        <programlisting language="xml"><xi:include href="../../../build/examples/fig1-abbr.txt" parse="text"/></programlisting>
+      </example>
 
-<para><xref linkend="fig-style-proc"/> is a more complex example: it
-performs schema validation with an appropriate schema and then styles
-the validated document.</para>
+      <para><xref linkend="fig-style-proc"/> is a more complex example: it performs schema
+        validation with an appropriate schema and then styles the validated document.</para>
 
-<figure xml:id="fig-style-proc">
-  <title>A validate and transform pipeline</title>
-  <mediaobject>
-    <alt>A validate and transform pipeline</alt>
-    <imageobject>
-      <imagedata fileref="graphics/sch-transform.png"/>
-    </imageobject>
-  </mediaobject>
-</figure>
+      <figure xml:id="fig-style-proc">
+        <title>A validate and transform pipeline</title>
+        <mediaobject>
+          <alt>A validate and transform pipeline</alt>
+          <imageobject>
+            <imagedata fileref="graphics/sch-transform.png"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
 
-<para>The heart of this example is the conditional. The “choose” step
-evaluates an XPath expression over a test document. Based on the
-result of that expression, one or another branch is run. In this
-example, each branch consists of a single validate step.</para>
+      <para>The heart of this example is the conditional. The “choose” step evaluates an XPath
+        expression over a test document. Based on the result of that expression, one or another
+        branch is run. In this example, each branch consists of a single validate step.</para>
 
-<example xml:id="ex2">
-  <title>A validate and transform pipeline</title>
-  <programlisting language="xml"><xi:include href="../../../build/examples/fig2.txt" parse="text"/></programlisting>
-</example>
+      <example xml:id="ex2">
+        <title>A validate and transform pipeline</title>
+        <programlisting language="xml"><xi:include href="../../../build/examples/fig2.txt" parse="text"/></programlisting>
+      </example>
 
-<para>This example, like the preceding, relies on XProc defaults for
-simplicity. It is always valid to write the fully explicit form if you
-prefer. This example also takes advantage of using the <tag class="attribute">href</tag>
-attribute directly on <tag>p:with-input</tag> as a shortcut for the
-<tag>p:document</tag> connection.</para>
+      <para>This example, like the preceding, relies on XProc defaults for simplicity. It is always
+        valid to write the fully explicit form if you prefer. This example also takes advantage of
+        using the <tag class="attribute">href</tag> attribute directly on <tag>p:with-input</tag> as
+        a shortcut for the <tag>p:document</tag> connection.</para>
 
-</section>
+    </section>
 
 
   </section>
@@ -194,82 +176,71 @@ attribute directly on <tag>p:with-input</tag> as a shortcut for the
       of evaluating the steps that it contains, in an order consistent with the connections between
       them. A pipeline must behave as if it evaluated each step each time it is encountered. Unless
       otherwise indicated, implementations <rfc2119>must not</rfc2119> assume that steps are
+      functional (that is, that their outputs depend only on their <link linkend="input-output"
+        >inputs</link> and <glossterm baseform="option">options</glossterm>) or side-effect
+      free.</para>
 
-functional (that is, that their outputs depend only on their
-<link linkend="input-output" >inputs</link> and
-<glossterm baseform="option">options</glossterm>) or side-effect
-free.</para>
+    <para>The pattern of connections between steps will not always completely determine their order
+      of evaluation. <impl>The evaluation order of steps not connected to one another is
+          <glossterm>implementation-dependent</glossterm>.</impl></para>
 
-<para>The pattern of connections between steps will not always
-completely determine their order of evaluation. <impl>The evaluation
-order of steps not connected to one another is
-<glossterm>implementation-dependent</glossterm>.</impl></para>
+    <section xml:id="step-concept">
+      <title>Steps</title>
 
-<section xml:id="step-concept">
-<title>Steps</title>
+      <para><termdef xml:id="dt-step">A <firstterm>step</firstterm> is the basic computational unit
+          of a pipeline.</termdef> A typical step has inputs, from which it receives documents to
+        process, outputs, to which it sends result documents, and options which influence its
+        behavior.</para>
 
-<para><termdef xml:id="dt-step">A <firstterm>step</firstterm> is the
-basic computational unit of a pipeline.</termdef> A typical step has
-inputs, from which it receives documents to process, outputs, to which
-it sends result documents, and options which influence its behavior.</para>
+      <para>There are two kinds of steps: atomic and compound:</para>
 
-<para>There are two kinds of steps: atomic and compound:</para>
+      <para><termdef xml:id="dt-atomic-step">An <firstterm>atomic step</firstterm> is a step that
+          performs a unit of processing on its input, such as validation or transformation, and has
+          no internal <glossterm>subpipeline</glossterm>.</termdef> Atomic steps carry out
+        fundamental operations and can perform arbitrary amounts of computation, but they are
+        indivisible.</para>
 
-<para><termdef xml:id="dt-atomic-step">An <firstterm>atomic
-step</firstterm> is a step that performs a unit of processing
-on its input,
-such as validation or transformation, and has no internal
-<glossterm>subpipeline</glossterm>.</termdef> Atomic steps carry out
-fundamental operations and can perform arbitrary amounts of
-computation, but they are indivisible.</para>
+      <para>There are many <emphasis>types</emphasis> of atomic steps. The standard library of
+        atomic steps is described in <biblioref linkend="steps30"/>, but implementations
+          <rfc2119>may</rfc2119> provide others as well. <impl>It is
+            <glossterm>implementation-defined</glossterm> what additional step types, if any, are
+          provided. </impl> Each use, or instance, of an atomic step invokes the processing defined
+        by that type of step. A pipeline may contain instances of many types of steps and many
+        instances of the same type of step.</para>
 
-<para>There are many <emphasis>types</emphasis> of atomic steps. The
-standard library of atomic steps is described in <biblioref
-linkend="steps30"/>, but implementations <rfc2119>may</rfc2119>
-provide others as well. <impl>It is
-<glossterm>implementation-defined</glossterm> what additional step
-types, if any, are provided. </impl> Each use, or instance, of an
-atomic step invokes the processing defined by that type of step. A
-pipeline may contain instances of many types of steps and many
-instances of the same type of step.</para>
+      <para>Compound steps, on the other hand, control and organize the flow of documents through a
+        pipeline, providing familiar programming language functionality such as conditionals,
+        iterators and exception handling. They contain other steps, whose evaluation they
+        control.</para>
 
-<para>Compound steps, on the other hand, control and organize the flow
-of documents through a pipeline, providing familiar programming
-language functionality such as conditionals, iterators and exception
-handling. They contain other steps, whose evaluation they
-control.</para>
+      <para><termdef xml:id="dt-compound-step">A <firstterm>compound step</firstterm> is a step that
+          contains one or more <glossterm baseform="subpipeline">subpipelines</glossterm>.</termdef>
+        That is, a compound step differs from an atomic step in that its semantics are at least
+        partially determined by the steps that it contains.</para>
 
-<para><termdef xml:id="dt-compound-step">A <firstterm>compound
-step</firstterm> is a step that contains one or more
-<glossterm baseform="subpipeline">subpipelines</glossterm>.</termdef>
-That is, a compound step differs from an atomic step in that its
-semantics are at least partially determined by the steps that it
-contains.</para>
+      <para>Compound steps either directly contain a single subpipeline or contain several
+        subpipelines and select one or more to evaluate dynamically. In the latter case, alternate
+        subpipelines are identified by non-step wrapper elements that each contain a single
+        subpipeline. </para>
 
-<para>Compound steps either directly contain a single subpipeline or
-contain several subpipelines and select one or more to evaluate
-dynamically. In the latter case, alternate subpipelines are identified
-by non-step wrapper elements that each contain a single subpipeline.
-</para>
+      <para>
+        <termdef xml:id="dt-container">A <firstterm>container</firstterm> is either a compound step
+          or one of the non-step wrapper elements in a compound step that contains several
+          subpipelines.</termdef>
+        <termdef xml:id="dt-contained-steps">The steps that occur directly within a container are
+          called that step’s <firstterm>contained steps</firstterm>. In other words, “container” and
+          “contained steps” are inverse relationships.</termdef>
+        <termdef xml:id="dt-ancestors">The <firstterm>ancestors</firstterm> of a step, if it has
+          any, are its <glossterm>container</glossterm> and the ancestors of its
+          container.</termdef>
+      </para>
 
-<para><termdef xml:id="dt-container">A <firstterm>container</firstterm>
-is either a compound step or one
-of the non-step wrapper elements in a compound step that contains
-several subpipelines.</termdef>
-<termdef xml:id="dt-contained-steps">The steps that occur directly
-within a container are called
-that step’s <firstterm>contained steps</firstterm>. In other words,
-“container” and “contained steps” are inverse relationships.</termdef>
-<termdef xml:id="dt-ancestors">The <firstterm>ancestors</firstterm> of
-a step, if it has any, are its <glossterm>container</glossterm> and
-the ancestors of its container.</termdef>
-</para>
-
-<para><termdef xml:id="dt-subpipeline">Sibling steps and variables (and the
-connections between them) form a
-<firstterm>subpipeline</firstterm>.</termdef> <termdef
-xml:id="dt-last-step">The <firstterm>last step</firstterm> in a
-subpipeline is its last step in document order.</termdef></para>
+      <para>
+        <termdef xml:id="dt-subpipeline">Sibling steps and variables (and the connections between
+          them) form a <firstterm>subpipeline</firstterm>.</termdef>
+        <termdef xml:id="dt-last-step">The <firstterm>last step</firstterm> in a subpipeline is its
+          last step in document order.</termdef>
+      </para>
 
       <para xml:id="p.subpipeline"
         role="element-syntax element-syntax-language-construct hanging-indent">
@@ -278,18 +249,17 @@ subpipeline is its last step in document order.</termdef></para>
           xlink:href="#p.atomic"><replaceable>pfx:user-pipeline</replaceable></code>)+ </para>
 
       <note xml:id="note-udp">
-        <para>When a user-defined pipeline is invoked, (identified
-        with <code><replaceable>pfx:user-pipeline</replaceable></code>
-        in the preceding syntax summary) it appears as an atomic step.
-        A pipeline <emphasis>declaration</emphasis> may contain a
-        subpipeline, but the invocation of that pipeline is atomic and
-        does not contain a subpipeline.</para>
+        <para>When a user-defined pipeline is invoked, (identified with
+              <code><replaceable>pfx:user-pipeline</replaceable></code> in the preceding syntax
+          summary) it appears as an atomic step. A pipeline <emphasis>declaration</emphasis> may
+          contain a subpipeline, but the invocation of that pipeline is atomic and does not contain
+          a subpipeline.</para>
       </note>
       <para>Steps have “ports” into which inputs and outputs are connected. Each step has a number
         of input ports and a number of output ports; a step can have zero input ports and/or zero
-        output ports. The names of all ports on each step must be
-        unique on that step (you can't have two input ports named “source”, nor can you have an
-        input port named “schema” and an output port named “schema”). </para>
+        output ports. The names of all ports on each step must be unique on that step (you can't
+        have two input ports named “source”, nor can you have an input port named “schema” and an
+        output port named “schema”). </para>
       <para>A Step may have zero or more <link linkend="options">options</link>, all with unique
         names.</para>
       <para>All of the different instances of steps (atomic or compound) in a pipeline can be
@@ -298,21 +268,22 @@ subpipeline is its last step in document order.</termdef></para>
       <section xml:id="step-names">
         <title>Step names</title>
         <para>The <tag class="attribute">name</tag> attribute on any step can be used to give it a
-          name. <assert xml:id="unique-names">The name <rfc2119>must</rfc2119> be unique within its scope, see <xref linkend="scoping"/>.</assert></para>
+          name. <assert xml:id="unique-names">The name <rfc2119>must</rfc2119> be unique within its
+            scope, see <xref linkend="scoping"/>.</assert></para>
         <para>If the pipeline author does not provide an explicit name, the processor manufactures a
           default name. All default names are of the form
             “<literal>!1</literal><replaceable>.m</replaceable><replaceable>.n</replaceable>…” where
             “<replaceable>m</replaceable>” is the position (in the sense of counting sibling
           elements) of the step's highest ancestor element within the pipeline document or library
           which contains it, “<replaceable>n</replaceable>” is the position of the next-highest
-          ancestor, and so on, including all of the elements in the pipeline document
-(that were not <glossterm>effectively excluded</glossterm>). For example, consider the
-          pipeline in <xref linkend="ex2"/>. The <tag>p:declare-step</tag> step has no name, so it gets
-          the default name “<literal>!1</literal>”; the <tag>p:choose</tag> gets the name
+          ancestor, and so on, including all of the elements in the pipeline document (that were not
+            <glossterm>effectively excluded</glossterm>). For example, consider the pipeline in
+            <xref linkend="ex2"/>. The <tag>p:declare-step</tag> step has no name, so it gets the
+          default name “<literal>!1</literal>”; the <tag>p:choose</tag> gets the name
             “<literal>!1.1</literal>”; the first <tag>p:when</tag> gets the name
             “<literal>!1.1.1</literal>”; the <tag>p:otherwise</tag> gets the name
-            “<literal>!1.1.2</literal>”, etc. If the <tag>p:choose</tag> had a name, it would
-          not have received a default name, but it would still have been counted and its first
+            “<literal>!1.1.2</literal>”, etc. If the <tag>p:choose</tag> had a name, it would not
+          have received a default name, but it would still have been counted and its first
             <tag>p:when</tag> would still have been “<literal>!1.1.1</literal>”.</para>
         <para>Providing every step in the pipeline with an interoperable name has several
           benefits:</para>
@@ -330,44 +301,40 @@ subpipeline is its last step in document order.</termdef></para>
         <para>In a valid pipeline that runs successfully to completion, the manufactured names
           aren't visible (except perhaps in debugging or logging output).</para>
 
-<note xml:id="def-name-ncname">
-<para>The format for defaulted names does not conform to the
-requirements of an
-<link xlink:href="http://www.w3.org/TR/xml-names/#NT-NCName">NCName</link>.
-This is an explicit design decision; it prevents pipelines from using
-the defaulted names on <tag>p:pipe</tag> elements. If an explicit
-connection requires a step name, the pipeline author must name
-the step.
-</para>
-</note>
+        <note xml:id="def-name-ncname">
+          <para>The format for defaulted names does not conform to the requirements of an <link
+              xlink:href="http://www.w3.org/TR/xml-names/#NT-NCName">NCName</link>. This is an
+            explicit design decision; it prevents pipelines from using the defaulted names on
+              <tag>p:pipe</tag> elements. If an explicit connection requires a step name, the
+            pipeline author must name the step. </para>
+        </note>
 
       </section>
     </section>
   </section>
 
-<section xml:id="documents">
-<title>Documents</title>
+  <section xml:id="documents">
+    <title>Documents</title>
 
     <para>An XProc pipeline processes documents. <termdef xml:id="dt-document">A
           <firstterm>document</firstterm> is a <glossterm>representation</glossterm> and its
           <glossterm>document properties</glossterm>.</termdef>. <termdef xml:id="dt-representation"
         >A <firstterm>representation</firstterm> is a data structure used by an XProc processor to
         refer to the actual document content.</termdef></para>
-  
-  <para>An output port may have several connections. In this case the document(s) that
-    appear on that port are sent to each of the connections. In principle, a distinct
-    copy of each document is sent to each connection. Critically, any changes made to one
-    copy <rfc2119>must not</rfc2119> be visible in any other copy. In the interest of efficiency,
-    if an implementation can isolate such changes, it is not required to make actual copies.
-  </para>
+
+    <para>An output port may have several connections. In this case the document(s) that appear on
+      that port are sent to each of the connections. In principle, a distinct copy of each document
+      is sent to each connection. Critically, any changes made to one copy <rfc2119>must
+        not</rfc2119> be visible in any other copy. In the interest of efficiency, if an
+      implementation can isolate such changes, it is not required to make actual copies. </para>
 
     <section xml:id="document-properties">
       <title>Document Properties</title>
 
-<para>Documents have associated with them a set of properties.
-<termdef xml:id="dt-document-properties">The <firstterm>document
-properties</firstterm> are key/value pairs; they are exposed to the
-XProc pipeline as a map (<code>map(xs:QName, item()*)</code>).</termdef></para>
+      <para>Documents have associated with them a set of properties. <termdef
+          xml:id="dt-document-properties">The <firstterm>document properties</firstterm> are
+          key/value pairs; they are exposed to the XProc pipeline as a map (<code>map(xs:QName,
+            item()*)</code>).</termdef></para>
 
       <para>Several properties are defined by this specification:</para>
 
@@ -389,10 +356,10 @@ XProc pipeline as a map (<code>map(xs:QName, item()*)</code>).</termdef></para>
             <code>base-uri</code>
           </term>
           <listitem>
-            <para>The value of the (optional) “<code>base-uri</code>” property identifies the base URI of the
-              document. If no such key is present, the document has no base URI. The processor is
-              responsible for assuring that the <code>base-uri</code> property matches the base URI
-              of each document produced on every output port.</para>
+            <para>The value of the (optional) “<code>base-uri</code>” property identifies the base
+              URI of the document. If no such key is present, the document has no base URI. The
+              processor is responsible for assuring that the <code>base-uri</code> property matches
+              the base URI of each document produced on every output port.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -400,13 +367,14 @@ XProc pipeline as a map (<code>map(xs:QName, item()*)</code>).</termdef></para>
             <code>serialization</code>
           </term>
           <listitem>
-            <para>The value of the (optional) “<code>serialization</code>” property holds serialization
-              properties for the document. If present, it's value <rfc2119>must</rfc2119> be of type
-                <code>map(xs:QName, item()*)</code>. <error code="D0070">It is a <glossterm>dynamic
-                  error</glossterm> if a value is assigned to the <code>serialization</code>
-                document property that is not of type <code>map(xs:QName, item()*)</code>.</error>
-              Serialization properties control XML serialization as defined by <biblioref
-                linkend="xml-serialization-31"/>. See also <xref linkend="serialization"/>. </para>
+            <para>The value of the (optional) “<code>serialization</code>” property holds
+              serialization properties for the document. If present, it's value
+                <rfc2119>must</rfc2119> be of type <code>map(xs:QName, item()*)</code>. <error
+                code="D0070">It is a <glossterm>dynamic error</glossterm> if a value is assigned to
+                the <code>serialization</code> document property that is not of type
+                  <code>map(xs:QName, item()*)</code>.</error> Serialization properties control XML
+              serialization as defined by <biblioref linkend="xml-serialization-31"/>. See also
+                <xref linkend="serialization"/>. </para>
             <para>Some steps, like <code>p:xslt</code> and <code>p:xquery</code>, can specify
               serialization properties (for instance using an XSLT <tag>xsl:output</tag> element).
               If this is the case, the specified serialization properties <rfc2119>should</rfc2119>
@@ -414,220 +382,196 @@ XProc pipeline as a map (<code>map(xs:QName, item()*)</code>).</termdef></para>
               appropriate serialization properties map.</para>
             <para>If a step serializes a document whose document properties contain a
                 <code>serialization</code> property, it <rfc2119>must</rfc2119> use these
-              serialization properties. If the step itself allows specification of serialization properties
-              (usually by a <option>serialization</option> option), both sets of serialization
-              properties are merged. Serialization properties specified on the step itself have
-              precedence over serialization properties specified with the <code>serialization</code>
-              document property.</para>
+              serialization properties. If the step itself allows specification of serialization
+              properties (usually by a <option>serialization</option> option), both sets of
+              serialization properties are merged. Serialization properties specified on the step
+              itself have precedence over serialization properties specified with the
+                <code>serialization</code> document property.</para>
           </listitem>
         </varlistentry>
       </variablelist>
 
       <para>Other property keys may also be present, including user defined properties.</para>
 
-<para>Steps are responsible for describing how document properties are
-transformed as documents flow through them. Many steps claim that the
-specified properties are preserved. Generally, it is the
-responsibility of the pipeline author to determine when this is
-inapropriate and take corrective action. However, it is the
-responsibility of the pipeline processor to assure that the
-<code>content-type</code> property is correct. If a step transforms a
-document in a manner that is inconsistent with the
-<code>content-type</code> property (accepting an XML document on the
-source port but producing a text document on the result, for example), the
-processor must assure that the <code>content-type</code> property is appropriate.
-If a step changes the <code>content-type</code> in this way, it <rfc2119>must</rfc2119> also
-remove the <code>serialization</code> property
-</para>
+      <para>Steps are responsible for describing how document properties are transformed as
+        documents flow through them. Many steps claim that the specified properties are preserved.
+        Generally, it is the responsibility of the pipeline author to determine when this is
+        inapropriate and take corrective action. However, it is the responsibility of the pipeline
+        processor to assure that the <code>content-type</code> property is correct. If a step
+        transforms a document in a manner that is inconsistent with the <code>content-type</code>
+        property (accepting an XML document on the source port but producing a text document on the
+        result, for example), the processor must assure that the <code>content-type</code> property
+        is appropriate. If a step changes the <code>content-type</code> in this way, it
+          <rfc2119>must</rfc2119> also remove the <code>serialization</code> property </para>
 
     </section>
 
-<section xml:id="document-types">
-<title>Document Types</title>
+    <section xml:id="document-types">
+      <title>Document Types</title>
 
-<para>XProc 3.0 has been designed to make it possible to process any kind of
-document. Each document has a representation in the <biblioref linkend="xpath-datamodel"/>.
-This is necessary so that any kind of document can be passed as an argument to XPath functions,
-such as <tag>p:document-properties</tag>.
-Practically speaking, there are five kinds of documents:</para>
+      <para>XProc 3.0 has been designed to make it possible to process any kind of document. Each
+        document has a representation in the <biblioref linkend="xpath-datamodel"/>. This is
+        necessary so that any kind of document can be passed as an argument to XPath functions, such
+        as <tag>p:document-properties</tag>. Practically speaking, there are five kinds of
+        documents:</para>
 
-<orderedlist>
-<listitem>
-<para><link linkend="xml-documents">XML documents</link>
-</para>
-</listitem>
-<listitem>
-<para><link linkend="html-documents">HTML documents</link>
-</para>
-</listitem>
-<listitem>
-<para><link linkend="text-documents">Text documents</link>
-</para>
-</listitem>
-<listitem>
-<para><link linkend="json-documents">JSON documents</link>
-</para>
-</listitem>
-<listitem>
-<para><link linkend="other-documents">Other documents</link>
-</para>
-</listitem>
-</orderedlist>
+      <orderedlist>
+        <listitem>
+          <para>
+            <link linkend="xml-documents">XML documents</link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="html-documents">HTML documents</link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="text-documents">Text documents</link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="json-documents">JSON documents</link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="other-documents">Other documents</link>
+          </para>
+        </listitem>
+      </orderedlist>
 
-<section xml:id="xml-documents">
-<title>XML Documents</title>
+      <section xml:id="xml-documents">
+        <title>XML Documents</title>
 
-<para>Representations of XML documents are general instances of the XDM.
-They are documents that contain a mixture
-of other node types (elements, text, comments, and processing
-instructions). This definition is intentionally broader than the
-definition of a well-formed XML document because it is often
-convenient for intermediate stages in a pipeline to produce
-more-or-less arbitrary fragments of XML that can be combined together
-by later stages.
-XML documents are identified by an XML media type.
-<termdef xml:id="dt-XML-media-type">The
-“<literal>application/xml</literal>” and “<literal>text/xml</literal>
-media types and all media types of the form
-“<literal><replaceable>something</replaceable>/<replaceable>something</replaceable>+xml</literal>”
-(except for “<literal>application/xhtml+xml</literal>” which is explicitly
-an <glossterm>HTML media type</glossterm>)
-are <firstterm baseform="XML media type">XML media types</firstterm>.
-</termdef>
-</para>
+        <para>Representations of XML documents are general instances of the XDM. They are documents
+          that contain a mixture of other node types (elements, text, comments, and processing
+          instructions). This definition is intentionally broader than the definition of a
+          well-formed XML document because it is often convenient for intermediate stages in a
+          pipeline to produce more-or-less arbitrary fragments of XML that can be combined together
+          by later stages. XML documents are identified by an XML media type. <termdef
+            xml:id="dt-XML-media-type">The “<literal>application/xml</literal>” and
+              “<literal>text/xml</literal> media types and all media types of the form
+                “<literal><replaceable>something</replaceable>/<replaceable>something</replaceable>+xml</literal>”
+            (except for “<literal>application/xhtml+xml</literal>” which is explicitly an
+              <glossterm>HTML media type</glossterm>) are <firstterm baseform="XML media type">XML
+              media types</firstterm>. </termdef>
+        </para>
 
-<para>In order to be consistent with the XPath data model, all general
-and external parsed entities <rfc2119>must</rfc2119> be fully expanded
-in XML documents; they <rfc2119>must not</rfc2119> contain any representation of
-<biblioref linkend="xml-infoset-rec"/>
-<literal role="infoset-property">unexpanded entity reference
-information items</literal>.</para>
+        <para>In order to be consistent with the XPath data model, all general and external parsed
+          entities <rfc2119>must</rfc2119> be fully expanded in XML documents; they <rfc2119>must
+            not</rfc2119> contain any representation of <biblioref linkend="xml-infoset-rec"/>
+          <literal role="infoset-property">unexpanded entity reference information
+          items</literal>.</para>
 
-<para><impl>The level of support for typed values in XDM instances
-in an XProc pipeline is <glossterm>implementation-defined</glossterm>.</impl>
-</para>
+        <para>
+          <impl>The level of support for typed values in XDM instances in an XProc pipeline is
+              <glossterm>implementation-defined</glossterm>.</impl>
+        </para>
 
-<para>When an XML document is serialized, it <rfc2119>should</rfc2119>
-be serialized using the XML serializer (see <xref
-linkend="xml-serialization-31"/>) by default.
-</para>
-</section>
+        <para>When an XML document is serialized, it <rfc2119>should</rfc2119> be serialized using
+          the XML serializer (see <xref linkend="xml-serialization-31"/>) by default. </para>
+      </section>
 
-<section xml:id="html-documents">
-<title>HTML Documents</title>
+      <section xml:id="html-documents">
+        <title>HTML Documents</title>
 
-<para>Representations of HTML documents are general instances of the XDM.
-Within XProc, they are <link linkend="xml-documents">XML documents</link>.
-HTML documents are identified by an HTML media type.
-<termdef xml:id="dt-HTML-media-type">The
-  “<literal>text/html</literal>” and “<literal>application/xhtml+xml</literal>”
-media types
-are <firstterm baseform="HTML media type">HTML media types</firstterm>.
-</termdef>
-</para>
+        <para>Representations of HTML documents are general instances of the XDM. Within XProc, they
+          are <link linkend="xml-documents">XML documents</link>. HTML documents are identified by
+          an HTML media type. <termdef xml:id="dt-HTML-media-type">The
+            “<literal>text/html</literal>” and “<literal>application/xhtml+xml</literal>” media
+            types are <firstterm baseform="HTML media type">HTML media types</firstterm>. </termdef>
+        </para>
 
-<para>The distinction between XML documents and HTML documents is apparent
-in two places:</para>
+        <para>The distinction between XML documents and HTML documents is apparent in two
+          places:</para>
 
-<orderedlist>
-<listitem>
-<para>When an HTML document is <emphasis>parsed</emphasis>, for example when it
-is the result of querying a web service or is loaded from a file on disk, an
-HTML parser <rfc2119>must</rfc2119> be used. An HTML parser will construct a
-balanced tree even if the HTML document would not be seen as
-well-formed XML if it was parsed by an XML parser.  An HTML parser may also
-add elements not found in the original (for example table body elements inside tables).
-</para>
-<note xml:id="inline-html">
-<para>The HTML parsing rules only apply when the content is parsed. HTML content
-in an unencoded <tag>p:inline</tag> must be well-formed XML (because it is literally
-in the pipeline) and will not be transformed in any way.</para>
-</note>
-</listitem>
-<listitem>
-<para>When an HTML document is serialized, it <rfc2119>should</rfc2119> be serialized using the
-  HTML serializer for documents with media type “<literal>text/html</literal>” and the
-  XHTML serializer for those with media type “<literal>application/xhtml+xml</literal>” 
-  (see <xref linkend="xml-serialization-31"/>) by default.
-</para>
-</listitem>
-</orderedlist>
-</section>
+        <orderedlist>
+          <listitem>
+            <para>When an HTML document is <emphasis>parsed</emphasis>, for example when it is the
+              result of querying a web service or is loaded from a file on disk, an HTML parser
+                <rfc2119>must</rfc2119> be used. An HTML parser will construct a balanced tree even
+              if the HTML document would not be seen as well-formed XML if it was parsed by an XML
+              parser. An HTML parser may also add elements not found in the original (for example
+              table body elements inside tables). </para>
+            <note xml:id="inline-html">
+              <para>The HTML parsing rules only apply when the content is parsed. HTML content in an
+                unencoded <tag>p:inline</tag> must be well-formed XML (because it is literally in
+                the pipeline) and will not be transformed in any way.</para>
+            </note>
+          </listitem>
+          <listitem>
+            <para>When an HTML document is serialized, it <rfc2119>should</rfc2119> be serialized
+              using the HTML serializer for documents with media type “<literal>text/html</literal>”
+              and the XHTML serializer for those with media type
+                “<literal>application/xhtml+xml</literal>” (see <xref linkend="xml-serialization-31"
+              />) by default. </para>
+          </listitem>
+        </orderedlist>
+      </section>
 
-<section xml:id="text-documents">
-<title>Text Documents</title>
+      <section xml:id="text-documents">
+        <title>Text Documents</title>
 
-<para>Representations of text documents are XDM documents that contain a single text node.
-Text documents are identified by a
-text media type.
-<termdef xml:id="dt-text-media-type">Media types of the form
-“<literal>text/<replaceable>something</replaceable></literal>”
-are <firstterm baseform="text media type">text media types</firstterm> with the
-exception of “<literal>text/xml</literal>” which is an XML media type,
-and “<literal>text/html</literal>” which is an HTML media type. Additionally the
-  media types “<literal>application/javascript</literal>”, 
-“<literal>application/relax-ng-compact-syntax</literal>”, and
-“<literal>application/xquery</literal>” are also text media types.
-</termdef> <impl>It is <glossterm>implementation-defined</glossterm>
-whether other media types not mentioned in this document are treated
-as text media types as well.</impl>
-</para>
+        <para>Representations of text documents are XDM documents that contain a single text node.
+          Text documents are identified by a text media type. <termdef xml:id="dt-text-media-type"
+            >Media types of the form “<literal>text/<replaceable>something</replaceable></literal>”
+            are <firstterm baseform="text media type">text media types</firstterm> with the
+            exception of “<literal>text/xml</literal>” which is an XML media type, and
+              “<literal>text/html</literal>” which is an HTML media type. Additionally the media
+            types “<literal>application/javascript</literal>”,
+              “<literal>application/relax-ng-compact-syntax</literal>”, and
+              “<literal>application/xquery</literal>” are also text media types. </termdef>
+          <impl>It is <glossterm>implementation-defined</glossterm> whether other media types not
+            mentioned in this document are treated as text media types as well.</impl>
+        </para>
 
-<para>When a text document is serialized, it <rfc2119>should</rfc2119> be serialized using the
-Text serializer (see <xref linkend="xml-serialization-31"/>) by default.</para>
+        <para>When a text document is serialized, it <rfc2119>should</rfc2119> be serialized using
+          the Text serializer (see <xref linkend="xml-serialization-31"/>) by default.</para>
 
-</section>
+      </section>
 
-<section xml:id="json-documents">
-<title>JSON Documents</title>
+      <section xml:id="json-documents">
+        <title>JSON Documents</title>
 
-<para>Representations of JSON documents are instances of the XDM.
-They are maps, arrays, or
-atomic values.
-JSON documents are identified by a
-JSON media type.
-<termdef xml:id="dt-JSON-media-type">The
-“<literal>application/json</literal>”
-media type and all media types of the form
-“<literal>application/<replaceable>something</replaceable>+json</literal>”
-are <firstterm baseform="JSON media type">JSON media types</firstterm>.
-</termdef>
-</para>
+        <para>Representations of JSON documents are instances of the XDM. They are maps, arrays, or
+          atomic values. JSON documents are identified by a JSON media type. <termdef
+            xml:id="dt-JSON-media-type">The “<literal>application/json</literal>” media type and all
+            media types of the form
+              “<literal>application/<replaceable>something</replaceable>+json</literal>” are
+              <firstterm baseform="JSON media type">JSON media types</firstterm>. </termdef>
+        </para>
 
-<note xml:id="json-documents-xdm" role="editorial">
-<title>Editorial Note</title>
-<para>This definition doesn’t say that JSON documents are represented by
-<emphasis>document nodes</emphasis> that contain something (because document nodes
-can’t contain maps or arrays). Can we get away with that?</para>
-</note>
+        <note xml:id="json-documents-xdm" role="editorial">
+          <title>Editorial Note</title>
+          <para>This definition doesn’t say that JSON documents are represented by
+              <emphasis>document nodes</emphasis> that contain something (because document nodes
+            can’t contain maps or arrays). Can we get away with that?</para>
+        </note>
 
-<para>When a JSON document is serialized, it <rfc2119>should</rfc2119> be serialized using the
-JSON serializer (see <xref linkend="xml-serialization-31"/>) by default.</para>
-</section>
+        <para>When a JSON document is serialized, it <rfc2119>should</rfc2119> be serialized using
+          the JSON serializer (see <xref linkend="xml-serialization-31"/>) by default.</para>
+      </section>
 
-<section xml:id="other-documents">
-<title>Other documents</title>
+      <section xml:id="other-documents">
+        <title>Other documents</title>
 
-<para>Representations of other kinds of documents are empty XDM documents.
-<impl>The <emphasis>underlying</emphasis> representations of other
-kinds of documents are
-<glossterm>implementation-dependent</glossterm>.</impl>
-Other kinds of documents are identified by media types that are not
-<glossterm baseform="XML media type">XML media types</glossterm>,
-<glossterm baseform="HTML media type">HTML media types</glossterm>,
-<glossterm baseform="text media type">text media types</glossterm>,
-or
-<glossterm baseform="JSON media type">JSON media types</glossterm>.
-</para>
+        <para>Representations of other kinds of documents are empty XDM documents. <impl>The
+              <emphasis>underlying</emphasis> representations of other kinds of documents are
+              <glossterm>implementation-dependent</glossterm>.</impl> Other kinds of documents are
+          identified by media types that are not <glossterm baseform="XML media type">XML media
+            types</glossterm>, <glossterm baseform="HTML media type">HTML media types</glossterm>,
+            <glossterm baseform="text media type">text media types</glossterm>, or <glossterm
+            baseform="JSON media type">JSON media types</glossterm>. </para>
 
-<para><impl>Serialization of other kinds of documents is
-<glossterm>implementation-defined</glossterm>.</impl> The stored
-sequence of octets <rfc2119>should</rfc2119> be consistent with the
-media type: an <code>image/png</code> image should be a PNG image,
-etc.
-</para>
-</section>
-</section>
+        <para><impl>Serialization of other kinds of documents is
+              <glossterm>implementation-defined</glossterm>.</impl> The stored sequence of octets
+            <rfc2119>should</rfc2119> be consistent with the media type: an <code>image/png</code>
+          image should be a PNG image, etc. </para>
+      </section>
+    </section>
 
     <section>
       <title>Creating documents from XDM step results</title>
@@ -656,555 +600,532 @@ etc.
       </itemizedlist>
     </section>
 
-<section xml:id="specified-content-types">
-<title>Specifying content types</title>
+    <section xml:id="specified-content-types">
+      <title>Specifying content types</title>
 
-<para>In some contexts (step inputs, and step outputs, for example), 
-XProc allows the pipeline author to specify a
-list of content types to identify what kinds of documents are allowed.
-Each content type in this list must have one of the following
-forms:</para>
+      <para>In some contexts (step inputs, and step outputs, for example), XProc allows the pipeline
+        author to specify a list of content types to identify what kinds of documents are allowed.
+        Each content type in this list must have one of the following forms:</para>
 
-<itemizedlist>
-<listitem>
-<para>A fully qualified type of the form
-“<literal><replaceable>type</replaceable>/<replaceable>subtype</replaceable>+<replaceable>ext</replaceable></literal>”
-where “<literal>+<replaceable>ext</replaceable></literal>” is optional and any of <replaceable>type</replaceable>,
-<replaceable>subtype</replaceable>, and <replaceable>ext</replaceable>
-can be specified as “<literal>*</literal>” meaning “any”.
-For example:
-<literal>text/plain</literal> (only plain text documents),
-<literal>text/*</literal> (any “text” content type),
-<literal>*/*+xml</literal> (any “+xml” content type),
-and <literal>*/*</literal> (any content type).
-</para>
-</listitem>
-<listitem>
-<para>A fully qualified type preceded by a minus sign (“-”) indicates that the specified type is forbidden.
-For example:
-<literal>-image/svg</literal> forbids SVG images,
-<literal>-text/*</literal> forbids “text” content types,
-and <literal>-text/html</literal> forbids HTML documents.
-</para>
-</listitem>
-<listitem>
-<para>A single token (without a “/”), is considered a shortcut form.
-The following shortcuts <rfc2119>must</rfc2119> be supported by the processor:</para>
-<variablelist>
-<varlistentry><term><literal>xml</literal></term>
-<listitem>
-<para>Expands to “<literal>application/xml text/xml */*+xml -application/xhtml+xml</literal>”.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><literal>html</literal></term>
-<listitem>
-<para>Expands to “<literal>text/html application/xhtml+xml</literal>”.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><literal>text</literal></term>
-<listitem>
-<para>Expands to: “<literal>text/* -text/html -text/xml</literal>”.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><literal>json</literal></term>
-<listitem>
-<para>Expands to “<literal>application/json</literal>”.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><literal>any</literal></term>
-<listitem>
-<para>Expands to “<literal>*/*</literal>”.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
-</listitem>
-</itemizedlist>
+      <itemizedlist>
+        <listitem>
+          <para>A fully qualified type of the form
+                “<literal><replaceable>type</replaceable>/<replaceable>subtype</replaceable>+<replaceable>ext</replaceable></literal>”
+            where “<literal>+<replaceable>ext</replaceable></literal>” is optional and any of
+              <replaceable>type</replaceable>, <replaceable>subtype</replaceable>, and
+              <replaceable>ext</replaceable> can be specified as “<literal>*</literal>” meaning
+            “any”. For example: <literal>text/plain</literal> (only plain text documents),
+              <literal>text/*</literal> (any “text” content type), <literal>*/*+xml</literal> (any
+            “+xml” content type), and <literal>*/*</literal> (any content type). </para>
+        </listitem>
+        <listitem>
+          <para>A fully qualified type preceded by a minus sign (“-”) indicates that the specified
+            type is forbidden. For example: <literal>-image/svg</literal> forbids SVG images,
+              <literal>-text/*</literal> forbids “text” content types, and
+              <literal>-text/html</literal> forbids HTML documents. </para>
+        </listitem>
+        <listitem>
+          <para>A single token (without a “/”), is considered a shortcut form. The following
+            shortcuts <rfc2119>must</rfc2119> be supported by the processor:</para>
+          <variablelist>
+            <varlistentry>
+              <term>
+                <literal>xml</literal>
+              </term>
+              <listitem>
+                <para>Expands to “<literal>application/xml text/xml */*+xml
+                    -application/xhtml+xml</literal>”. </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <literal>html</literal>
+              </term>
+              <listitem>
+                <para>Expands to “<literal>text/html application/xhtml+xml</literal>”. </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <literal>text</literal>
+              </term>
+              <listitem>
+                <para>Expands to: “<literal>text/* -text/html -text/xml</literal>”. </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <literal>json</literal>
+              </term>
+              <listitem>
+                <para>Expands to “<literal>application/json</literal>”. </para>
+              </listitem>
+            </varlistentry>
+            <varlistentry>
+              <term>
+                <literal>any</literal>
+              </term>
+              <listitem>
+                <para>Expands to “<literal>*/*</literal>”. </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </listitem>
+      </itemizedlist>
 
-<para><impl>It is <glossterm>implementation-defined</glossterm> if a processor accepts any other content type shortcuts.</impl>
-<error code="S0111">It is a <glossterm>static error</glossterm> if an unrecognized content type shortcut is specified.</error>
-</para>
+      <para>
+        <impl>It is <glossterm>implementation-defined</glossterm> if a processor accepts any other
+          content type shortcuts.</impl>
+        <error code="S0111">It is a <glossterm>static error</glossterm> if an unrecognized content
+          type shortcut is specified.</error>
+      </para>
 
-<para>To determine if a document is acceptable, the (expanded) list of
-content types is considered from left to right. If the actual content
-type matches an acceptable content type, the document is acceptable.
-If it matches a forbidden content type, then it is not. A content type
-that isn’t matched is ignored. The document is considered acceptable
-if and only if it matches at least one acceptable content type
-and the last content type that matched was not forbidden.</para>
+      <para>To determine if a document is acceptable, the (expanded) list of content types is
+        considered from left to right. If the actual content type matches an acceptable content
+        type, the document is acceptable. If it matches a forbidden content type, then it is not. A
+        content type that isn’t matched is ignored. The document is considered acceptable if and
+        only if it matches at least one acceptable content type and the last content type that
+        matched was not forbidden.</para>
 
-<para>For example: a document with the content type “<literal>image/svg</literal>” is acceptable if the content type list expands
-to “<literal>image/* application/xml</literal>” but it is not acceptable if the content type list expands
-to “<literal>image/* -image/svg</literal>”. (Note that order matters; the document would be considered acceptable
-if the content type list expands to “<literal>-image/svg image/*</literal>”.)
-</para>
+      <para>For example: a document with the content type “<literal>image/svg</literal>” is
+        acceptable if the content type list expands to “<literal>image/* application/xml</literal>”
+        but it is not acceptable if the content type list expands to “<literal>image/*
+          -image/svg</literal>”. (Note that order matters; the document would be considered
+        acceptable if the content type list expands to “<literal>-image/svg image/*</literal>”.) </para>
 
-<para>In the particular case of shortcut values, note that “<literal>application/xhtml+xml</literal>” is acceptable if the
-content type list is “<literal>xml html</literal>” but not if it is “<literal>html xml</literal>”.</para>
-<para><error code="D0038">It is a <glossterm>dynamic error</glossterm>
-if an input document arrives on a port and it does not match the
-allowed content types.</error></para>
+      <para>In the particular case of shortcut values, note that
+          “<literal>application/xhtml+xml</literal>” is acceptable if the content type list is
+          “<literal>xml html</literal>” but not if it is “<literal>html xml</literal>”.</para>
+      <para>
+        <error code="D0038">It is a <glossterm>dynamic error</glossterm> if an input document
+          arrives on a port and it does not match the allowed content types.</error>
+      </para>
 
-</section>
-
-</section>
-
-<section xml:id="input-output">
-<title>Inputs and Outputs</title>
-
-<para>Most steps have one or more inputs and one
-or more outputs. <xref linkend="fig-atomic-step"/> illustrates
-symbolically an <glossterm>atomic step</glossterm> with two inputs and
-one output.</para>
-
-      <figure xml:id="fig-atomic-step">
-        <title>An atomic step</title>
-        <mediaobject>
-          <alt>An atomic step with two inputs and one output</alt>
-          <imageobject>
-            <imagedata fileref="graphics/atomic-step.png"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-
-<para>All atomic steps are defined by a <tag>p:declare-step</tag>. The
-declaration of an atomic step type defines the input ports, output
-ports, and options of all steps of that type. For example, every
-<tag>p:validate-with-xml-schema</tag> step has two inputs, named
-“<literal>source</literal>” and “<literal>schema</literal>”, one
-output named “<literal>result</literal>”, and the same set of options.
-</para>
-      <para>Like atomic steps, top level, user-defined pipelines also have declarations.</para>
-
-<para>The
-        situation is slightly more complicated for the other compound steps because they don't have
-        separate declarations; each instance of the compound step serves as its own declaration. On
-        these compound steps, the number and names of the outputs can be different on each instance
-        of the step.</para>
-      <para><xref linkend="fig-compound-step"/> illustrates symbolically a compound step with a
-        subpipeline with one output. As you can see from the diagram, the output from the compound
-        step comes from one of the outputs of the subpipeline within the step.</para>
-      <figure xml:id="fig-compound-step">
-        <title>A compound step</title>
-        <mediaobject>
-          <alt>A compound step with two inputs and one output</alt>
-          <imageobject>
-            <imagedata fileref="graphics/compound-step.png"/>
-          </imageobject>
-        </mediaobject>
-      </figure>
-      <para><termdef xml:id="dt-declared-inputs">The input ports declared on a step are its
-            <firstterm>declared inputs</firstterm>.</termdef>
-        <termdef xml:id="dt-declared-outputs">The output ports declared on a step are its
-            <firstterm>declared outputs</firstterm>.</termdef> When a step is used in a pipeline, it
-        is connected to other steps through its inputs and outputs. </para>
-
-         <para>When a step is used, all of the <glossterm>declared inputs</glossterm> of the step
-               <rfc2119>must</rfc2119> be connected. Each connection binds the input to a data
-            source (see <xref linkend="connections"/>). <error
-               code="S0003">It is a <glossterm>static error</glossterm> if any declared input is not
-               connected.</error></para>
-         <para>The <glossterm>declared outputs</glossterm> of a step are only connected when they
-            are used by another step or expression. 
-Any documents produced on an unconnected output port are discarded.</para>
-
-<para>Primary input and primary output ports may be implicitly
-connected if no explicit connection is given, see <xref
-linkend="primary-input-output"/>.</para>
-
-<para>Output ports on compound steps have a dual nature: from the
-perspective of the compound step's siblings, its outputs are just
-ordinary outputs and can be connected the same as other
-<glossterm>declared outputs</glossterm>. From the perspective of the
-subpipeline inside the compound step, they behave like inputs and can
-be connected just like other inputs.</para>
-
-<para>Within a compound step, the <glossterm>declared
-outputs</glossterm> of the step can be connected to any of the various
-available outputs of <glossterm baseform="contained steps">contained
-steps</glossterm> as well as other data sources
-(see <xref linkend="connections"/>). If a (non-primary)
-output port of a compound step is left unconnected, it produces an
-empty sequence of documents from the perspective of its
-siblings.</para>
-
-      <para>Each input and output on a step is declared to accept or produce either a single
-        document or a sequence of documents. It <emphasis>is not</emphasis> an error to connect a
-        port that is declared to produce a sequence of documents to a port that is declared to
-        accept only a single document. It is, however, an error if the former step does not
-        produce exactly one document at run time.</para>
-      <para>It is also not an error to connect a port that is declared to produce a single document
-        to a port that is declared to accept a sequence. A single document is the same as a sequence
-        of one document.</para>
-      <para>An output port may have more than one connection: it may be connected to more than one
-        input port, more than one of its container's output ports, or both. At runtime this will
-        result in the outputs being sent to each of those places.</para>
-      <para><termdef xml:id="dt-signature">The <firstterm>signature</firstterm> of a step is the set
-          of inputs, outputs, and options that it is declared to accept.</termdef> The declaration
-        for a step provides a fixed signature which all its instances share.</para>
-
-<note>
-<para>Within the context of what can be defined by XProc pipelines,
-step signatures are fixed and shared by all instances. There is no
-mechanism for a pipeline author to declare that an atomic step has a
-signature that varies. However, implementors may provide such
-mechanisms and other specifications may depend upon them. For example,
-the standard <tag>p:run</tag> step violates this constraint in that
-the name and number of its output ports depends on its inputs and may
-vary between invocations.
-</para>
-<para>Such steps are “magic” and XProc 3.0 makes no effort to provide
-a mechanism to define them.</para>
-</note>
-
-      <para><termdef xml:id="dt-matches">A step <firstterm>matches</firstterm> its signature if and
-          only if it specifies an input for each declared input, it specifies no inputs that are not
-          declared, it specifies an option for each option that is declared to be required, and it
-          specifies no options that are not declared.</termdef> In other words, every input and
-        required option <rfc2119>must</rfc2119> be specified and only inputs and options that are
-        declared <rfc2119>may</rfc2119> be specified. Options that aren't required do not have to be
-        specified.</para>
-      <para>Steps <rfc2119>may</rfc2119> also produce error, warning, and informative messages.
-        These messages are captured and provided on the <port>error</port> port inside of a
-          <tag>p:catch</tag>. <impl>Outside of a <link linkend="p.try">try/catch</link>, the
-          disposition of error messages is <glossterm>implementation-dependent</glossterm></impl>. </para>
-
-<para><impl>How inputs are connected to documents outside the pipeline
-is <glossterm>implementation-defined</glossterm>.</impl></para>
-
-<para><impl>How pipeline outputs are connected to documents outside
-the pipeline is
-<glossterm>implementation-defined</glossterm>.</impl></para>
-
-<para>Input ports <rfc2119>may</rfc2119> specify a content type, or list of
-content types, that they accept, se <xref linkend="specified-content-types"/>.</para>
-
-<section xml:id="external-docs">
-        <title>External Documents</title>
-        <para>It's common for some of the documents used in processing a pipeline to be read from
-          URIs. Sometimes this occurs directly, for example with a <tag>p:document</tag> element.
-          Sometimes it occurs indirectly, for example if an implementation allows the URI of a
-          pipeline input to be specified on the command line or if an <tag>p:xslt</tag> step
-          encounters an <tag>xsl:import</tag> in the stylesheet that it is processing. It's also
-          common for some of the documents produced in processing a pipeline to be written to
-          locations which have, or at least could have, a URI. </para>
-        <para>The process of dereferencing a URI to retrieve a document is often more interesting
-          than it seems at first. On the web, it may involve caches, proxies, and various forms of
-          indirection. <impl>Resolving a URI locally may involve resolvers of various sorts and
-            possibly appeal to <glossterm>implementation-dependent</glossterm> mechanisms such as
-            catalog files.</impl></para>
-        <para>In XProc, the situation is made even more interesting by the fact that many
-          intermediate results produced by steps in the pipeline have base URIs. <impl>Whether (and
-            when and how) or not the intermediate results that pass between steps are ever written
-            to a filesystem is <glossterm>implementation-dependent</glossterm>.</impl></para>
-        <para><impl>In Version 3.0 of XProc, how (or if) implementers provide local resolution
-            mechanisms and how (or if) they provide access to intermediate results by URI is
-              <glossterm>implementation-defined</glossterm>.</impl>
-        </para>
-        <para>Version 3.0 of XProc does not require implementations to guarantee that multiple
-          attempts to dereference the same URI always produce the same results.</para>
-        <note xml:id="note-unsatisfying">
-          <para>On the one hand, this is a somewhat unsatisfying state of affairs because it leaves
-            room for interoperability problems. On the other, it is not expected to cause such
-            problems very often in practice. </para>
-          <para>If these problems arise in practice, implementers are encouraged to use the existing
-            extension mechanisms to give users the control needed to circumvent them. Should such
-            mechanisms become widespread, a standard mechanism could be added in some future version
-            of the language.</para>
-        </note>
-      </section>
-    </section>
-    <section xml:id="primary-input-output">
-      <title>Primary Inputs and Outputs</title>
-      <para>Each step may have one input port designated as
-        the primary input port and one output port designated as the primary output port.</para>
-      <para><termdef xml:id="dt-primary-input-port">If a step has an input port which is
-          explicitly marked “<code>primary='true'</code>”, or if it has exactly one document input
-          port and that port is <emphasis>not</emphasis> explicitly marked
-            “<code>primary='false'</code>”, then that input port is the <firstterm>primary input
-            port</firstterm> of the step.</termdef> If a step has a single input port and that port
-        is explicitly marked “<code>primary='false'</code>”, or if a step has more than one input
-        port and none is explicitly marked as the primary, then the primary input port of that step
-        is undefined. A step can have at most one primary input port.</para>
-      <para><termdef xml:id="dt-primary-output-port">If a step has an output port which is
-          explicitly marked “<code>primary='true'</code>”, or if it has exactly one document output
-          port and that port is <emphasis>not</emphasis> explicitly marked
-            “<code>primary='false'</code>”, then that output port is the <firstterm>primary output
-            port</firstterm> of the step.</termdef> If a step has a single output port and that port
-        is explicitly marked “<code>primary='false'</code>”, or if a step has more than one output
-        port and none is explicitly marked as the primary, then the primary output port of that step
-        is undefined. A step can have at most one primary output port.</para>
-      <para>The special significance of primary input and output ports is that they are connected
-        automatically by the processor if no explicit connection is given. Generally speaking, if
-        two steps appear sequentially in a subpipeline, then the primary output of the first step
-        will automatically be connected to the primary input of the second.</para>
-
-<para>Additionally, if a container, that can have
-declared outputs, has no declared outputs and the
-<glossterm>last step</glossterm> in its subpipeline has an unconnected
-primary output, then an implicit primary output port will be added to
-the compound step (and consequently the last step's primary output
-will be connected to it). This implicit output port has no name. It
-inherits the <tag class="attribute">sequence</tag> and the <tag
-class="attribute">content-types</tag> properties of the port connected
-to it. This rule does not apply to <tag>p:declare-step</tag>; step
-declarations must provide explicit names for all of their
-outputs.</para>
-
-</section>
-
-<section xml:id="connections">
-<title>Connections</title>
-
-<para>Steps are connected together by their input ports, output
-ports, and bindings to variables and options. Variables and options
-also behave something like steps, connected together by the
-input on which they receive their context and by references to them
-by name elsewhere.
-<error code="S0001" >It is a <glossterm>static error</glossterm>
-if there are any loops in the connections between steps, variables,
-and options: no step, variable, or option can be connected to itself
-nor can there be any sequence of connections through other steps that
-leads back to itself.</error></para>
-
-<para>Consider <xref linkend="fig-depends"/>.</para>
-
-<figure xml:id="fig-depends">
-  <title>Dependencies between steps, variables, and options</title>
-  <mediaobject>
-    <alt>Dependencies between steps, variables, and options</alt>
-    <imageobject>
-      <imagedata fileref="graphics/depends.png"/>
-    </imageobject>
-  </mediaobject>
-</figure>
-
-<itemizedlist>
-<listitem>
-<para>Step1 has no connections.
-</para>
-</listitem>
-<listitem>
-<para>Step2 is connected to Step1 by an explicit dependency, see <xref linkend="depends"/>.
-</para>
-</listitem>
-<listitem>
-<para>Step3 is connected to Step2 because it reads from the output of Step2. It is also
-transitively connected to Step1 because Step2 is connected to it.
-</para>
-</listitem>
-<listitem>
-<para>Step4 has no connections. In principle, Step1 and Step4 can be evaluated in parallel
-or in either order.
-</para>
-</listitem>
-<listitem>
-<para>Step5 is connected to Step3 because it reads from the output of Step3. It is also
-transitively connected to Step2 and the connections that Step2 has. Step5 is also connected
-to Step4 because it’s option “<literal>option1</literal>” is connected to “<literal>someVar</literal>”
-which is connected to “<literal>ecount</literal>” which reads its context from Step4.
-</para>
-</listitem>
-<listitem>
-<para>Step6 is connected to Step5 because it reads from the output of Step5. It is also
-transitively connected to all of the other steps.
-</para>
-</listitem>
-</itemizedlist>
-
-         <para><termdef xml:id="dt-connection">A <firstterm>connection</firstterm> associates an
-               input or output port with some data source.</termdef>  Such a connection represents a
-            binding between the port's name and the data source as described by various locations,
-            inline expressions, or readable ports.</para>
-         <para>An input port can be connected to:</para>
-         <itemizedlist>
-            <listitem>
-               <para>The output port of some other step.</para>
-            </listitem>
-            <listitem>
-               <para>A fixed, inline document.</para>
-            </listitem>
-            <listitem>
-               <para>A document read from a URI.</para>
-            </listitem>
-            <listitem>
-               <para>One of the inputs declared on one of its
-                  <glossterm>ancestors</glossterm> or
-               a special port provided by an ancestor compound step, for example,
-                     “<port>current</port>” in a <tag>p:for-each</tag> or <tag>p:viewport</tag>.
-               </para>
-            </listitem>
-         </itemizedlist>
-
-<para>When an input accepts a sequence of documents, the documents can
-come from any combination of these locations.</para>
-
-<para>In contrast, output ports are connected when they are referenced
-by another input port, <glossterm baseform="declared outputs">declared
-output</glossterm> or other expression and may be connected to:</para>
-
-<itemizedlist>
-<listitem>
-  <para>The input port or input context of some other step.</para>
-</listitem>
-<listitem>
-  <para>An option assigned with <tag>p:with-option</tag> or a
-<tag>p:variable</tag> in a compound step.</para>
-</listitem>
-<listitem>
-  <para>A <glossterm>value template</glossterm> in an immediately following step.
-This can be an AVT in an
-<link xlink:href="#option-shortcut">option shortcut</link>,
-an AVT on a <tag>p:document</tag> element, or a
-value template in a <tag>p:inline</tag>.
-  </para>
-</listitem>
-<listitem>
-  <para>One of the outputs declared on its container. </para>
-</listitem>
-</itemizedlist>
-
-         <para>As with an input, the output can be a sequence of documents constructed from any
-            combination of the above.</para>
-         <para>Within the context of a <glossterm>compound step</glossterm>, the <glossterm>declared
-               outputs</glossterm> of the compound step must describe their connections.  The set of
-            possibilities for this connection is exactly the same set as for any other input port
-            within the current <glossterm>environment</glossterm>.</para>
-
-
-      <section xml:id="namespace-fixup">
-        <title>Namespace Fixup on XML Outputs</title>
-        <para>XProc processors are expected, and sometimes required, to perform <glossterm>namespace
-            fixup</glossterm> on XML outputs. Unless the semantics of a step explicitly says otherwise:</para>
-        <itemizedlist>
-          <listitem>
-            <para>The in-scope namespaces associated with a node (even those that are inherited from
-              namespace bindings that appear among its ancestors in the document in which it appears
-              initially) are assumed to travel with that node.</para>
-          </listitem>
-          <listitem>
-            <para>Changes to one part of a tree (wrapping or unwrapping a node or renaming an
-              element, for example) do not change the in-scope namespaces associated with the
-              descendants of the node so changed.</para>
-          </listitem>
-        </itemizedlist>
-        <para>As a result, some steps can produce XML documents which have no direct serialization
-          (because they include nodes with conflicting or missing namespace declarations, for
-          example). <termdef xml:id="dt-namespace-fixup">To produce a serializable
-              <glossterm>XML</glossterm> document, the XProc processor must sometimes add additional
-            namespace nodes, perhaps even renaming prefixes, to satisfy the constraints of
-              <glossterm>Namespaces in XML</glossterm>. This process is referred to as
-              <firstterm>namespace fixup</firstterm>.</termdef>
-        </para>
-        <para>Implementors are encouraged to perform <glossterm>namespace fixup</glossterm> before
-          passing documents between steps, but they are not required to do so. Conversely, an
-          implementation which <emphasis>does</emphasis> serialize between steps and therefore must
-          perform such fixups, or reject documents that cannot be serialized, is also
-          conformant.</para>
-        <para>Except where the semantics of a step explicitly require changes, processors are
-          required to preserve the information in the documents and fragments they manipulate. In
-          particular, the information corresponding to the <biblioref linkend="xml-infoset-rec"/>
-          properties <literal role="infoset-property">attributes</literal>, <literal
-            role="infoset-property">base URI</literal>, <literal role="infoset-property"
-            >children</literal>, <literal role="infoset-property">local name</literal>, <literal
-            role="infoset-property">namespace name</literal>, <literal role="infoset-property"
-            >normalized value</literal>, <literal role="infoset-property">owner</literal>, and
-            <literal role="infoset-property">parent</literal>
-          <rfc2119>must</rfc2119> be preserved.</para>
-        <para>The information corresponding to <literal role="infoset-property">prefix</literal>,
-            <literal role="infoset-property">in-scope namespaces</literal>, <literal
-            role="infoset-property">namespace attributes</literal>, and <literal
-            role="infoset-property">attribute type</literal>
-          <rfc2119>should</rfc2119> be preserved, with changes to the first three only as required
-          for <glossterm>namespace fixup</glossterm>. In particular, processors are encouraged to
-          take account of prefix information in creating new namespace bindings, to minimize
-          negative impact on prefixed names in content.</para>
-        <para><impl>Except for cases which are specifically called out in <biblioref
-              linkend="steps30"/>, the extent to which namespace fixup, and other checks for
-            outputs which cannot be serialized, are performed on intermediate outputs is
-              <glossterm>implementation-defined</glossterm>.</impl></para>
-        <para>Whenever an implementation serializes XML, for example for pipeline
-          outputs, logging, or as part of steps such as <tag>p:store</tag> or
-            <tag>p:http-request</tag>, it is a dynamic error if
-          that serialization can not be done so as to produce a document which is both well-formed
-          and namespace-well-formed, as specified in <glossterm>XML</glossterm> and
-            <glossterm>Namespaces in XML</glossterm>.</para>
-      </section>
     </section>
 
-<section xml:id="initiating">
-<title>Initiating a pipeline</title>
+  </section>
 
-<para>Initiating a pipeline necessarily involves two activities:
-static analysis and dynamic evaluation.
-<termdef xml:id="dt-static-analysis"><firstterm baseform="static analysis">Static
-analysis</firstterm>
-consists of
-those tasks that can be performed by inspection of the pipeline
-alone, including the binding of
-<link linkend="statics">static options and variables</link>,
-computation of serialization properties and document-properties,
-<link linkend="use-when">evaluation of <code>use-when</code> expressions</link>,
-performing a static analysis of all XPath expressions, and detecting static errors.</termdef>
-<termdef xml:id="dt-dynamic-evaluation"><firstterm baseform="dynamic evaluation">Dynamic
-evaluation</firstterm> consists of tasks which, in general,
-cannot be performed out until a source document is available.</termdef></para>
+  <section xml:id="input-output">
+    <title>Inputs and Outputs</title>
 
-<para><error code="S0107">It is a <glossterm>static error</glossterm> in XProc
-if any XPath expression contains a static error (error in expression syntax,
-references to unknown variables or functions, etc.).</error>
-Type errors, even if they are determined during static
-analysis, <rfc2119>must not</rfc2119> be raised statically by
-the XProc processor.
-</para>
+    <para>Most steps have one or more inputs and one or more outputs. <xref
+        linkend="fig-atomic-step"/> illustrates symbolically an <glossterm>atomic step</glossterm>
+      with two inputs and one output.</para>
 
-<para><impl>There may be an <glossterm>implementation-defined</glossterm>
-mechanism for providing default values for static
-<tag>p:option</tag>s. If such a mechanism exists, the values provided
-must match the sequence type declared for the option, if such a
-declaration exists.</impl></para>
+    <figure xml:id="fig-atomic-step">
+      <title>An atomic step</title>
+      <mediaobject>
+        <alt>An atomic step with two inputs and one output</alt>
+        <imageobject>
+          <imagedata fileref="graphics/atomic-step.png"/>
+        </imageobject>
+      </mediaobject>
+    </figure>
 
-<section xml:id="static-expressions">
-<title>Evaluating expressions during static analysis</title>
+    <para>All atomic steps are defined by a <tag>p:declare-step</tag>. The declaration of an atomic
+      step type defines the input ports, output ports, and options of all steps of that type. For
+      example, every <tag>p:validate-with-xml-schema</tag> step has two inputs, named
+        “<literal>source</literal>” and “<literal>schema</literal>”, one output named
+        “<literal>result</literal>”, and the same set of options. </para>
+    <para>Like atomic steps, top level, user-defined pipelines also have declarations.</para>
 
-<para>Several kinds of expressions are evaluated during static analysis:</para>
+    <para>The situation is slightly more complicated for the other compound steps because they don't
+      have separate declarations; each instance of the compound step serves as its own declaration.
+      On these compound steps, the number and names of the outputs can be different on each instance
+      of the step.</para>
+    <para><xref linkend="fig-compound-step"/> illustrates symbolically a compound step with a
+      subpipeline with one output. As you can see from the diagram, the output from the compound
+      step comes from one of the outputs of the subpipeline within the step.</para>
+    <figure xml:id="fig-compound-step">
+      <title>A compound step</title>
+      <mediaobject>
+        <alt>A compound step with two inputs and one output</alt>
+        <imageobject>
+          <imagedata fileref="graphics/compound-step.png"/>
+        </imageobject>
+      </mediaobject>
+    </figure>
+    <para><termdef xml:id="dt-declared-inputs">The input ports declared on a step are its
+          <firstterm>declared inputs</firstterm>.</termdef>
+      <termdef xml:id="dt-declared-outputs">The output ports declared on a step are its
+          <firstterm>declared outputs</firstterm>.</termdef> When a step is used in a pipeline, it
+      is connected to other steps through its inputs and outputs. </para>
 
-<orderedlist>
-<listitem>
-<para>The <tag class="attribute">select</tag> expressions on static
-options and static variables.</para>
-</listitem>
-<listitem>
-<para>
-<link linkend="value-templates">Value templates</link> in the attributes
-or descendants of <tag>p:input</tag> and <tag>p:output</tag>
-and map attributes on those descendants.
-</para>
-</listitem>
-<listitem>
-<para>Expressions in <tag class="attribute">use-when</tag> attributes used
-for <link linkend="use-when">conditional element exclusion</link>.</para>
-</listitem>
-</orderedlist>
+    <para>When a step is used, all of the <glossterm>declared inputs</glossterm> of the step
+        <rfc2119>must</rfc2119> be connected. Each connection binds the input to a data source (see
+        <xref linkend="connections"/>). <error code="S0003">It is a <glossterm>static
+          error</glossterm> if any declared input is not connected.</error></para>
+    <para>The <glossterm>declared outputs</glossterm> of a step are only connected when they are
+      used by another step or expression. Any documents produced on an unconnected output port are
+      discarded.</para>
 
-<para>For the purposes of evaluating a these expressions,
-the initial context node, position, and size are all undefined. The
-<glossterm>in-scope bindings</glossterm> are limited to the lexically preceding,
-statically declared options and variables. There are no available collections
-except the default collection on <tag>p:variable</tag>s which explicitly create
-a collection.</para>
+    <para>Primary input and primary output ports may be implicitly connected if no explicit
+      connection is given, see <xref linkend="primary-input-output"/>.</para>
 
-<para>The entire expression must be evaluated without reference to the
-non-static inputs to the pipeline. Expressions can access documents as long
-as they are available statically.</para>
+    <para>Output ports on compound steps have a dual nature: from the perspective of the compound
+      step's siblings, its outputs are just ordinary outputs and can be connected the same as other
+        <glossterm>declared outputs</glossterm>. From the perspective of the subpipeline inside the
+      compound step, they behave like inputs and can be connected just like other inputs.</para>
 
-<para>Consider:</para>
+    <para>Within a compound step, the <glossterm>declared outputs</glossterm> of the step can be
+      connected to any of the various available outputs of <glossterm baseform="contained steps"
+        >contained steps</glossterm> as well as other data sources (see <xref linkend="connections"
+      />). If a (non-primary) output port of a compound step is left unconnected, it produces an
+      empty sequence of documents from the perspective of its siblings.</para>
 
-<programlisting language="xml"><![CDATA[<p:declare-step version="3.0"
+    <para>Each input and output on a step is declared to accept or produce either a single document
+      or a sequence of documents. It <emphasis>is not</emphasis> an error to connect a port that is
+      declared to produce a sequence of documents to a port that is declared to accept only a single
+      document. It is, however, an error if the former step does not produce exactly one document at
+      run time.</para>
+    <para>It is also not an error to connect a port that is declared to produce a single document to
+      a port that is declared to accept a sequence. A single document is the same as a sequence of
+      one document.</para>
+    <para>An output port may have more than one connection: it may be connected to more than one
+      input port, more than one of its container's output ports, or both. At runtime this will
+      result in the outputs being sent to each of those places.</para>
+    <para><termdef xml:id="dt-signature">The <firstterm>signature</firstterm> of a step is the set
+        of inputs, outputs, and options that it is declared to accept.</termdef> The declaration for
+      a step provides a fixed signature which all its instances share.</para>
+
+    <note>
+      <para>Within the context of what can be defined by XProc pipelines, step signatures are fixed
+        and shared by all instances. There is no mechanism for a pipeline author to declare that an
+        atomic step has a signature that varies. However, implementors may provide such mechanisms
+        and other specifications may depend upon them. For example, the standard <tag>p:run</tag>
+        step violates this constraint in that the name and number of its output ports depends on its
+        inputs and may vary between invocations. </para>
+      <para>Such steps are “magic” and XProc 3.0 makes no effort to provide a mechanism to define
+        them.</para>
+    </note>
+
+    <para><termdef xml:id="dt-matches">A step <firstterm>matches</firstterm> its signature if and
+        only if it specifies an input for each declared input, it specifies no inputs that are not
+        declared, it specifies an option for each option that is declared to be required, and it
+        specifies no options that are not declared.</termdef> In other words, every input and
+      required option <rfc2119>must</rfc2119> be specified and only inputs and options that are
+      declared <rfc2119>may</rfc2119> be specified. Options that aren't required do not have to be
+      specified.</para>
+    <para>Steps <rfc2119>may</rfc2119> also produce error, warning, and informative messages. These
+      messages are captured and provided on the <port>error</port> port inside of a
+        <tag>p:catch</tag>. <impl>Outside of a <link linkend="p.try">try/catch</link>, the
+        disposition of error messages is <glossterm>implementation-dependent</glossterm></impl>. </para>
+
+    <para>
+      <impl>How inputs are connected to documents outside the pipeline is
+          <glossterm>implementation-defined</glossterm>.</impl>
+    </para>
+
+    <para>
+      <impl>How pipeline outputs are connected to documents outside the pipeline is
+          <glossterm>implementation-defined</glossterm>.</impl>
+    </para>
+
+    <para>Input ports <rfc2119>may</rfc2119> specify a content type, or list of content types, that
+      they accept, se <xref linkend="specified-content-types"/>.</para>
+
+    <section xml:id="external-docs">
+      <title>External Documents</title>
+      <para>It's common for some of the documents used in processing a pipeline to be read from
+        URIs. Sometimes this occurs directly, for example with a <tag>p:document</tag> element.
+        Sometimes it occurs indirectly, for example if an implementation allows the URI of a
+        pipeline input to be specified on the command line or if an <tag>p:xslt</tag> step
+        encounters an <tag>xsl:import</tag> in the stylesheet that it is processing. It's also
+        common for some of the documents produced in processing a pipeline to be written to
+        locations which have, or at least could have, a URI. </para>
+      <para>The process of dereferencing a URI to retrieve a document is often more interesting than
+        it seems at first. On the web, it may involve caches, proxies, and various forms of
+        indirection. <impl>Resolving a URI locally may involve resolvers of various sorts and
+          possibly appeal to <glossterm>implementation-dependent</glossterm> mechanisms such as
+          catalog files.</impl></para>
+      <para>In XProc, the situation is made even more interesting by the fact that many intermediate
+        results produced by steps in the pipeline have base URIs. <impl>Whether (and when and how)
+          or not the intermediate results that pass between steps are ever written to a filesystem
+          is <glossterm>implementation-dependent</glossterm>.</impl></para>
+      <para>
+        <impl>In Version 3.0 of XProc, how (or if) implementers provide local resolution mechanisms
+          and how (or if) they provide access to intermediate results by URI is
+            <glossterm>implementation-defined</glossterm>.</impl>
+      </para>
+      <para>Version 3.0 of XProc does not require implementations to guarantee that multiple
+        attempts to dereference the same URI always produce the same results.</para>
+      <note xml:id="note-unsatisfying">
+        <para>On the one hand, this is a somewhat unsatisfying state of affairs because it leaves
+          room for interoperability problems. On the other, it is not expected to cause such
+          problems very often in practice. </para>
+        <para>If these problems arise in practice, implementers are encouraged to use the existing
+          extension mechanisms to give users the control needed to circumvent them. Should such
+          mechanisms become widespread, a standard mechanism could be added in some future version
+          of the language.</para>
+      </note>
+    </section>
+  </section>
+  <section xml:id="primary-input-output">
+    <title>Primary Inputs and Outputs</title>
+    <para>Each step may have one input port designated as the primary input port and one output port
+      designated as the primary output port.</para>
+    <para><termdef xml:id="dt-primary-input-port">If a step has an input port which is explicitly
+        marked “<code>primary='true'</code>”, or if it has exactly one document input port and that
+        port is <emphasis>not</emphasis> explicitly marked “<code>primary='false'</code>”, then that
+        input port is the <firstterm>primary input port</firstterm> of the step.</termdef> If a step
+      has a single input port and that port is explicitly marked “<code>primary='false'</code>”, or
+      if a step has more than one input port and none is explicitly marked as the primary, then the
+      primary input port of that step is undefined. A step can have at most one primary input
+      port.</para>
+    <para><termdef xml:id="dt-primary-output-port">If a step has an output port which is explicitly
+        marked “<code>primary='true'</code>”, or if it has exactly one document output port and that
+        port is <emphasis>not</emphasis> explicitly marked “<code>primary='false'</code>”, then that
+        output port is the <firstterm>primary output port</firstterm> of the step.</termdef> If a
+      step has a single output port and that port is explicitly marked
+      “<code>primary='false'</code>”, or if a step has more than one output port and none is
+      explicitly marked as the primary, then the primary output port of that step is undefined. A
+      step can have at most one primary output port.</para>
+    <para>The special significance of primary input and output ports is that they are connected
+      automatically by the processor if no explicit connection is given. Generally speaking, if two
+      steps appear sequentially in a subpipeline, then the primary output of the first step will
+      automatically be connected to the primary input of the second.</para>
+
+    <para>Additionally, if a container, that can have declared outputs, has no declared outputs and
+      the <glossterm>last step</glossterm> in its subpipeline has an unconnected primary output,
+      then an implicit primary output port will be added to the compound step (and consequently the
+      last step's primary output will be connected to it). This implicit output port has no name. It
+      inherits the <tag class="attribute">sequence</tag> and the <tag class="attribute"
+        >content-types</tag> properties of the port connected to it. This rule does not apply to
+        <tag>p:declare-step</tag>; step declarations must provide explicit names for all of their
+      outputs.</para>
+
+  </section>
+
+  <section xml:id="connections">
+    <title>Connections</title>
+
+    <para>Steps are connected together by their input ports, output ports, and bindings to variables
+      and options. Variables and options also behave something like steps, connected together by the
+      input on which they receive their context and by references to them by name elsewhere. <error
+        code="S0001">It is a <glossterm>static error</glossterm> if there are any loops in the
+        connections between steps, variables, and options: no step, variable, or option can be
+        connected to itself nor can there be any sequence of connections through other steps that
+        leads back to itself.</error></para>
+
+    <para>Consider <xref linkend="fig-depends"/>.</para>
+
+    <figure xml:id="fig-depends">
+      <title>Dependencies between steps, variables, and options</title>
+      <mediaobject>
+        <alt>Dependencies between steps, variables, and options</alt>
+        <imageobject>
+          <imagedata fileref="graphics/depends.png"/>
+        </imageobject>
+      </mediaobject>
+    </figure>
+
+    <itemizedlist>
+      <listitem>
+        <para>Step1 has no connections. </para>
+      </listitem>
+      <listitem>
+        <para>Step2 is connected to Step1 by an explicit dependency, see <xref linkend="depends"/>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>Step3 is connected to Step2 because it reads from the output of Step2. It is also
+          transitively connected to Step1 because Step2 is connected to it. </para>
+      </listitem>
+      <listitem>
+        <para>Step4 has no connections. In principle, Step1 and Step4 can be evaluated in parallel
+          or in either order. </para>
+      </listitem>
+      <listitem>
+        <para>Step5 is connected to Step3 because it reads from the output of Step3. It is also
+          transitively connected to Step2 and the connections that Step2 has. Step5 is also
+          connected to Step4 because it’s option “<literal>option1</literal>” is connected to
+            “<literal>someVar</literal>” which is connected to “<literal>ecount</literal>” which
+          reads its context from Step4. </para>
+      </listitem>
+      <listitem>
+        <para>Step6 is connected to Step5 because it reads from the output of Step5. It is also
+          transitively connected to all of the other steps. </para>
+      </listitem>
+    </itemizedlist>
+
+    <para><termdef xml:id="dt-connection">A <firstterm>connection</firstterm> associates an input or
+        output port with some data source.</termdef> Such a connection represents a binding between
+      the port's name and the data source as described by various locations, inline expressions, or
+      readable ports.</para>
+    <para>An input port can be connected to:</para>
+    <itemizedlist>
+      <listitem>
+        <para>The output port of some other step.</para>
+      </listitem>
+      <listitem>
+        <para>A fixed, inline document.</para>
+      </listitem>
+      <listitem>
+        <para>A document read from a URI.</para>
+      </listitem>
+      <listitem>
+        <para>One of the inputs declared on one of its <glossterm>ancestors</glossterm> or a special
+          port provided by an ancestor compound step, for example, “<port>current</port>” in a
+            <tag>p:for-each</tag> or <tag>p:viewport</tag>. </para>
+      </listitem>
+    </itemizedlist>
+
+    <para>When an input accepts a sequence of documents, the documents can come from any combination
+      of these locations.</para>
+
+    <para>In contrast, output ports are connected when they are referenced by another input port,
+        <glossterm baseform="declared outputs">declared output</glossterm> or other expression and
+      may be connected to:</para>
+
+    <itemizedlist>
+      <listitem>
+        <para>The input port or input context of some other step.</para>
+      </listitem>
+      <listitem>
+        <para>An option assigned with <tag>p:with-option</tag> or a <tag>p:variable</tag> in a
+          compound step.</para>
+      </listitem>
+      <listitem>
+        <para>A <glossterm>value template</glossterm> in an immediately following step. This can be
+          an AVT in an <link xlink:href="#option-shortcut">option shortcut</link>, an AVT on a
+            <tag>p:document</tag> element, or a value template in a <tag>p:inline</tag>. </para>
+      </listitem>
+      <listitem>
+        <para>One of the outputs declared on its container. </para>
+      </listitem>
+    </itemizedlist>
+
+    <para>As with an input, the output can be a sequence of documents constructed from any
+      combination of the above.</para>
+    <para>Within the context of a <glossterm>compound step</glossterm>, the <glossterm>declared
+        outputs</glossterm> of the compound step must describe their connections. The set of
+      possibilities for this connection is exactly the same set as for any other input port within
+      the current <glossterm>environment</glossterm>.</para>
+
+
+    <section xml:id="namespace-fixup">
+      <title>Namespace Fixup on XML Outputs</title>
+      <para>XProc processors are expected, and sometimes required, to perform <glossterm>namespace
+          fixup</glossterm> on XML outputs. Unless the semantics of a step explicitly says
+        otherwise:</para>
+      <itemizedlist>
+        <listitem>
+          <para>The in-scope namespaces associated with a node (even those that are inherited from
+            namespace bindings that appear among its ancestors in the document in which it appears
+            initially) are assumed to travel with that node.</para>
+        </listitem>
+        <listitem>
+          <para>Changes to one part of a tree (wrapping or unwrapping a node or renaming an element,
+            for example) do not change the in-scope namespaces associated with the descendants of
+            the node so changed.</para>
+        </listitem>
+      </itemizedlist>
+      <para>As a result, some steps can produce XML documents which have no direct serialization
+        (because they include nodes with conflicting or missing namespace declarations, for
+        example). <termdef xml:id="dt-namespace-fixup">To produce a serializable
+            <glossterm>XML</glossterm> document, the XProc processor must sometimes add additional
+          namespace nodes, perhaps even renaming prefixes, to satisfy the constraints of
+            <glossterm>Namespaces in XML</glossterm>. This process is referred to as
+            <firstterm>namespace fixup</firstterm>.</termdef>
+      </para>
+      <para>Implementors are encouraged to perform <glossterm>namespace fixup</glossterm> before
+        passing documents between steps, but they are not required to do so. Conversely, an
+        implementation which <emphasis>does</emphasis> serialize between steps and therefore must
+        perform such fixups, or reject documents that cannot be serialized, is also
+        conformant.</para>
+      <para>Except where the semantics of a step explicitly require changes, processors are required
+        to preserve the information in the documents and fragments they manipulate. In particular,
+        the information corresponding to the <biblioref linkend="xml-infoset-rec"/> properties
+          <literal role="infoset-property">attributes</literal>, <literal role="infoset-property"
+          >base URI</literal>, <literal role="infoset-property">children</literal>, <literal
+          role="infoset-property">local name</literal>, <literal role="infoset-property">namespace
+          name</literal>, <literal role="infoset-property">normalized value</literal>, <literal
+          role="infoset-property">owner</literal>, and <literal role="infoset-property"
+          >parent</literal>
+        <rfc2119>must</rfc2119> be preserved.</para>
+      <para>The information corresponding to <literal role="infoset-property">prefix</literal>,
+          <literal role="infoset-property">in-scope namespaces</literal>, <literal
+          role="infoset-property">namespace attributes</literal>, and <literal
+          role="infoset-property">attribute type</literal>
+        <rfc2119>should</rfc2119> be preserved, with changes to the first three only as required for
+          <glossterm>namespace fixup</glossterm>. In particular, processors are encouraged to take
+        account of prefix information in creating new namespace bindings, to minimize negative
+        impact on prefixed names in content.</para>
+      <para>
+        <impl>Except for cases which are specifically called out in <biblioref linkend="steps30"/>,
+          the extent to which namespace fixup, and other checks for outputs which cannot be
+          serialized, are performed on intermediate outputs is
+            <glossterm>implementation-defined</glossterm>.</impl>
+      </para>
+      <para>Whenever an implementation serializes XML, for example for pipeline outputs, logging, or
+        as part of steps such as <tag>p:store</tag> or <tag>p:http-request</tag>, it is a dynamic
+        error if that serialization can not be done so as to produce a document which is both
+        well-formed and namespace-well-formed, as specified in <glossterm>XML</glossterm> and
+          <glossterm>Namespaces in XML</glossterm>.</para>
+    </section>
+  </section>
+
+  <section xml:id="initiating">
+    <title>Initiating a pipeline</title>
+
+    <para>Initiating a pipeline necessarily involves two activities: static analysis and dynamic
+      evaluation. <termdef xml:id="dt-static-analysis"><firstterm baseform="static analysis">Static
+          analysis</firstterm> consists of those tasks that can be performed by inspection of the
+        pipeline alone, including the binding of <link linkend="statics">static options and
+          variables</link>, computation of serialization properties and document-properties, <link
+          linkend="use-when">evaluation of <code>use-when</code> expressions</link>, performing a
+        static analysis of all XPath expressions, and detecting static errors.</termdef>
+      <termdef xml:id="dt-dynamic-evaluation"><firstterm baseform="dynamic evaluation">Dynamic
+          evaluation</firstterm> consists of tasks which, in general, cannot be performed out until
+        a source document is available.</termdef></para>
+
+    <para><error code="S0107">It is a <glossterm>static error</glossterm> in XProc if any XPath
+        expression contains a static error (error in expression syntax, references to unknown
+        variables or functions, etc.).</error> Type errors, even if they are determined during
+      static analysis, <rfc2119>must not</rfc2119> be raised statically by the XProc processor. </para>
+
+    <para>
+      <impl>There may be an <glossterm>implementation-defined</glossterm> mechanism for providing
+        default values for static <tag>p:option</tag>s. If such a mechanism exists, the values
+        provided must match the sequence type declared for the option, if such a declaration
+        exists.</impl>
+    </para>
+
+    <section xml:id="static-expressions">
+      <title>Evaluating expressions during static analysis</title>
+
+      <para>Several kinds of expressions are evaluated during static analysis:</para>
+
+      <orderedlist>
+        <listitem>
+          <para>The <tag class="attribute">select</tag> expressions on static options and static
+            variables.</para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="value-templates">Value templates</link> in the attributes or descendants
+            of <tag>p:input</tag> and <tag>p:output</tag> and map attributes on those descendants.
+          </para>
+        </listitem>
+        <listitem>
+          <para>Expressions in <tag class="attribute">use-when</tag> attributes used for <link
+              linkend="use-when">conditional element exclusion</link>.</para>
+        </listitem>
+      </orderedlist>
+
+      <para>For the purposes of evaluating a these expressions, the initial context node, position,
+        and size are all undefined. The <glossterm>in-scope bindings</glossterm> are limited to the
+        lexically preceding, statically declared options and variables. There are no available
+        collections except the default collection on <tag>p:variable</tag>s which explicitly create
+        a collection.</para>
+
+      <para>The entire expression must be evaluated without reference to the non-static inputs to
+        the pipeline. Expressions can access documents as long as they are available
+        statically.</para>
+
+      <para>Consider:</para>
+
+      <programlisting language="xml"><![CDATA[<p:declare-step version="3.0"
                 xmlns:p="http://www.w3.org/ns/xproc">
   <p:input port="source"/>
   <p:variable name="D" select="count(//*)"/>
@@ -1217,1050 +1138,1147 @@ as they are available statically.</para>
   …
 </p:declare-step>]]></programlisting>
 
-<para>The value of <code>$A</code> will be 5, unless a different
-value is provided before static analysis. The value of <code>$B</code> will
-be the value of <code>$A</code> plus the number of elements in
-<uri>doc.xml</uri> <emphasis>which must be successfully resolved during
-static analysis</emphasis>. Although <code>$D</code> can reference
-the document provided dynamically on the <port>source</port> port,
-any attempt to refer to <code>$D</code> in the expression(s) that
-initialize <code>$A</code> and <code>$B</code> would be an error.</para>
+      <para>The value of <code>$A</code> will be 5, unless a different value is provided before
+        static analysis. The value of <code>$B</code> will be the value of <code>$A</code> plus the
+        number of elements in <uri>doc.xml</uri>
+        <emphasis>which must be successfully resolved during static analysis</emphasis>. Although
+          <code>$D</code> can reference the document provided dynamically on the <port>source</port>
+        port, any attempt to refer to <code>$D</code> in the expression(s) that initialize
+          <code>$A</code> and <code>$B</code> would be an error.</para>
 
-<note>
-<title>Note</title>
-<para>There is no guarantee that the document read from <uri>doc.xml</uri> during
-static anlaysis will be the same as the document read later during dynamic evaluation.
-See <xref linkend="external-docs"/> for further discussion.</para>
-</note>
+      <note>
+        <title>Note</title>
+        <para>There is no guarantee that the document read from <uri>doc.xml</uri> during static
+          anlaysis will be the same as the document read later during dynamic evaluation. See <xref
+            linkend="external-docs"/> for further discussion.</para>
+      </note>
 
-<para>The results of XProc extension functions may differ during static analysis,
-as described in the description of each function.</para>
+      <para>The results of XProc extension functions may differ during static analysis, as described
+        in the description of each function.</para>
 
-<para>Any errors that occur while evaluating expressions during static analysis will
-be raised statically.</para>
+      <para>Any errors that occur while evaluating expressions during static analysis will be raised
+        statically.</para>
 
-</section>
+    </section>
 
-<section xml:id="dynamic-evaluation">
-<title>Dynamic evaluation of the pipeline</title>
+    <section xml:id="dynamic-evaluation">
+      <title>Dynamic evaluation of the pipeline</title>
 
-<para>Dynamic evaluation of the pipeline occurs when it begins to process documents.
-The processor evaluates any expressions necessary to provide all of the input documents
-and options required. The step processes the input documents and produces outputs which
-flow through the pipeline.</para>
+      <para>Dynamic evaluation of the pipeline occurs when it begins to process documents. The
+        processor evaluates any expressions necessary to provide all of the input documents and
+        options required. The step processes the input documents and produces outputs which flow
+        through the pipeline.</para>
 
-    <section xml:id="environment">
-      <title>Environment</title>
-      <para><termdef xml:id="dt-environment">The <firstterm>environment</firstterm> is a
-          context-dependent collection of information available within subpipelines.</termdef>
-</para>
-      <para>The environment consists of:</para>
-      <orderedlist>
-        <listitem>
-          <para>A set of readable ports. <termdef xml:id="dt-readable-ports">The <firstterm>readable
-                ports</firstterm> are a set of step name/port name pairs.</termdef> Inputs and
-            outputs can only be connected to readable ports.</para>
-        </listitem>
-        <listitem>
-          <para>A default readable port. <termdef xml:id="dt-default-readable-port">The
-                <firstterm>default readable port</firstterm>, which may be undefined, is a specific
-              step name/port name pair from the set of readable ports.</termdef></para>
-        </listitem>
-        <listitem>
-          <para>A set of in-scope bindings. <termdef xml:id="dt-in-scope-bindings">The
-                <firstterm>in-scope bindings</firstterm> are a set of name-value pairs, based on
-                <glossterm>option</glossterm> and <glossterm>variable</glossterm>
-              bindings.</termdef></para>
-        </listitem>
-      </orderedlist>
-      <para><termdef xml:id="dt-empty-environment">The <firstterm>empty environment</firstterm>
-          contains no readable ports, an undefined default readable port, and no in-scope
-          bindings.</termdef>
-      </para>
-      <para>Unless otherwise specified, the environment of a <glossterm baseform="contained steps"
-          >contained step</glossterm> is its <glossterm>inherited environment</glossterm>. <termdef
-          xml:id="dt-inherited-environment">The <firstterm>inherited environment</firstterm> of a
-            <glossterm baseform="contained steps">contained step</glossterm> is an environment that
-          is the same as the environment of its <glossterm>container</glossterm> with the <link
-            linkend="dt-standard-modifications">standard modifications</link>. </termdef></para>
-      <para>The <phrase xml:id="dt-standard-modifications">standard modifications</phrase> made to
-        an inherited environment are:</para>
-      <orderedlist>
-        <listitem>
-          <para>The declared inputs of the container are added to the <glossterm>readable
-              ports</glossterm>.</para>
-          <para>In other words, contained steps can see the inputs to their container.</para>
-        </listitem>
-        <listitem>
-          <para>The union of all the declared outputs of all of the step's sibling steps are added
-            to the <glossterm>readable ports</glossterm>.</para>
-          <!--
+      <section xml:id="environment">
+        <title>Environment</title>
+        <para>
+          <termdef xml:id="dt-environment">The <firstterm>environment</firstterm> is a
+            context-dependent collection of information available within subpipelines.</termdef>
+        </para>
+        <para>The environment consists of:</para>
+        <orderedlist>
+          <listitem>
+            <para>A set of readable ports. <termdef xml:id="dt-readable-ports">The
+                  <firstterm>readable ports</firstterm> are a set of step name/port name
+                pairs.</termdef> Inputs and outputs can only be connected to readable ports.</para>
+          </listitem>
+          <listitem>
+            <para>A default readable port. <termdef xml:id="dt-default-readable-port">The
+                  <firstterm>default readable port</firstterm>, which may be undefined, is a
+                specific step name/port name pair from the set of readable ports.</termdef></para>
+          </listitem>
+          <listitem>
+            <para>A set of in-scope bindings. <termdef xml:id="dt-in-scope-bindings">The
+                  <firstterm>in-scope bindings</firstterm> are a set of name-value pairs, based on
+                  <glossterm>option</glossterm> and <glossterm>variable</glossterm>
+                bindings.</termdef></para>
+          </listitem>
+        </orderedlist>
+        <para>
+          <termdef xml:id="dt-empty-environment">The <firstterm>empty environment</firstterm>
+            contains no readable ports, an undefined default readable port, and no in-scope
+            bindings.</termdef>
+        </para>
+        <para>Unless otherwise specified, the environment of a <glossterm baseform="contained steps"
+            >contained step</glossterm> is its <glossterm>inherited environment</glossterm>.
+            <termdef xml:id="dt-inherited-environment">The <firstterm>inherited
+              environment</firstterm> of a <glossterm baseform="contained steps">contained
+              step</glossterm> is an environment that is the same as the environment of its
+              <glossterm>container</glossterm> with the <link linkend="dt-standard-modifications"
+              >standard modifications</link>. </termdef></para>
+        <para>The <phrase xml:id="dt-standard-modifications">standard modifications</phrase> made to
+          an inherited environment are:</para>
+        <orderedlist>
+          <listitem>
+            <para>The declared inputs of the container are added to the <glossterm>readable
+                ports</glossterm>.</para>
+            <para>In other words, contained steps can see the inputs to their container.</para>
+          </listitem>
+          <listitem>
+            <para>The union of all the declared outputs of all of the step's sibling steps are added
+              to the <glossterm>readable ports</glossterm>.</para>
+            <!--
           <para>The union of all the declared outputs of all of the containers's
               <glossterm>contained steps</glossterm> are added to the <glossterm>readable
               ports</glossterm>.</para>
               -->
-          <para>In other words, sibling steps can see each other's outputs in addition to the
-            outputs visible to their container.</para>
-        </listitem>
-        <listitem>
-          <para>If there is a preceding sibling step element:</para>
-          <itemizedlist>
-            <listitem>
-              <para>If that preceding sibling has a <glossterm>primary output port</glossterm>, then
-                that output port becomes the <glossterm>default readable port</glossterm>.</para>
-            </listitem>
-            <listitem>
-              <para>Otherwise, the <glossterm>default readable port</glossterm> is undefined.</para>
-            </listitem>
-          </itemizedlist>
-        </listitem>
-        <listitem>
-          <para>If there <emphasis>is not</emphasis> a preceding sibling step element: </para>
-          <itemizedlist>
-            <listitem>
-              <para>If the container has a <glossterm>primary input port</glossterm>, the
-                  <glossterm>default readable port</glossterm> is that <glossterm>primary input
+            <para>In other words, sibling steps can see each other's outputs in addition to the
+              outputs visible to their container.</para>
+          </listitem>
+          <listitem>
+            <para>If there is a preceding sibling step element:</para>
+            <itemizedlist>
+              <listitem>
+                <para>If that preceding sibling has a <glossterm>primary output port</glossterm>,
+                  then that output port becomes the <glossterm>default readable
                   port</glossterm>.</para>
-            </listitem>
-            <listitem>
-              <para>Otherwise, the default readable port is unchanged.</para>
-            </listitem>
-          </itemizedlist>
-        </listitem>
-      </orderedlist>
+              </listitem>
+              <listitem>
+                <para>Otherwise, the <glossterm>default readable port</glossterm> is
+                  undefined.</para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+          <listitem>
+            <para>If there <emphasis>is not</emphasis> a preceding sibling step element: </para>
+            <itemizedlist>
+              <listitem>
+                <para>If the container has a <glossterm>primary input port</glossterm>, the
+                    <glossterm>default readable port</glossterm> is that <glossterm>primary input
+                    port</glossterm>.</para>
+              </listitem>
+              <listitem>
+                <para>Otherwise, the default readable port is unchanged.</para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </orderedlist>
 
-<para>A step with no parent inherits the <glossterm>empty
-environment</glossterm>. </para>
+        <para>A step with no parent inherits the <glossterm>empty environment</glossterm>. </para>
 
-<para>Variables and options are lexically scoped. The environment of a step
-also includes the <glossterm>in-scope bindings</glossterm> for all of
-the variables and options “visible” from its lexical position. Variables
-and options can shadow each other; only the lexically most recent bindings
-are visible.</para>
+        <para>Variables and options are lexically scoped. The environment of a step also includes
+          the <glossterm>in-scope bindings</glossterm> for all of the variables and options
+          “visible” from its lexical position. Variables and options can shadow each other; only the
+          lexically most recent bindings are visible.</para>
 
-         <section xml:id="initial-environment">
-            <title>Initial Environment</title>
-            <para>When a pipeline is invoked by a processor, an initial environment is constructed.
-                  <termdef xml:id="dt-initial-environment">An <firstterm>initial
-                     environment</firstterm> is a <glossterm>connection</glossterm> for each of the
-                     <glossterm>readable ports</glossterm> and a set of option bindings used to
-                  construct the initial <glossterm>in-scope bindings</glossterm>.</termdef> This environment
-               is used in place of the <glossterm>empty environment</glossterm> that might have
-               otherwise been provided.</para>
-            <para>An invoked pipeline's <glossterm>initial environment</glossterm> is different from
-               the environment constructed for the sub-pipeline of a declared step.  The initial
-               environment is constructed for the initial invocation of the pipeline by the
-               processor outside the application.  Steps that are subsequently invoked construct
-               an environment as specified in <xref linkend="declare-pipelines"/>.</para>
-            <para>When constructing an <glossterm>initial environment</glossterm>, an implementation
-               is free to provide any set of mechanisms to construct connections for the input ports
-               of the invoked step. These mechanisms are not limited to the variety of mechnisms
-               described within this specification. Any extensions are implementation
-               defined.</para>
-            <para>The set of <glossterm>in-scope bindings</glossterm> are constructed from a set of
-               option name/value pairs.  Each option value can be a simple string value, a specific
-               data type instance (e.g. xs:dateTime), or a more complex value like a map item.  How
-               these values are specified is implementation defined.</para>
-         </section>
-
-    </section>
-
-    <section xml:id="xpath-context">
-      <title>XPath in XProc</title>
-
-<para>XProc uses XPath 3.1 as an expression language. XPath expressions
-are evaluated by the XProc processor in several places: on compound
-steps, to compute the default values of options and the values of
-variables; on atomic steps, to compute the actual values of options.
-</para>
-
-      <para>XPath expressions are also passed to some steps. These expressions are evaluated by the
-        implementations of the individual steps.</para>
-      <para>This distinction can be seen in the following example:</para>
-      <programlisting language="xml"><xi:include href="../../../build/examples/xpathcontext.txt" parse="text"/></programlisting>
-      <para>The select expression on the variable “<varname>home</varname>” is evaluated by the
-        XProc processor. The value of the variable is “<uri>http://example.com/docs</uri>”.</para>
-      <para>The <option>href</option> option of the <tag>p:load</tag> step is evaluated by the XProc
-        processor. The actual <literal>href</literal> option received by the step is simply the
-        string literal “<uri>http://example.com/docs/document.xml</uri>”. (The select expression on
-        the <literal>source</literal> input of the <tag>p:split-sequence</tag> step is also
-        evaluated by the XProc processor.) </para>
-      <para>The XPath expression “<literal>@role='chapter'</literal>” is passed literally to the
-          <literal>test</literal> option on the <tag>p:split-sequence</tag> step. That's because the
-        nature of the <tag>p:split-sequence</tag> is that <emphasis>it evaluates</emphasis> the
-        expression. Only some options on some steps expect XPath expressions. </para>
-
-<para>The XProc processor evaluates all of the XPath expressions in
-<tag class="attribute" >select</tag> attributes on variables, options,
-and inputs, in <tag class="attribute">match</tag> attributes on
-<tag>p:viewport</tag>, and in <tag class="attribute">test</tag>
-attributes on <tag>p:when</tag> and <tag>p:if</tag> steps.</para>
-
-<para>See <xref linkend="xproc-and-step-xpath-context"/> for a detailed description of the context.</para>
-    </section>
-  </section>
-</section>
-
-<section xml:id="xpath-extension-functions">
-<title>XPath Extension Functions</title>
-
-<para>The XProc processor <rfc2119>must</rfc2119> support the
-additional functions described in this section in XPath expressions
-evaluated by the processor.</para>
-
-<para>These functions <rfc2119>must not</rfc2119> be supported in
-XPath expressions evaluated by a step. In the interest of
-interoperability and to avoid imposing unnecessary constraints on
-implementors, XPath expressions inside, for example, a template in an
-XSLT step, cannot be aware of the XProc-defined functions.
-</para>
-
-      <section xml:id="f.system-property">
-        <title>System Properties</title>
-        <para>XPath expressions within a pipeline document can interrogate the processor for
-          information about the current state of the pipeline. Various aspects of the processor are
-          exposed through the <function>p:system-property</function> function:</para>
-
-<methodsynopsis>
-<type>xs:string</type>
-<methodname>p:system-property</methodname>
-<methodparam><type>xs:string</type><parameter>property</parameter></methodparam>
-</methodsynopsis>
-
-<para>The <varname>$property</varname> string <rfc2119>must</rfc2119> have the form of an
-<link xlink:href="https://www.w3.org/TR/xquery-30/#doc-xquery30-EQName">EQName</link>.
-If it is a QName, it is expanded using the namespace declarations in
-scope for the expression. <error code="D0015">It is a
-<glossterm>dynamic error</glossterm> if a QName is specified and it cannot be
-resolved with the in-scope namespace declarations.</error> The
-<function>p:system-property</function> function returns the string
-representing the value of the system property identified by the EQName.
-If there is no such property, the empty string <rfc2119>must</rfc2119>
-be returned.</para>
-
-<para>Implementations <rfc2119>must</rfc2119> provide the following
-system properties, which are all in the XProc namespace:</para>
-
-        <variablelist>
-          <varlistentry>
-            <term><varname>p:episode</varname></term>
-            <listitem>
-              <para>Returns a string which <rfc2119>should</rfc2119> be unique for each invocation
-                of the pipeline processor. In other words, if a processor is run several times in
-                succession, or if several processors are running simultaneously, each invocation of
-                each processor should get a distinct value from <varname>p:episode</varname>.</para>
-              <para>The unique identifier must be a valid <link
-                  xlink:href="http://www.w3.org/TR/xml/#NT-Name">XML name</link>. </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:locale</varname></term>
-            <listitem>
-              <para>Returns a string which identifies the current environment (usually the OS)
-                language. This is useful for, for example, message
-                localization purposes. <impl>The exact format of the language string is
-                    <glossterm>implementation-defined</glossterm> but <rfc2119>should</rfc2119> be
-                  consistent with the <tag class="attribute">xml:lang</tag> attribute.</impl></para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:product-name</varname></term>
-            <listitem>
-              <para>Returns a string containing the name of the implementation, as defined by the
-                implementer. This should normally remain constant from one release of the product to
-                the next. It should also be constant across platforms in cases where the same source
-                code is used to produce compatible products for multiple execution platforms.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:product-version</varname></term>
-            <listitem>
-              <para>Returns a string identifying the version of the implementation, as defined by
-                the implementer. This should normally vary from one release of the product to the
-                next, and at the discretion of the implementer it may also vary across different
-                execution platforms. </para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:vendor</varname></term>
-            <listitem>
-              <para>Returns a string which identifies the vendor of the processor.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:vendor-uri</varname></term>
-            <listitem>
-              <para>Returns a URI which identifies the vendor of the processor. Often, this is the
-                URI of the vendor's web site.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:version</varname></term>
-            <listitem>
-              <para>Returns the version(s) of XProc implemented by the processor
-                as a space-separated list. For example, a processor that
-                supports XProc 1.0 would return “1.0”; a processor that supports
-                XProc 1.0 and 3.0 would return “1.0 3.0”; a processor that
-                supports only XProc 3.0 would return “3.0”.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:xpath-version</varname></term>
-            <listitem>
-              <para>Returns the version(s) of XPath implemented by the processor
-                for evaluating XPath expressions on XProc elements. The result
-                is a space-separated list of versions supported. For example, a
-                processor that only supports XPath 3.1 would return “3.1”; a
-                processor that supports XPath 3.1 and XPath 3.2 could return
-                “3.1 3.2”.</para>
-            </listitem>
-          </varlistentry>
-          <varlistentry>
-            <term><varname>p:psvi-supported</varname></term>
-            <listitem>
-              <para>Returns true if the implementation supports passing PSVI annotations between
-                steps, false otherwise.</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-
-<para>Implementations may support additional system properties but such properties
-<rfc2119>must</rfc2119> be in a namespace and <rfc2119>must not</rfc2119> be
-in the XProc namespace.</para>
-
-<para>The <function>p:system-property</function> function behaves normally during static 
-analysis. <impl>It is <glossterm>implementation-defined</glossterm> which additional
-system properties are available during static analysis.</impl> If an additional system
-property is not available during static analysis, an empty string <rfc2119>must</rfc2119>
-be returned.</para>
+        <section xml:id="initial-environment">
+          <title>Initial Environment</title>
+          <para>When a pipeline is invoked by a processor, an initial environment is constructed.
+              <termdef xml:id="dt-initial-environment">An <firstterm>initial environment</firstterm>
+              is a <glossterm>connection</glossterm> for each of the <glossterm>readable
+                ports</glossterm> and a set of option bindings used to construct the initial
+                <glossterm>in-scope bindings</glossterm>.</termdef> This environment is used in
+            place of the <glossterm>empty environment</glossterm> that might have otherwise been
+            provided.</para>
+          <para>An invoked pipeline's <glossterm>initial environment</glossterm> is different from
+            the environment constructed for the sub-pipeline of a declared step. The initial
+            environment is constructed for the initial invocation of the pipeline by the processor
+            outside the application. Steps that are subsequently invoked construct an environment as
+            specified in <xref linkend="declare-pipelines"/>.</para>
+          <para>When constructing an <glossterm>initial environment</glossterm>, an implementation
+            is free to provide any set of mechanisms to construct connections for the input ports of
+            the invoked step. These mechanisms are not limited to the variety of mechnisms described
+            within this specification. Any extensions are implementation defined.</para>
+          <para>The set of <glossterm>in-scope bindings</glossterm> are constructed from a set of
+            option name/value pairs. Each option value can be a simple string value, a specific data
+            type instance (e.g. xs:dateTime), or a more complex value like a map item. How these
+            values are specified is implementation defined.</para>
+        </section>
 
       </section>
-      <section xml:id="f.step-available">
-        <title>Step Available</title>
-        <para>The <function>p:step-available</function> function reports whether or not a particular
-          type of step is understood by the processor.</para>
 
-<methodsynopsis>
-<type>xs:boolean</type>
-<methodname>p:step-available</methodname>
-<methodparam><type>xs:string</type><parameter>step-type</parameter></methodparam>
-</methodsynopsis>
+      <section xml:id="xpath-context">
+        <title>XPath in XProc</title>
 
-<para>The <varname>$step-type</varname> string <rfc2119>must</rfc2119>
-have the form of an
-<link xlink:href="https://www.w3.org/TR/xquery-30/#doc-xquery30-EQName">EQName</link>.
-If it is a QName, it is expanded using the namespace declarations in
-scope for the expression. The
-<function>p:step-available</function> function returns true if and
-only if the processor knows how to evaluate steps of the specified
-type.</para>
+        <para>XProc uses XPath 3.1 as an expression language. XPath expressions are evaluated by the
+          XProc processor in several places: on compound steps, to compute the default values of
+          options and the values of variables; on atomic steps, to compute the actual values of
+          options. </para>
 
-<para><impl>The value of the <function>p:step-available</function> function during
-static analysis is <glossterm>implementation-dependent</glossterm>.</impl></para>
-</section>
+        <para>XPath expressions are also passed to some steps. These expressions are evaluated by
+          the implementations of the individual steps.</para>
+        <para>This distinction can be seen in the following example:</para>
+        <programlisting language="xml"><xi:include href="../../../build/examples/xpathcontext.txt" parse="text"/></programlisting>
+        <para>The select expression on the variable “<varname>home</varname>” is evaluated by the
+          XProc processor. The value of the variable is “<uri>http://example.com/docs</uri>”.</para>
+        <para>The <option>href</option> option of the <tag>p:load</tag> step is evaluated by the
+          XProc processor. The actual <literal>href</literal> option received by the step is simply
+          the string literal “<uri>http://example.com/docs/document.xml</uri>”. (The select
+          expression on the <literal>source</literal> input of the <tag>p:split-sequence</tag> step
+          is also evaluated by the XProc processor.) </para>
+        <para>The XPath expression “<literal>@role='chapter'</literal>” is passed literally to the
+            <literal>test</literal> option on the <tag>p:split-sequence</tag> step. That's because
+          the nature of the <tag>p:split-sequence</tag> is that <emphasis>it evaluates</emphasis>
+          the expression. Only some options on some steps expect XPath expressions. </para>
 
-<section xml:id="f.iteration-position">
-<title>Iteration Position</title>
+        <para>The XProc processor evaluates all of the XPath expressions in <tag class="attribute"
+            >select</tag> attributes on variables, options, and inputs, in <tag class="attribute"
+            >match</tag> attributes on <tag>p:viewport</tag>, and in <tag class="attribute"
+            >test</tag> attributes on <tag>p:when</tag> and <tag>p:if</tag> steps.</para>
 
-<para>Some compound steps, such as <tag>p:for-each</tag> and <tag>p:viewport</tag>, process a
-sequence of documents. The iteration position is the position of the
-current document in that sequence: the first document has position 1, the
-second 2, etc. The <function>p:iteration-position</function> function
-returns the iteration position of the nearest compound step that processes
-a sequence of documents.</para>
+        <para>See <xref linkend="xproc-and-step-xpath-context"/> for a detailed description of the
+          context.</para>
+      </section>
+    </section>
+  </section>
 
-<methodsynopsis>
-<type>xs:integer</type>
-<methodname>p:iteration-position</methodname>
-<void/>
-</methodsynopsis>
+  <section xml:id="xpath-extension-functions">
+    <title>XPath Extension Functions</title>
 
-<para>If there is no compound step that processes a sequence of documents
-among the ancestors of the element on which the expression involving
-<function>p:iteration-position</function> occurs, it returns 1.</para>
+    <para>The XProc processor <rfc2119>must</rfc2119> support the additional functions described in
+      this section in XPath expressions evaluated by the processor.</para>
 
-<para>The value of the <function>p:iteration-position</function> function during
-static analysis is 1.</para>
-</section>
+    <para>These functions <rfc2119>must not</rfc2119> be supported in XPath expressions evaluated by
+      a step. In the interest of interoperability and to avoid imposing unnecessary constraints on
+      implementors, XPath expressions inside, for example, a template in an XSLT step, cannot be
+      aware of the XProc-defined functions. </para>
 
-<section xml:id="f.iteration-size">
-<title>Iteration Size</title>
+    <section xml:id="f.system-property">
+      <title>System Properties</title>
+      <para>XPath expressions within a pipeline document can interrogate the processor for
+        information about the current state of the pipeline. Various aspects of the processor are
+        exposed through the <function>p:system-property</function> function:</para>
 
-<para>Both <tag>p:for-each</tag> and <tag>p:viewport</tag> process a
-sequence of documents. The iteration size is the total number of documents
-in that sequence. The <function>p:iteration-size</function> function
-returns the iteration size of the nearest
-ancestor
-compound step that processes a sequence of documents.</para>
+      <methodsynopsis>
+        <type>xs:string</type>
+        <methodname>p:system-property</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>property</parameter>
+        </methodparam>
+      </methodsynopsis>
 
-<methodsynopsis>
-<type>xs:integer</type>
-<methodname>p:iteration-size</methodname>
-<void/>
-</methodsynopsis>
+      <para>The <varname>$property</varname> string <rfc2119>must</rfc2119> have the form of an
+          <link xlink:href="https://www.w3.org/TR/xquery-30/#doc-xquery30-EQName">EQName</link>. If
+        it is a QName, it is expanded using the namespace declarations in scope for the expression.
+          <error code="D0015">It is a <glossterm>dynamic error</glossterm> if a QName is specified
+          and it cannot be resolved with the in-scope namespace declarations.</error> The
+          <function>p:system-property</function> function returns the string representing the value
+        of the system property identified by the EQName. If there is no such property, the empty
+        string <rfc2119>must</rfc2119> be returned.</para>
 
-<para>If there is no <tag>p:for-each</tag> or <tag>p:viewport</tag>
-among the ancestors of the element on which the expression involving
-<function>p:iteration-size</function> occurs, it returns 1.</para>
+      <para>Implementations <rfc2119>must</rfc2119> provide the following system properties, which
+        are all in the XProc namespace:</para>
 
-<para>The value of the <function>p:iteration-size</function> function during
-static analysis is 1.</para>
-</section>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <varname>p:episode</varname>
+          </term>
+          <listitem>
+            <para>Returns a string which <rfc2119>should</rfc2119> be unique for each invocation of
+              the pipeline processor. In other words, if a processor is run several times in
+              succession, or if several processors are running simultaneously, each invocation of
+              each processor should get a distinct value from <varname>p:episode</varname>.</para>
+            <para>The unique identifier must be a valid <link
+                xlink:href="http://www.w3.org/TR/xml/#NT-Name">XML name</link>. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:locale</varname>
+          </term>
+          <listitem>
+            <para>Returns a string which identifies the current environment (usually the OS)
+              language. This is useful for, for example, message localization purposes. <impl>The
+                exact format of the language string is <glossterm>implementation-defined</glossterm>
+                but <rfc2119>should</rfc2119> be consistent with the <tag class="attribute"
+                  >xml:lang</tag> attribute.</impl></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:product-name</varname>
+          </term>
+          <listitem>
+            <para>Returns a string containing the name of the implementation, as defined by the
+              implementer. This should normally remain constant from one release of the product to
+              the next. It should also be constant across platforms in cases where the same source
+              code is used to produce compatible products for multiple execution platforms.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:product-version</varname>
+          </term>
+          <listitem>
+            <para>Returns a string identifying the version of the implementation, as defined by the
+              implementer. This should normally vary from one release of the product to the next,
+              and at the discretion of the implementer it may also vary across different execution
+              platforms. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:vendor</varname>
+          </term>
+          <listitem>
+            <para>Returns a string which identifies the vendor of the processor.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:vendor-uri</varname>
+          </term>
+          <listitem>
+            <para>Returns a URI which identifies the vendor of the processor. Often, this is the URI
+              of the vendor's web site.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:version</varname>
+          </term>
+          <listitem>
+            <para>Returns the version(s) of XProc implemented by the processor as a space-separated
+              list. For example, a processor that supports XProc 1.0 would return “1.0”; a processor
+              that supports XProc 1.0 and 3.0 would return “1.0 3.0”; a processor that supports only
+              XProc 3.0 would return “3.0”.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:xpath-version</varname>
+          </term>
+          <listitem>
+            <para>Returns the version(s) of XPath implemented by the processor for evaluating XPath
+              expressions on XProc elements. The result is a space-separated list of versions
+              supported. For example, a processor that only supports XPath 3.1 would return “3.1”; a
+              processor that supports XPath 3.1 and XPath 3.2 could return “3.1 3.2”.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <varname>p:psvi-supported</varname>
+          </term>
+          <listitem>
+            <para>Returns true if the implementation supports passing PSVI annotations between
+              steps, false otherwise.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<section xml:id="f.version-available">
-<title>Version Available</title>
+      <para>Implementations may support additional system properties but such properties
+          <rfc2119>must</rfc2119> be in a namespace and <rfc2119>must not</rfc2119> be in the XProc
+        namespace.</para>
 
-<para>Returns true if and only if the processor supports the version
-specified.</para>
+      <para>The <function>p:system-property</function> function behaves normally during static
+        analysis. <impl>It is <glossterm>implementation-defined</glossterm> which additional system
+          properties are available during static analysis.</impl> If an additional system property
+        is not available during static analysis, an empty string <rfc2119>must</rfc2119> be
+        returned.</para>
 
-<methodsynopsis>
-<type>xs:boolean</type>
-<methodname>p:version-available</methodname>
-<methodparam><type>xs:string</type><parameter>version</parameter></methodparam>
-</methodsynopsis>
+    </section>
+    <section xml:id="f.step-available">
+      <title>Step Available</title>
+      <para>The <function>p:step-available</function> function reports whether or not a particular
+        type of step is understood by the processor.</para>
 
-<para>A version 1.0 processor will return <literal>true()</literal> when
-<code>p:version-available('1.0')</code> is evaluated.</para>
+      <methodsynopsis>
+        <type>xs:boolean</type>
+        <methodname>p:step-available</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>step-type</parameter>
+        </methodparam>
+      </methodsynopsis>
 
-<para>The <function>p:version-available</function> function behaves
-normally during static analysis.</para>
-</section>
+      <para>The <varname>$step-type</varname> string <rfc2119>must</rfc2119> have the form of an
+          <link xlink:href="https://www.w3.org/TR/xquery-30/#doc-xquery30-EQName">EQName</link>. If
+        it is a QName, it is expanded using the namespace declarations in scope for the expression.
+        The <function>p:step-available</function> function returns true if and only if the processor
+        knows how to evaluate steps of the specified type.</para>
 
-<section xml:id="f.xpath-version-available">
-<title>XPath Version Available</title>
-
-<para>Returns true if and only if the processor supports the XPath version
-specified.</para>
-
-<methodsynopsis>
-<type>xs:boolean</type>
-<methodname>p:xpath-version-available</methodname>
-<methodparam><type>xs:string</type><parameter>version</parameter></methodparam>
-</methodsynopsis>
-
-<para>A processor that supports XPath 3.1 will return <literal>true()</literal> when
-<code>p:xpath-version-available('3.1')</code> is evaluated.</para>
-
-<para>The <function>p:xpath-version-available</function> function behaves
-normally during static analysis.</para>
-</section>
-
-<section xml:id="f.document-properties">
-<title>Document properties</title>
-
-<para>This function retrieves the <glossterm>document properties</glossterm>
-of a document as a map.</para>
-
-<methodsynopsis>
-<type>map(xs:QName,item()*)</type>
-<methodname>p:document-properties</methodname>
-<methodparam><type>item()</type><parameter>doc</parameter></methodparam>
-</methodsynopsis>
-
-<para>The map returned contains (exclusively) the document properties
-associated with the <parameter>doc</parameter> specified. If the item
-is not associated with a document, the resulting map will be empty.</para>
-
-<para>The <function>p:document-properties</function> function behaves
-normally during static analysis.</para>
-</section>
-
-<section xml:id="f.document-properties-document">
-<title>Document properties document</title>
-
-<para>This function retrieves the <glossterm>document properties</glossterm>
-of a document as an XML document.</para>
-
-<methodsynopsis>
-<type>document-node()</type>
-<methodname>p:document-properties-document</methodname>
-<methodparam><type>item()</type><parameter>doc</parameter></methodparam>
-</methodsynopsis>
-
-<para>The document returned is a <tag>c:document-properties</tag>
-document that contains (exclusively) the document properties
-associated with the <parameter>doc</parameter> specified.
-If the item is not associated with a document, the <tag>c:document-properties</tag>
-element will be empty.</para>
-
-<para>The underlying properties are serialized as follows:</para>
-
-<itemizedlist>
-<listitem>
-<para>Each property/value pair in the map becomes an element in the
-document. The property name is used as the name of the element and the
-value becomes the element content.
-</para>
-</listitem>
-<listitem>
-<para>If the property value is a sequence, then the element is
-repeated for each item in the sequence.
-</para>
-</listitem>
-<listitem>
-<para>If a map appears as a value, the property element will have an
-attribute named <tag class="attribute">map</tag> with the value “<code>true</code>”.
-<impl>It is <glossterm>implementation-defined</glossterm> how or if a
-processor attempts to serialize maps that appear in document properties.</impl>
-If the implementation does not serialize maps, the property element will be empty.
-</para>
-</listitem>
-<listitem>
-<para>If an array appears as a value, the property element will have an
-attribute named <tag class="attribute">array</tag> with the value “<code>true</code>”.
-<impl>It is <glossterm>implementation-defined</glossterm> how or if a
-processor attempts to serialize arrays that appear in document properties.</impl>
-If the implementation does not serialize arrays, the property element will be empty.
-</para>
-</listitem>
-<listitem>
-<para>For atomic values other than maps, arrays, and strings, an <tag
-class="attribute">xsi:type</tag> attribute is added to the element to
-identify the type of the value.
-</para>
-</listitem>
-</itemizedlist>
-
-<para>If any values in the properties map cannot be serialized, an empty string
-is used for their value. Construction of the <tag>c:document-properties</tag> document
-never fails.</para>
-
-<para>The <function>p:document-properties-document</function> function behaves
-normally during static analysis.</para>
-</section>
-
-<section xml:id="f.document-property">
-<title>Document property</title>
-
-<para>This function retrieves a single value from the
-<glossterm>document properties</glossterm> of a document.</para>
-
-<methodsynopsis>
-<type>item()*</type>
-<methodname>p:document-property</methodname>
-<methodparam><type>item()</type><parameter>doc</parameter></methodparam>
-<methodparam><type>item()</type><parameter>key</parameter></methodparam>
-</methodsynopsis>
-
-  <para>The item returned is the value of the property named <code>$key</code> 
-in the document properties. An empty sequence is returned if <code>$doc</code> is
-not associated with a document or no such key exists. <code>$key</code> is 
-interpreted as follows:</para>
-  
-  <itemizedlist>
-    <listitem>
-      <para>If <code>$key</code> is of type <type>xs:QName</type>, its value is used unchanged.</para>
-    </listitem>
-    <listitem>
-      <para>If <code>$key</code> is an instance of type <type>xs:string</type> (or a type derived from
-        <type>xs:string</type>) its value is transformed into a <type>xs:Qname</type> using the <link
-          xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName"
-          >XPath EQName production rules</link>. That is, it can be written
-        as a local-name only, as a prefix plus local-name or as a URI plus
-        local-name (using the <code>Q{}</code> syntax).</para>
       <para>
-        <error code="D0061">It is a <glossterm>dynamic error</glossterm>
-          if <code>$key</code> is of type <type>xs:string</type> and cannot be converted into a <type>xs:Qname</type>.</error>
+        <impl>The value of the <function>p:step-available</function> function during static analysis
+          is <glossterm>implementation-dependent</glossterm>.</impl>
       </para>
-    </listitem>
-    <listitem>
-      <para>If <code>$key</code> is of any other type, the function returns the empty sequence.</para>
-    </listitem>
-  </itemizedlist>
-
-<para>The <function>p:document-property</function> function behaves
-normally during static analysis.</para>
-</section>
-  
-  <section xml:id="f.urify">
-   <title>Transform filesystem paths into URIs</title>
-  <para><function>p:urify</function> is a function that attempts to transform file system paths into file URIs (<biblioref
-      linkend="rfc2396"/>). If a URI is already given as an argument, it <rfc2119>should</rfc2119> return it unchanged, 
-    apart from character escaping and path normalizations that are permitted for (presumptive) file URIs.</para>
-
-  <methodsynopsis>
-    <type>xs:string</type>
-    <methodname>p:urify</methodname>
-    <methodparam><type>xs:string</type><parameter>filepath</parameter></methodparam>
-    <methodparam><type>xs:string?</type><parameter>basedir</parameter></methodparam>
-  </methodsynopsis>
-  
-    <methodsynopsis>
-      <type>xs:string</type>
-      <methodname>p:urify</methodname>
-      <methodparam><type>xs:string</type><parameter>filepath</parameter></methodparam>
-    </methodsynopsis>
-
-<para>If the single-argument version of the function is used, the result is the same as calling 
-the two-argument version with <parameter>basedir</parameter> set to empty sequence.</para>
-<para>The function may be implemented as an operation on strings; it
-need not try to determine the existence of a file or directory, and it
-<rfc2119>should not</rfc2119> follow symbolic links. <impl>How <function>p:urify</function>
-transforms its arguments into a URI is
-<glossterm>implementation-defined</glossterm></impl>.</para>
-
-<para>The purpose of this function is to resolve a file system path to
-a URI on the platform that the processor runs on; the function need
-not resolve, for example, Windows paths when the processor runs on a
-Unix-like operating system. The function is intended as a convenience
-for pipeline authors and users for transforming OS specific paths and
-paths relative to the working directory from which they invoked the
-processor.</para>
-
-<para>The function should support Unix-like (for example, Linux,
-Solaris, Mac OS X) and Windows file system paths. For Windows paths,
-the forward slash and the backslash <rfc2119>should</rfc2119> be
-considered equivalent. Operating systems with other filesystem path
-addressing schemes (for example, VMS or Mac OS) need not be
-supported.</para>
-  <para>Each argument may be an operating system path, including paths with drive letters and UNC paths on Windows, or a URI.
-    On non-Windows systems, file URIs that contain an authority component (<literal>file://hostname/path</literal>) may be reported 
-    as an error.</para>
-  <para>The function need not make sure that an argument identified as a URI is already a <emphasis>correct</emphasis> URI
-    according to <biblioref linkend="rfc2396"/>. It may attempt to correct errors in purported file URIs, such as fixing the
-    missing escaping of a space character. It <rfc2119>should</rfc2119> leave presumptive non-file URIs unchanged.
-  The scheme-relative URI <literal>//hostname/path</literal>) may be reported as an error on non-Windows platforms,
-    even though the omitted scheme may well be a non-file scheme.</para>
-  <para>The function may normalize URIs and file system paths by contracting multiple consecutive directory path separator slashes,
-    by eliminating path components <code>.</code> or by letting path components <code>..</code> “consume” their parent path 
-    components. Other permitted normalizations contain, but are not limited to, making Windows drive letters uppercase or
-  making the URI scheme lowercase.</para>
-  <para>The function is allowed to produce URIs that do not strictly conform to <biblioref linkend="rfc2396"/> as long as the
-    URIs can be resolved by the processor and by the standard steps that ship with the processor. Examples for non-conforming
-    yet probably acceptable URIs are file URIs with a single slash instead of three slashes after <literal>file:</literal> or
-    URIs that contain unescaped UTF-8 characters whose codepoints are above the ASCII range.</para>
-
-<para><impl>For any URI argument to <function>p:urify</function>, it is
-<glossterm>implementation-dependent</glossterm> whether query or
-fragment components are supported.</impl> An implementation may choose to
-return them unchanged, to silently omit them, or to raise an error. It
-<rfc2119>must not</rfc2119> return <literal>?</literal> and
-<literal>#</literal> escaped though.</para>
-
-<para>If the <parameter>basedir</parameter> argument is omitted or is the empty sequence, the current working directory should be used
-    if available. The <parameter>basedir</parameter> argument or the current working directory need only be considered if the
-      <parameter>filepath</parameter> is determined to be a relative path or URI.</para>
-  <note xml:id="note-urify-encoding">
-    <para>Sometimes file names are created in an encoding that does not match the system’s locale. This function does not aim at
-      solving these issues. Implementations should not try to correct apparent errors that originate from garbled encodings
-      since they will probably not be able to produce file URIs that address the corresponding files correctly.</para>
-    <para>Likewise it is also possible, in particular on Windows, that the encoding gets garbled when command line arguments are
-      passed to the processor. On modern Windows 10 versions (April 2018 or later), this can be addressed by setting the system
-      locale to UTF-8.</para>
-  </note>
-  <note role="editorial" xml:id="ednote-test-p_urify">
-    <title>Testing</title>
-    <para>Depending on the system where the tests run on, the results may vary. For example, an implementation may add a
-      trailing slash to the file URI if it recognizes that it represents a directory.</para>
-    <para>One way to make the test results more predictable is to provide an additional function argument that holds a map with
-      certain overriding parameters, such as the <code>file-separator</code> or whether the <code>filepath</code> argument
-      represents a directory. However, this is impractical if the implementation relies on external libraries to perform the
-      conversion.</para>
-    <para>A test suite may therefore specify system-dependent tests that run only on Windows or Linux and that accept function
-      results with or without a trailing slash.</para>
-  </note>
-  <para>The <function>p:urify</function> function behaves normally during static analysis.</para>
-  <simplesect>
-    <title>Examples</title>
-    <itemizedlist>
-      <title>Windows</title>
-      <listitem>
-        <para><literal>c:\path\to\file</literal> → <literal>file:///c:/path/to/file</literal>
-            (<literal>file:///C:/path/to/file</literal> will also be correct, as will
-            <literal>file:///c:/path/to/file/</literal> be if the implementation detects that
-            <literal>c:/path/to/file/</literal> is actually a directory)</para>
-      </listitem>
-      <listitem>
-        <para><literal>\\hostname\path\to\file</literal>, <literal>\\hostname/path/to/file</literal> or 
-          <literal>//hostname/path/to/file</literal> → <literal>file://hostname/path/to/file</literal></para>
-      </listitem>
-      <listitem>
-        <para><literal>C:/Program Files (x86)</literal> → <literal>file:///C:/Program%20Files%20(x86)</literal>
-        (or <literal>file:///C:/Program%20Files%20(x86)/</literal>)</para>
-      </listitem>
-      <listitem>
-        <para><literal>temp</literal>, <literal>/</literal> (two arguments) → <literal>file:///C:/temp/</literal> (depending on
-        the drive letter of the current working directory, and possibly without the trailing slash)</para>
-      </listitem>
-      <listitem>
-        <para><literal>[workspace]</literal>, <literal>E:\temp</literal> → <literal>file:///E:/temp/%5Bworkspace%5D/</literal>
-        (or without trailing slash)</para>
-      </listitem>
-    </itemizedlist>
-    <itemizedlist>
-      <title>Unix-like or Windows</title>
-      <listitem>
-        <para><literal>x y/rαaßβöů亊.txt</literal> → <literal>…/x%20y/r%CE%B1a%C3%9F%CE%B2%C3%B6%C5%AF%E4%BA%8A.txt</literal>
-        (where <literal>…</literal> represents the file URI of the current working directory) 
-          (or <literal>…/x%20y/rαaßβöů亊.txt</literal> if unescaped non-ASCII UTF-8 is acceptable
-          on the given processor/OS combination)</para>
-        <para><literal>@50%.csv</literal> → <literal>…/@50%25.csv</literal></para>
-        <para><literal>@50%25.csv</literal> → <literal>…/@50%2525.csv</literal></para>
-      </listitem>
-    </itemizedlist>
-    <itemizedlist>
-      <title>Unix-like</title>
-      <listitem>
-        <para><literal>/etc</literal> → <literal>file:///etc/</literal>
-        (or <literal>file:///etc</literal>)</para>
-        <para><literal>file:/etc</literal> → <literal>file:///etc/</literal>
-        (or <literal>file:///etc</literal>)</para>
-        <para><literal>/etc?foo=bar#fragment</literal> → <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
-        <para><literal>file:/etc?foo=bar#fragment</literal> → error (or <literal>file:///etc?foo=bar#fragment</literal>,
-        <literal>file:///etc</literal>, or <literal>file:///etc/</literal></para>
-        <para><literal>/etc?foo=bar#fragment</literal> → <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
-        <para><literal>file:///etc%3Ffoo=bar%23fragment</literal> → <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
-      </listitem>
-    </itemizedlist>
-  </simplesect>
-  <simplesect>
-    <title>Errors</title>
-
-    <para>It is a dynamic error if <code>$filepath</code> is
-    determined to be relative, no <code>$basedir</code> is given that
-    can be transformed into an absolute URI and the current working
-    directory is unavailable.</para>
-
-    <para><impl>Other <glossterm>implementation-dependent</glossterm> errors may be thrown by
-<function>p:urify</function>.</impl></para>
-  </simplesect>
-</section>
-
-<section xml:id="f.function-library-importable">
-<title>Function library importable</title>
-
-<para>The <function>p:function-library-importable</function> function
-reports whether or not function libraries of a particular type can be imported.
-</para>
-
-<methodsynopsis>
-<type>xs:boolean</type>
-<methodname>p:function-library-importable</methodname>
-<methodparam><type>xs:string</type><parameter>library-type</parameter></methodparam>
-</methodsynopsis>
-
-<para>The <varname>$library-type</varname> string is interpreted as a content type.
-If the processor understands
-(<foreignphrase>i.e.</foreignphrase> if <tag>p:import-functions</tag> understands)
-how to load function libraries of that type, this function returns
-<literal>true()</literal>, otherewise it returns <literal>false()</literal>.
-</para>
-
-<para>The <function>p:function-library-importable</function> function behaves
-normally during static analysis.</para>
-</section>
-
-<section xml:id="other-xpath-extension-functions">
-  <title>Other XPath Extension Functions</title>
-  <para><impl>It is <glossterm>implementation-defined</glossterm> if the processor supports
-  any other XPath extension functions.</impl> Additional extension functions, if any,
-  <rfc2119>must not</rfc2119> use any of the XProc namespaces. </para>
-
-<para><impl>The value of the any other XPath extension functions during
-static analysis is <glossterm>implementation-defined</glossterm>.</impl></para>
-</section>
-</section>
-
-  <section xml:id="psvi-support">
-      <title>PSVIs in XProc</title>
-      <para>XML documents flow between steps in an XProc pipeline. <xref
-          linkend="infoset-conformance"/> identifies the properties of those documents that
-          <rfc2119>must</rfc2119> be available. Implementations <rfc2119>may</rfc2119> also have the
-        ability to pass PSVI annotations between steps.</para>
-      <para><impl>Whether or not the pipeline processor supports passing PSVI annotations between
-          steps is <glossterm>implementation-defined</glossterm>.</impl>
-        <impl>The exact PSVI properties that are preserved when documents are passed between steps
-          is <glossterm>implementation-defined</glossterm>.</impl></para>
-      <para>A pipeline can use the <varname>p:psvi-supported</varname> system property to determine
-        whether or not PSVI properties can be passed between steps.</para>
-      <para>A pipeline can assert that PSVI support is required with the <tag class="attribute"
-          >psvi-required</tag> attribute:</para>
-      <itemizedlist>
-        <listitem>
-          <para>On a <tag>p:declare-step</tag>, <tag class="attribute"
-              >psvi-required</tag> indicates whether or not the declared step requires PSVI support.
-              <error code="D0022">It is a <glossterm>dynamic error</glossterm> if a processor that
-              does not support PSVI annotations attempts to invoke a step which asserts that they
-              are required.</error></para>
-        </listitem>
-        <listitem>
-          <para>On a <tag>p:library</tag>, the <tag class="attribute">psvi-required</tag> attribute
-            provides a default value for all of its <tag>p:declare-step</tag>
-            <emphasis>children</emphasis> that do not specify a value themselves.</para>
-        </listitem>
-      </itemizedlist>
-      <para>Many of the steps that an XProc pipeline can use are transformative in nature. The
-          <tag>p:delete</tag> step, for example, can remove elements and attributes; the
-          <tag>p:label-elements</tag> step can add attributes; etc. If PSVI annotations were always
-        preserved, the use of such steps could result in documents that were inconsistent with their
-        schema annotations.</para>
-      <para>In order to avoid these inconsistencies, most steps <rfc2119>must not</rfc2119> produce
-        PSVI annotated results even when PSVI passing is supported.</para>
-      <para>If PSVI passing is supported, the following constraints apply:</para>
-      <orderedlist>
-        <listitem>
-          <para>Implementations <rfc2119>must</rfc2119> faithfully transmit any PSVI properties
-            produced on step outputs to the steps to which they are connected.</para>
-        </listitem>
-        <listitem>
-          <para>When only a subset of the input is processed by a step (because a <tag
-              class="attribute">select</tag> expression appears on an input port or a <tag
-              class="attribute">match</tag> expression is used to process only part of the input),
-            any PSVI annotations that appear on the selected input <rfc2119>must</rfc2119> be
-            preserved in the resulting documents passed to the step.</para>
-          <para>Note that ID/IDREF constraints, and any other whole-document constraints, may not be
-            satisfied within the selected portion, irrespective of what its PSVI properties
-            claim.</para>
-        </listitem>
-        <listitem>
-          <para>If an output of a compound step is connected to an output which includes PSVI
-            properties, those properties <rfc2119>must</rfc2119> be preserved on the output of the
-            compound step, <emphasis>except</emphasis> for the output of <tag>p:viewport</tag> which
-              <rfc2119>must not</rfc2119> contain any PSVI properties.</para>
-        </listitem>
-        <listitem>
-          <para>If an implementation supports XPath 2.0 or later, the data model constructed with which to
-            evaluate XPath expressions and <glossterm baseform="selection pattern">selection patterns</glossterm> <rfc2119>should</rfc2119> take advantage
-            of as much PSVI information as possible. </para>
-          <para>
-          <termdef xml:id="dt-selection-pattern">A <firstterm>selection pattern</firstterm> uses a
-            subset of the syntax for path expressions, and is defined to match a node if the
-            corresponding path expression would select the node. It is defined as in the 
-            <link xlink:href="https://www.w3.org/TR/xslt-30/#dt-selection-pattern">XSLT 3.0
-              specification</link>.</termdef></para>
-        </listitem>
-        <listitem>
-          <para>Except as specified above, or in the descriptions of individual steps,
-            implementations <rfc2119>must not</rfc2119> include PSVI properties in the outputs of
-            steps defined by this specification. <impl>It is
-                <glossterm>implementation-defined</glossterm> what PSVI properties, if any, are
-              produced by extension steps.</impl></para>
-          <para>The exceptions in the standard XProc steps are the
-              <tag>p:validate-with-xml-schema</tag>, <tag>p:validate-with-relax-ng</tag>, and
-              <tag>p:validate-with-schematron</tag> steps, <tag>p:xslt</tag> (when XSLT 2.0 is
-            used), <tag>p:xquery</tag>, <tag>p:identity</tag>, and <tag>p:split-sequence</tag>.
-          </para>
-        </listitem>
-      </orderedlist>
-      <note xml:id="note-psvi">
-        <para>A processor that supports passing PSVI properties between steps is always free to do
-          so. Even if <code>psvi-required="false"</code> is explicitly specified, it is not an error
-          for a step to produce a result that includes additional PSVI properties, provide it does
-          not violate the constraints above.</para>
-      </note>
     </section>
 
-<section xml:id="value-templates">
-<title>Value Templates</title>
+    <section xml:id="f.iteration-position">
+      <title>Iteration Position</title>
 
-<para>An attribute or text node in a pipeline may, in particular
-circumstances, contain embedded expressions enclosed between curly
-brackets. Attributes and text nodes that use (or are permitted to use)
-this mechanism are referred to respectively as <glossterm
-baseform="attribute value template">attribute value
-templates</glossterm> (AVTs) and <glossterm baseform="text value
+      <para>Some compound steps, such as <tag>p:for-each</tag> and <tag>p:viewport</tag>, process a
+        sequence of documents. The iteration position is the position of the current document in
+        that sequence: the first document has position 1, the second 2, etc. The
+          <function>p:iteration-position</function> function returns the iteration position of the
+        nearest compound step that processes a sequence of documents.</para>
+
+      <methodsynopsis>
+        <type>xs:integer</type>
+        <methodname>p:iteration-position</methodname>
+        <void/>
+      </methodsynopsis>
+
+      <para>If there is no compound step that processes a sequence of documents among the ancestors
+        of the element on which the expression involving <function>p:iteration-position</function>
+        occurs, it returns 1.</para>
+
+      <para>The value of the <function>p:iteration-position</function> function during static
+        analysis is 1.</para>
+    </section>
+
+    <section xml:id="f.iteration-size">
+      <title>Iteration Size</title>
+
+      <para>Both <tag>p:for-each</tag> and <tag>p:viewport</tag> process a sequence of documents.
+        The iteration size is the total number of documents in that sequence. The
+          <function>p:iteration-size</function> function returns the iteration size of the nearest
+        ancestor compound step that processes a sequence of documents.</para>
+
+      <methodsynopsis>
+        <type>xs:integer</type>
+        <methodname>p:iteration-size</methodname>
+        <void/>
+      </methodsynopsis>
+
+      <para>If there is no <tag>p:for-each</tag> or <tag>p:viewport</tag> among the ancestors of the
+        element on which the expression involving <function>p:iteration-size</function> occurs, it
+        returns 1.</para>
+
+      <para>The value of the <function>p:iteration-size</function> function during static analysis
+        is 1.</para>
+    </section>
+
+    <section xml:id="f.version-available">
+      <title>Version Available</title>
+
+      <para>Returns true if and only if the processor supports the version specified.</para>
+
+      <methodsynopsis>
+        <type>xs:boolean</type>
+        <methodname>p:version-available</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>version</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>A version 1.0 processor will return <literal>true()</literal> when
+          <code>p:version-available('1.0')</code> is evaluated.</para>
+
+      <para>The <function>p:version-available</function> function behaves normally during static
+        analysis.</para>
+    </section>
+
+    <section xml:id="f.xpath-version-available">
+      <title>XPath Version Available</title>
+
+      <para>Returns true if and only if the processor supports the XPath version specified.</para>
+
+      <methodsynopsis>
+        <type>xs:boolean</type>
+        <methodname>p:xpath-version-available</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>version</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>A processor that supports XPath 3.1 will return <literal>true()</literal> when
+          <code>p:xpath-version-available('3.1')</code> is evaluated.</para>
+
+      <para>The <function>p:xpath-version-available</function> function behaves normally during
+        static analysis.</para>
+    </section>
+
+    <section xml:id="f.document-properties">
+      <title>Document properties</title>
+
+      <para>This function retrieves the <glossterm>document properties</glossterm> of a document as
+        a map.</para>
+
+      <methodsynopsis>
+        <type>map(xs:QName,item()*)</type>
+        <methodname>p:document-properties</methodname>
+        <methodparam>
+          <type>item()</type>
+          <parameter>doc</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>The map returned contains (exclusively) the document properties associated with the
+          <parameter>doc</parameter> specified. If the item is not associated with a document, the
+        resulting map will be empty.</para>
+
+      <para>The <function>p:document-properties</function> function behaves normally during static
+        analysis.</para>
+    </section>
+
+    <section xml:id="f.document-properties-document">
+      <title>Document properties document</title>
+
+      <para>This function retrieves the <glossterm>document properties</glossterm> of a document as
+        an XML document.</para>
+
+      <methodsynopsis>
+        <type>document-node()</type>
+        <methodname>p:document-properties-document</methodname>
+        <methodparam>
+          <type>item()</type>
+          <parameter>doc</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>The document returned is a <tag>c:document-properties</tag> document that contains
+        (exclusively) the document properties associated with the <parameter>doc</parameter>
+        specified. If the item is not associated with a document, the
+          <tag>c:document-properties</tag> element will be empty.</para>
+
+      <para>The underlying properties are serialized as follows:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>Each property/value pair in the map becomes an element in the document. The property
+            name is used as the name of the element and the value becomes the element content.
+          </para>
+        </listitem>
+        <listitem>
+          <para>If the property value is a sequence, then the element is repeated for each item in
+            the sequence. </para>
+        </listitem>
+        <listitem>
+          <para>If a map appears as a value, the property element will have an attribute named <tag
+              class="attribute">map</tag> with the value “<code>true</code>”. <impl>It is
+                <glossterm>implementation-defined</glossterm> how or if a processor attempts to
+              serialize maps that appear in document properties.</impl> If the implementation does
+            not serialize maps, the property element will be empty. </para>
+        </listitem>
+        <listitem>
+          <para>If an array appears as a value, the property element will have an attribute named
+              <tag class="attribute">array</tag> with the value “<code>true</code>”. <impl>It is
+                <glossterm>implementation-defined</glossterm> how or if a processor attempts to
+              serialize arrays that appear in document properties.</impl> If the implementation does
+            not serialize arrays, the property element will be empty. </para>
+        </listitem>
+        <listitem>
+          <para>For atomic values other than maps, arrays, and strings, an <tag class="attribute"
+              >xsi:type</tag> attribute is added to the element to identify the type of the value.
+          </para>
+        </listitem>
+      </itemizedlist>
+
+      <para>If any values in the properties map cannot be serialized, an empty string is used for
+        their value. Construction of the <tag>c:document-properties</tag> document never
+        fails.</para>
+
+      <para>The <function>p:document-properties-document</function> function behaves normally during
+        static analysis.</para>
+    </section>
+
+    <section xml:id="f.document-property">
+      <title>Document property</title>
+
+      <para>This function retrieves a single value from the <glossterm>document
+          properties</glossterm> of a document.</para>
+
+      <methodsynopsis>
+        <type>item()*</type>
+        <methodname>p:document-property</methodname>
+        <methodparam>
+          <type>item()</type>
+          <parameter>doc</parameter>
+        </methodparam>
+        <methodparam>
+          <type>item()</type>
+          <parameter>key</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>The item returned is the value of the property named <code>$key</code> in the document
+        properties. An empty sequence is returned if <code>$doc</code> is not associated with a
+        document or no such key exists. <code>$key</code> is interpreted as follows:</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>If <code>$key</code> is of type <type>xs:QName</type>, its value is used
+            unchanged.</para>
+        </listitem>
+        <listitem>
+          <para>If <code>$key</code> is an instance of type <type>xs:string</type> (or a type
+            derived from <type>xs:string</type>) its value is transformed into a
+              <type>xs:Qname</type> using the <link
+              xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">XPath EQName
+              production rules</link>. That is, it can be written as a local-name only, as a prefix
+            plus local-name or as a URI plus local-name (using the <code>Q{}</code> syntax).</para>
+          <para>
+            <error code="D0061">It is a <glossterm>dynamic error</glossterm> if <code>$key</code> is
+              of type <type>xs:string</type> and cannot be converted into a
+              <type>xs:Qname</type>.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>If <code>$key</code> is of any other type, the function returns the empty
+            sequence.</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>The <function>p:document-property</function> function behaves normally during static
+        analysis.</para>
+    </section>
+
+    <section xml:id="f.urify">
+      <title>Transform filesystem paths into URIs</title>
+      <para><function>p:urify</function> is a function that attempts to transform file system paths
+        into file URIs (<biblioref linkend="rfc2396"/>). If a URI is already given as an argument,
+        it <rfc2119>should</rfc2119> return it unchanged, apart from character escaping and path
+        normalizations that are permitted for (presumptive) file URIs.</para>
+
+      <methodsynopsis>
+        <type>xs:string</type>
+        <methodname>p:urify</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>filepath</parameter>
+        </methodparam>
+        <methodparam>
+          <type>xs:string?</type>
+          <parameter>basedir</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <methodsynopsis>
+        <type>xs:string</type>
+        <methodname>p:urify</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>filepath</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>If the single-argument version of the function is used, the result is the same as
+        calling the two-argument version with <parameter>basedir</parameter> set to empty
+        sequence.</para>
+      <para>The function may be implemented as an operation on strings; it need not try to determine
+        the existence of a file or directory, and it <rfc2119>should not</rfc2119> follow symbolic
+        links. <impl>How <function>p:urify</function> transforms its arguments into a URI is
+            <glossterm>implementation-defined</glossterm></impl>.</para>
+
+      <para>The purpose of this function is to resolve a file system path to a URI on the platform
+        that the processor runs on; the function need not resolve, for example, Windows paths when
+        the processor runs on a Unix-like operating system. The function is intended as a
+        convenience for pipeline authors and users for transforming OS specific paths and paths
+        relative to the working directory from which they invoked the processor.</para>
+
+      <para>The function should support Unix-like (for example, Linux, Solaris, Mac OS X) and
+        Windows file system paths. For Windows paths, the forward slash and the backslash
+          <rfc2119>should</rfc2119> be considered equivalent. Operating systems with other
+        filesystem path addressing schemes (for example, VMS or Mac OS) need not be
+        supported.</para>
+      <para>Each argument may be an operating system path, including paths with drive letters and
+        UNC paths on Windows, or a URI. On non-Windows systems, file URIs that contain an authority
+        component (<literal>file://hostname/path</literal>) may be reported as an error.</para>
+      <para>The function need not make sure that an argument identified as a URI is already a
+          <emphasis>correct</emphasis> URI according to <biblioref linkend="rfc2396"/>. It may
+        attempt to correct errors in purported file URIs, such as fixing the missing escaping of a
+        space character. It <rfc2119>should</rfc2119> leave presumptive non-file URIs unchanged. The
+        scheme-relative URI <literal>//hostname/path</literal>) may be reported as an error on
+        non-Windows platforms, even though the omitted scheme may well be a non-file scheme.</para>
+      <para>The function may normalize URIs and file system paths by contracting multiple
+        consecutive directory path separator slashes, by eliminating path components <code>.</code>
+        or by letting path components <code>..</code> “consume” their parent path components. Other
+        permitted normalizations contain, but are not limited to, making Windows drive letters
+        uppercase or making the URI scheme lowercase.</para>
+      <para>The function is allowed to produce URIs that do not strictly conform to <biblioref
+          linkend="rfc2396"/> as long as the URIs can be resolved by the processor and by the
+        standard steps that ship with the processor. Examples for non-conforming yet probably
+        acceptable URIs are file URIs with a single slash instead of three slashes after
+          <literal>file:</literal> or URIs that contain unescaped UTF-8 characters whose codepoints
+        are above the ASCII range.</para>
+
+      <para><impl>For any URI argument to <function>p:urify</function>, it is
+            <glossterm>implementation-dependent</glossterm> whether query or fragment components are
+          supported.</impl> An implementation may choose to return them unchanged, to silently omit
+        them, or to raise an error. It <rfc2119>must not</rfc2119> return <literal>?</literal> and
+          <literal>#</literal> escaped though.</para>
+
+      <para>If the <parameter>basedir</parameter> argument is omitted or is the empty sequence, the
+        current working directory should be used if available. The <parameter>basedir</parameter>
+        argument or the current working directory need only be considered if the
+          <parameter>filepath</parameter> is determined to be a relative path or URI.</para>
+      <note xml:id="note-urify-encoding">
+        <para>Sometimes file names are created in an encoding that does not match the system’s
+          locale. This function does not aim at solving these issues. Implementations should not try
+          to correct apparent errors that originate from garbled encodings since they will probably
+          not be able to produce file URIs that address the corresponding files correctly.</para>
+        <para>Likewise it is also possible, in particular on Windows, that the encoding gets garbled
+          when command line arguments are passed to the processor. On modern Windows 10 versions
+          (April 2018 or later), this can be addressed by setting the system locale to UTF-8.</para>
+      </note>
+      <note role="editorial" xml:id="ednote-test-p_urify">
+        <title>Testing</title>
+        <para>Depending on the system where the tests run on, the results may vary. For example, an
+          implementation may add a trailing slash to the file URI if it recognizes that it
+          represents a directory.</para>
+        <para>One way to make the test results more predictable is to provide an additional function
+          argument that holds a map with certain overriding parameters, such as the
+            <code>file-separator</code> or whether the <code>filepath</code> argument represents a
+          directory. However, this is impractical if the implementation relies on external libraries
+          to perform the conversion.</para>
+        <para>A test suite may therefore specify system-dependent tests that run only on Windows or
+          Linux and that accept function results with or without a trailing slash.</para>
+      </note>
+      <para>The <function>p:urify</function> function behaves normally during static
+        analysis.</para>
+      <simplesect>
+        <title>Examples</title>
+        <itemizedlist>
+          <title>Windows</title>
+          <listitem>
+            <para><literal>c:\path\to\file</literal> → <literal>file:///c:/path/to/file</literal>
+                (<literal>file:///C:/path/to/file</literal> will also be correct, as will
+                <literal>file:///c:/path/to/file/</literal> be if the implementation detects that
+                <literal>c:/path/to/file/</literal> is actually a directory)</para>
+          </listitem>
+          <listitem>
+            <para><literal>\\hostname\path\to\file</literal>,
+                <literal>\\hostname/path/to/file</literal> or
+                <literal>//hostname/path/to/file</literal> →
+                <literal>file://hostname/path/to/file</literal></para>
+          </listitem>
+          <listitem>
+            <para><literal>C:/Program Files (x86)</literal> →
+                <literal>file:///C:/Program%20Files%20(x86)</literal> (or
+                <literal>file:///C:/Program%20Files%20(x86)/</literal>)</para>
+          </listitem>
+          <listitem>
+            <para><literal>temp</literal>, <literal>/</literal> (two arguments) →
+                <literal>file:///C:/temp/</literal> (depending on the drive letter of the current
+              working directory, and possibly without the trailing slash)</para>
+          </listitem>
+          <listitem>
+            <para><literal>[workspace]</literal>, <literal>E:\temp</literal> →
+                <literal>file:///E:/temp/%5Bworkspace%5D/</literal> (or without trailing
+              slash)</para>
+          </listitem>
+        </itemizedlist>
+        <itemizedlist>
+          <title>Unix-like or Windows</title>
+          <listitem>
+            <para><literal>x y/rαaßβöů亊.txt</literal> →
+                <literal>…/x%20y/r%CE%B1a%C3%9F%CE%B2%C3%B6%C5%AF%E4%BA%8A.txt</literal> (where
+                <literal>…</literal> represents the file URI of the current working directory) (or
+                <literal>…/x%20y/rαaßβöů亊.txt</literal> if unescaped non-ASCII UTF-8 is acceptable
+              on the given processor/OS combination)</para>
+            <para><literal>@50%.csv</literal> → <literal>…/@50%25.csv</literal></para>
+            <para><literal>@50%25.csv</literal> → <literal>…/@50%2525.csv</literal></para>
+          </listitem>
+        </itemizedlist>
+        <itemizedlist>
+          <title>Unix-like</title>
+          <listitem>
+            <para><literal>/etc</literal> → <literal>file:///etc/</literal> (or
+                <literal>file:///etc</literal>)</para>
+            <para><literal>file:/etc</literal> → <literal>file:///etc/</literal> (or
+                <literal>file:///etc</literal>)</para>
+            <para><literal>/etc?foo=bar#fragment</literal> →
+                <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
+            <para><literal>file:/etc?foo=bar#fragment</literal> → error (or
+                <literal>file:///etc?foo=bar#fragment</literal>, <literal>file:///etc</literal>, or
+                <literal>file:///etc/</literal></para>
+            <para><literal>/etc?foo=bar#fragment</literal> →
+                <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
+            <para><literal>file:///etc%3Ffoo=bar%23fragment</literal> →
+                <literal>file:///etc%3Ffoo=bar%23fragment</literal></para>
+          </listitem>
+        </itemizedlist>
+      </simplesect>
+      <simplesect>
+        <title>Errors</title>
+
+        <para>It is a dynamic error if <code>$filepath</code> is determined to be relative, no
+            <code>$basedir</code> is given that can be transformed into an absolute URI and the
+          current working directory is unavailable.</para>
+
+        <para>
+          <impl>Other <glossterm>implementation-dependent</glossterm> errors may be thrown by
+              <function>p:urify</function>.</impl>
+        </para>
+      </simplesect>
+    </section>
+
+    <section xml:id="f.function-library-importable">
+      <title>Function library importable</title>
+
+      <para>The <function>p:function-library-importable</function> function reports whether or not
+        function libraries of a particular type can be imported. </para>
+
+      <methodsynopsis>
+        <type>xs:boolean</type>
+        <methodname>p:function-library-importable</methodname>
+        <methodparam>
+          <type>xs:string</type>
+          <parameter>library-type</parameter>
+        </methodparam>
+      </methodsynopsis>
+
+      <para>The <varname>$library-type</varname> string is interpreted as a content type. If the
+        processor understands (<foreignphrase>i.e.</foreignphrase> if <tag>p:import-functions</tag>
+        understands) how to load function libraries of that type, this function returns
+          <literal>true()</literal>, otherewise it returns <literal>false()</literal>. </para>
+
+      <para>The <function>p:function-library-importable</function> function behaves normally during
+        static analysis.</para>
+    </section>
+
+    <section xml:id="other-xpath-extension-functions">
+      <title>Other XPath Extension Functions</title>
+      <para><impl>It is <glossterm>implementation-defined</glossterm> if the processor supports any
+          other XPath extension functions.</impl> Additional extension functions, if any,
+          <rfc2119>must not</rfc2119> use any of the XProc namespaces. </para>
+
+      <para>
+        <impl>The value of the any other XPath extension functions during static analysis is
+            <glossterm>implementation-defined</glossterm>.</impl>
+      </para>
+    </section>
+  </section>
+
+  <section xml:id="psvi-support">
+    <title>PSVIs in XProc</title>
+    <para>XML documents flow between steps in an XProc pipeline. <xref linkend="infoset-conformance"
+      /> identifies the properties of those documents that <rfc2119>must</rfc2119> be available.
+      Implementations <rfc2119>may</rfc2119> also have the ability to pass PSVI annotations between
+      steps.</para>
+    <para>
+      <impl>Whether or not the pipeline processor supports passing PSVI annotations between steps is
+          <glossterm>implementation-defined</glossterm>.</impl>
+      <impl>The exact PSVI properties that are preserved when documents are passed between steps is
+          <glossterm>implementation-defined</glossterm>.</impl>
+    </para>
+    <para>A pipeline can use the <varname>p:psvi-supported</varname> system property to determine
+      whether or not PSVI properties can be passed between steps.</para>
+    <para>A pipeline can assert that PSVI support is required with the <tag class="attribute"
+        >psvi-required</tag> attribute:</para>
+    <itemizedlist>
+      <listitem>
+        <para>On a <tag>p:declare-step</tag>, <tag class="attribute">psvi-required</tag> indicates
+          whether or not the declared step requires PSVI support. <error code="D0022">It is a
+              <glossterm>dynamic error</glossterm> if a processor that does not support PSVI
+            annotations attempts to invoke a step which asserts that they are
+          required.</error></para>
+      </listitem>
+      <listitem>
+        <para>On a <tag>p:library</tag>, the <tag class="attribute">psvi-required</tag> attribute
+          provides a default value for all of its <tag>p:declare-step</tag>
+          <emphasis>children</emphasis> that do not specify a value themselves.</para>
+      </listitem>
+    </itemizedlist>
+    <para>Many of the steps that an XProc pipeline can use are transformative in nature. The
+        <tag>p:delete</tag> step, for example, can remove elements and attributes; the
+        <tag>p:label-elements</tag> step can add attributes; etc. If PSVI annotations were always
+      preserved, the use of such steps could result in documents that were inconsistent with their
+      schema annotations.</para>
+    <para>In order to avoid these inconsistencies, most steps <rfc2119>must not</rfc2119> produce
+      PSVI annotated results even when PSVI passing is supported.</para>
+    <para>If PSVI passing is supported, the following constraints apply:</para>
+    <orderedlist>
+      <listitem>
+        <para>Implementations <rfc2119>must</rfc2119> faithfully transmit any PSVI properties
+          produced on step outputs to the steps to which they are connected.</para>
+      </listitem>
+      <listitem>
+        <para>When only a subset of the input is processed by a step (because a <tag
+            class="attribute">select</tag> expression appears on an input port or a <tag
+            class="attribute">match</tag> expression is used to process only part of the input), any
+          PSVI annotations that appear on the selected input <rfc2119>must</rfc2119> be preserved in
+          the resulting documents passed to the step.</para>
+        <para>Note that ID/IDREF constraints, and any other whole-document constraints, may not be
+          satisfied within the selected portion, irrespective of what its PSVI properties
+          claim.</para>
+      </listitem>
+      <listitem>
+        <para>If an output of a compound step is connected to an output which includes PSVI
+          properties, those properties <rfc2119>must</rfc2119> be preserved on the output of the
+          compound step, <emphasis>except</emphasis> for the output of <tag>p:viewport</tag> which
+            <rfc2119>must not</rfc2119> contain any PSVI properties.</para>
+      </listitem>
+      <listitem>
+        <para>If an implementation supports XPath 2.0 or later, the data model constructed with
+          which to evaluate XPath expressions and <glossterm baseform="selection pattern">selection
+            patterns</glossterm>
+          <rfc2119>should</rfc2119> take advantage of as much PSVI information as possible. </para>
+        <para>
+          <termdef xml:id="dt-selection-pattern">A <firstterm>selection pattern</firstterm> uses a
+            subset of the syntax for path expressions, and is defined to match a node if the
+            corresponding path expression would select the node. It is defined as in the <link
+              xlink:href="https://www.w3.org/TR/xslt-30/#dt-selection-pattern">XSLT 3.0
+              specification</link>.</termdef>
+        </para>
+      </listitem>
+      <listitem>
+        <para>Except as specified above, or in the descriptions of individual steps, implementations
+            <rfc2119>must not</rfc2119> include PSVI properties in the outputs of steps defined by
+          this specification. <impl>It is <glossterm>implementation-defined</glossterm> what PSVI
+            properties, if any, are produced by extension steps.</impl></para>
+        <para>The exceptions in the standard XProc steps are the
+            <tag>p:validate-with-xml-schema</tag>, <tag>p:validate-with-relax-ng</tag>, and
+            <tag>p:validate-with-schematron</tag> steps, <tag>p:xslt</tag> (when XSLT 2.0 is used),
+            <tag>p:xquery</tag>, <tag>p:identity</tag>, and <tag>p:split-sequence</tag>. </para>
+      </listitem>
+    </orderedlist>
+    <note xml:id="note-psvi">
+      <para>A processor that supports passing PSVI properties between steps is always free to do so.
+        Even if <code>psvi-required="false"</code> is explicitly specified, it is not an error for a
+        step to produce a result that includes additional PSVI properties, provide it does not
+        violate the constraints above.</para>
+    </note>
+  </section>
+
+  <section xml:id="value-templates">
+    <title>Value Templates</title>
+
+    <para>An attribute or text node in a pipeline may, in particular circumstances, contain embedded
+      expressions enclosed between curly brackets. Attributes and text nodes that use (or are
+      permitted to use) this mechanism are referred to respectively as <glossterm
+        baseform="attribute value template">attribute value templates</glossterm> (AVTs) and
+        <glossterm baseform="text value
 template">text value templates.</glossterm> (TVTs).</para>
 
-<para><termdef xml:id="dt-value-template">Collectively,
-attribute value templates and text value templates are referred to as
-<firstterm baseform="value template">value templates</firstterm>.</termdef>
-</para>
+    <para>
+      <termdef xml:id="dt-value-template">Collectively, attribute value templates and text value
+        templates are referred to as <firstterm baseform="value template">value
+          templates</firstterm>.</termdef>
+    </para>
 
-<para>A value template is a string that contains zero or more
-expressions delimited by curly brackets. Outside an expression, a
-doubled left or right curly bracket (“<literal>{{</literal>” or
-“<literal>}}</literal>”) represents a literal, single bracket and does
-not start or end an expression. Once an expression begins, it extends
-to the first unmatched right curly bracket that is not within a string
-literal or comment.</para>
+    <para>A value template is a string that contains zero or more expressions delimited by curly
+      brackets. Outside an expression, a doubled left or right curly bracket
+      (“<literal>{{</literal>” or “<literal>}}</literal>”) represents a literal, single bracket and
+      does not start or end an expression. Once an expression begins, it extends to the first
+      unmatched right curly bracket that is not within a string literal or comment.</para>
 
-<para>Value templates are not recursive. Curly brackets inside an
-expression are part of that expression and are not recognized as
-nested value templates.</para>
+    <para>Value templates are not recursive. Curly brackets inside an expression are part of that
+      expression and are not recognized as nested value templates.</para>
 
-<para>
-<error code="S0066">It is a <glossterm>static error</glossterm> if
-an expression does not have a closing right curly bracket or if an
-unescaped right curly bracket occurs outside of an expression.
-</error>
-</para>
+    <para>
+      <error code="S0066">It is a <glossterm>static error</glossterm> if an expression does not have
+        a closing right curly bracket or if an unescaped right curly bracket occurs outside of an
+        expression. </error>
+    </para>
 
-<para>It is a static error if the string contained between matching curly
-brackets in a value template, when interpreted as an XPath expression,
-contains errors. The error is signaled using the appropriate
-XPath error code.</para>
+    <para>It is a static error if the string contained between matching curly brackets in a value
+      template, when interpreted as an XPath expression, contains errors. The error is signaled
+      using the appropriate XPath error code.</para>
 
-<para>
-<error code="D0050">It is a <glossterm>dynamic error</glossterm> if the
-XPath expression in a value template can not be evaluated.</error>
-</para>
+    <para>
+      <error code="D0050">It is a <glossterm>dynamic error</glossterm> if the XPath expression in a
+        value template can not be evaluated.</error>
+    </para>
 
-<para>
-<error code="D0051">It is a <glossterm>dynamic error</glossterm> if the XPath
-expression in an AVT or TVT evaluates to something to other than a sequence
-containing atomic values or nodes.</error> Function, array and map items are
-explicitly excluded here because they do not have a string representation.
-</para>
+    <para>
+      <error code="D0051">It is a <glossterm>dynamic error</glossterm> if the XPath expression in an
+        AVT or TVT evaluates to something to other than a sequence containing atomic values or
+        nodes.</error> Function, array and map items are explicitly excluded here because they do
+      not have a string representation. </para>
 
-<para>The context item used for evaluating value templates comes from
-the <glossterm>default readable port</glossterm>. 
-<error code="D0065">It is a <glossterm>dynamic error</glossterm>
-to refer to the context item, size, or position in a value template if a sequence of documents
-appears on the default readable port.</error>
-If the value template appears in a context where no default
-readable port exists, then the context item is undefined.</para>
+    <para>The context item used for evaluating value templates comes from the <glossterm>default
+        readable port</glossterm>. <error code="D0065">It is a <glossterm>dynamic error</glossterm>
+        to refer to the context item, size, or position in a value template if a sequence of
+        documents appears on the default readable port.</error> If the value template appears in a
+      context where no default readable port exists, then the context item is undefined.</para>
 
-<section xml:id="attribute-value-templates">
-<title>Attribute Value Templates</title>
+    <section xml:id="attribute-value-templates">
+      <title>Attribute Value Templates</title>
 
-<para><termdef xml:id="dt-attribute-value-template">In an attribute
-that is designated as an <firstterm>attribute value
-template</firstterm>, an expression can be used by surrounding the
-expression with curly brackets (<code>{}</code>), following the
-general rules for <glossterm baseform="value template">value
-templates</glossterm></termdef>.</para>
+      <para><termdef xml:id="dt-attribute-value-template">In an attribute that is designated as an
+            <firstterm>attribute value template</firstterm>, an expression can be used by
+          surrounding the expression with curly brackets (<code>{}</code>), following the general
+          rules for <glossterm baseform="value template">value
+        templates</glossterm></termdef>.</para>
 
-<para>Curly brackets are not treated specially in an attribute value
-in an XProc pipeline unless the attribute is specifically designated
-as one that permits an attribute value template. Option shortcuts
-permit attribute value templates.
-<impl>Whether or not an extension attribute permits attribute value
-templates is <glossterm>implementation-defined</glossterm>.</impl>
-In element
-syntax summaries in this specification, the value of an attribute that allows attribute value
-templates is surrounded by
-curly brackets.</para>
+      <para>Curly brackets are not treated specially in an attribute value in an XProc pipeline
+        unless the attribute is specifically designated as one that permits an attribute value
+        template. Option shortcuts permit attribute value templates. <impl>Whether or not an
+          extension attribute permits attribute value templates is
+            <glossterm>implementation-defined</glossterm>.</impl> In element syntax summaries in
+        this specification, the value of an attribute that allows attribute value templates is
+        surrounded by curly brackets.</para>
 
-<para>An attribute value template can be seen as an alternating
-sequence of zero or more “fixed” (non-expression) parts and expression
-parts.</para>
+      <para>An attribute value template can be seen as an alternating sequence of zero or more
+        “fixed” (non-expression) parts and expression parts.</para>
 
-<para>The result of the attribute value template is the concatenation
-of the fixed parts and the string-value of the result of evaluating
-each expression part.</para>
+      <para>The result of the attribute value template is the concatenation of the fixed parts and
+        the string-value of the result of evaluating each expression part.</para>
 
-<note xml:id="note-dynerr">
-<para>This process can generate dynamic errors, for example if the
-sequence contains an element with a complex content type (which cannot
-be atomized).</para>
-</note>
+      <note xml:id="note-dynerr">
+        <para>This process can generate dynamic errors, for example if the sequence contains an
+          element with a complex content type (which cannot be atomized).</para>
+      </note>
 
-<para>The value of an attribute that contains attribute value
-templates is a single string (the concatenation of the string values
-of the evaluated templates and non-template parts) as an
-<type>xs:untypedAtomic</type>.</para>
-</section>
+      <para>The value of an attribute that contains attribute value templates is a single string
+        (the concatenation of the string values of the evaluated templates and non-template parts)
+        as an <type>xs:untypedAtomic</type>.</para>
+    </section>
 
-<section xml:id="text-value-templates">
-<title>Text Value Templates</title>
+    <section xml:id="text-value-templates">
+      <title>Text Value Templates</title>
 
-<para><termdef xml:id="dt-text-value-template">In a text node that is
-designated as a <firstterm>text value template</firstterm>,
-expressions can be used by surrounding each expression with curly
-brackets (<code>{}</code>), following the
-general rules for <glossterm baseform="value template">value
-templates</glossterm>.</termdef>
-</para>
+      <para>
+        <termdef xml:id="dt-text-value-template">In a text node that is designated as a
+            <firstterm>text value template</firstterm>, expressions can be used by surrounding each
+          expression with curly brackets (<code>{}</code>), following the general rules for
+            <glossterm baseform="value template">value templates</glossterm>.</termdef>
+      </para>
 
-<para>Text nodes that are descendants
-of a <tag>p:inline</tag> and text nodes that are descendants of an
-element node in an implicit inline may be text value templates. No
-other text node is a text value template.</para>
+      <para>Text nodes that are descendants of a <tag>p:inline</tag> and text nodes that are
+        descendants of an element node in an implicit inline may be text value templates. No other
+        text node is a text value template.</para>
 
-<para>Whether or not a text node that may be a text value template is
-designated one is determined by <code>expand-text</code> and <code>p:inline-expand-text</code> attributes,
-see <xref linkend="expand-text-attribute"/>.</para>
+      <para>Whether or not a text node that may be a text value template is designated one is
+        determined by <code>expand-text</code> and <code>p:inline-expand-text</code> attributes, see
+          <xref linkend="expand-text-attribute"/>.</para>
 
-<para>A text value template can be seen as an alternating sequence of
-zero or more “fixed” (non-expression) parts and expression parts.</para>
+      <para>A text value template can be seen as an alternating sequence of zero or more “fixed”
+        (non-expression) parts and expression parts.</para>
 
-<para>This produces a sequence of strings (the fixed parts) and items
-(the results of evaluating each expression). Any items that are
-non-string atomic values are converted to strings by taking their
-string value. Strings are converted into text nodes.</para>
+      <para>This produces a sequence of strings (the fixed parts) and items (the results of
+        evaluating each expression). Any items that are non-string atomic values are converted to
+        strings by taking their string value. Strings are converted into text nodes.</para>
 
-<para>The result of the text value template is this sequence of nodes.</para>
+      <para>The result of the text value template is this sequence of nodes.</para>
 
-<note xml:id="unlike-xslt-tvts">
-<para>Unlike XSLT, in XProc, text value templates are not atomized
-and converted to single text nodes. It is possible to insert nodes with
-text value templates in XProc, for example, if the XPath
-expressions refer to variables that have node content.</para>
-</note>
+      <note xml:id="unlike-xslt-tvts">
+        <para>Unlike XSLT, in XProc, text value templates are not atomized and converted to single
+          text nodes. It is possible to insert nodes with text value templates in XProc, for
+          example, if the XPath expressions refer to variables that have node content.</para>
+      </note>
 
-<para>If a node to be inserted with a text value template is a document
-node, all the children of the document node are inserted.</para>
+      <para>If a node to be inserted with a text value template is a document node, all the children
+        of the document node are inserted.</para>
 
-<para>How the nodes are inserted depends on the content type of the
-<tag>p:inline</tag>.</para>
+      <para>How the nodes are inserted depends on the content type of the
+        <tag>p:inline</tag>.</para>
 
-<orderedlist>
-<listitem>
-<para>If the content type is an <glossterm>XML media type</glossterm> or an
-  <glossterm>HTML media type</glossterm>,
-the nodes are added to the XML document where they occur. This is analagous
-to the way element constructors work in <biblioref linkend="xquery10"/>.
-</para>
-<para>If the node is an attribute
-it is added to an element parent if and only if the attribute either has
-no preceding nodes in the sequence of nodes or has only attributes as preceding nodes.
-<error code="D0052">It is a <glossterm>dynamic error</glossterm> if the XPath
-expression in a TVT evaluates to an attribute and either the parent is not an
-element or the attribute has a preceding node that it not an attribute.</error>
-</para>
-</listitem>
-<listitem>
-<para>If the content type is not an <glossterm>XML media type</glossterm> or an 
-  <glossterm>HTML media type</glossterm>, each text value template is replaced by the
-            concatenation of the serialization of the nodes that result from evaluating the template.</para>
-<para>This serialization is performed with the following serialization parameters:</para>
+      <orderedlist>
+        <listitem>
+          <para>If the content type is an <glossterm>XML media type</glossterm> or an
+              <glossterm>HTML media type</glossterm>, the nodes are added to the XML document where
+            they occur. This is analagous to the way element constructors work in <biblioref
+              linkend="xquery10"/>. </para>
+          <para>If the node is an attribute it is added to an element parent if and only if the
+            attribute either has no preceding nodes in the sequence of nodes or has only attributes
+            as preceding nodes. <error code="D0052">It is a <glossterm>dynamic error</glossterm> if
+              the XPath expression in a TVT evaluates to an attribute and either the parent is not
+              an element or the attribute has a preceding node that it not an attribute.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>If the content type is not an <glossterm>XML media type</glossterm> or an
+              <glossterm>HTML media type</glossterm>, each text value template is replaced by the
+            concatenation of the serialization of the nodes that result from evaluating the
+            template.</para>
+          <para>This serialization is performed with the following serialization parameters:</para>
 
-<informaltable>
-<tgroup cols="2">
-<thead>
-<row>
-<entry>Parameter</entry>
-<entry>Value</entry>
-</row>
-</thead>
-<tbody>
-<row>
-  <entry><option>byte-order-mark</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>cdata-section-elements</option></entry><entry>()</entry></row>
-<row>
-  <entry><option>doctype-public</option></entry><entry>()</entry></row>
-<row>
-  <entry><option>doctype-system</option></entry><entry>()</entry></row>
-<row>
-  <entry><option>encoding</option></entry><entry>“utf-8”</entry></row>
-<row>
-  <entry><option>escape-uri-attributes</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>include-content-type</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>indent</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>media-type</option></entry><entry>“application/xml”</entry></row>
-<row>
-  <entry><option>method</option></entry><entry>“xml”</entry></row>
-<row>
-  <entry><option>normalization-form</option></entry><entry>()</entry></row>
-<row>
-  <entry><option>omit-xml-declaration</option></entry><entry>true</entry></row>
-<row>
-  <entry><option>standalone</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>undeclare-prefixes</option></entry><entry>false</entry></row>
-<row>
-  <entry><option>use-character-maps</option></entry><entry>()</entry></row>
-<row>
-  <entry><option>version</option></entry><entry>1.0</entry></row>
-</tbody>
-</tgroup>
-</informaltable>
+          <informaltable>
+            <tgroup cols="2">
+              <thead>
+                <row>
+                  <entry>Parameter</entry>
+                  <entry>Value</entry>
+                </row>
+              </thead>
+              <tbody>
+                <row>
+                  <entry>
+                    <option>byte-order-mark</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>cdata-section-elements</option>
+                  </entry>
+                  <entry>()</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>doctype-public</option>
+                  </entry>
+                  <entry>()</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>doctype-system</option>
+                  </entry>
+                  <entry>()</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>encoding</option>
+                  </entry>
+                  <entry>“utf-8”</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>escape-uri-attributes</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>include-content-type</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>indent</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>media-type</option>
+                  </entry>
+                  <entry>“application/xml”</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>method</option>
+                  </entry>
+                  <entry>“xml”</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>normalization-form</option>
+                  </entry>
+                  <entry>()</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>omit-xml-declaration</option>
+                  </entry>
+                  <entry>true</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>standalone</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>undeclare-prefixes</option>
+                  </entry>
+                  <entry>false</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>use-character-maps</option>
+                  </entry>
+                  <entry>()</entry>
+                </row>
+                <row>
+                  <entry>
+                    <option>version</option>
+                  </entry>
+                  <entry>1.0</entry>
+                </row>
+              </tbody>
+            </tgroup>
+          </informaltable>
 
-<!--
+          <!--
 <itemizedlist>
 <listitem>
 <para><option>byte-order-mark</option>: false</para>
@@ -2312,74 +2330,64 @@ element or the attribute has a preceding node that it not an attribute.</error>
 </listitem>
 </itemizedlist>
 -->
-</listitem>
-</orderedlist>
+        </listitem>
+      </orderedlist>
 
-<para>Interpretation of the character content of the <tag>p:inline</tag>
-according to the media type occurs after text value templates have been
-replaced.</para>
+      <para>Interpretation of the character content of the <tag>p:inline</tag> according to the
+        media type occurs after text value templates have been replaced.</para>
 
-<simplesect>
-<title>Examples</title>
+      <simplesect>
+        <title>Examples</title>
 
-<para>Consider the following examples. In each case:</para>
+        <para>Consider the following examples. In each case:</para>
 
-<itemizedlist>
-<listitem>
-<para>The variable <code>$name</code>
-is bound to the following XML element:</para>
+        <itemizedlist>
+          <listitem>
+            <para>The variable <code>$name</code> is bound to the following XML element:</para>
 
-<programlisting language="xml"
-><![CDATA[  <name><given>Mary</given> <surname>Smith</surname></name>]]></programlisting>
-</listitem>
-<listitem>
-<para>The result of evaluating the text value template
-“<code>{$name/node()}</code>” is a sequence of three nodes, the given
-name element, a text node containing a single space, and the surname
-element.</para>
-</listitem>
-</itemizedlist>
+            <programlisting language="xml"><![CDATA[  <name><given>Mary</given> <surname>Smith</surname></name>]]></programlisting>
+          </listitem>
+          <listitem>
+            <para>The result of evaluating the text value template “<code>{$name/node()}</code>” is
+              a sequence of three nodes, the given name element, a text node containing a single
+              space, and the surname element.</para>
+          </listitem>
+        </itemizedlist>
 
-<para>If the media type is an XML media type:</para>
+        <para>If the media type is an XML media type:</para>
 
-<programlisting
-><![CDATA[  <p:inline content-type="application/xml">
+        <programlisting><![CDATA[  <p:inline content-type="application/xml">
     <attribution>{$name/node()}</attribution>
   </p:inline>]]></programlisting>
 
-<para>the result is that sequence of nodes:</para>
+        <para>the result is that sequence of nodes:</para>
 
-<programlisting
-><![CDATA[  <attribution><given>Mary</given> <surname>Smith</surname></attribution>]]></programlisting>
+        <programlisting><![CDATA[  <attribution><given>Mary</given> <surname>Smith</surname></attribution>]]></programlisting>
 
-<para>If the media type is not an XML media type:</para>
+        <para>If the media type is not an XML media type:</para>
 
-<programlisting
-><![CDATA[  <p:inline content-type="application/json">
+        <programlisting><![CDATA[  <p:inline content-type="application/json">
     {{ "name": "{$name/node()}" }}
   </p:inline>]]></programlisting>
 
-<para>the result is the concatentation of the serialization of the nodes:</para>
+        <para>the result is the concatentation of the serialization of the nodes:</para>
 
-<programlisting
-><![CDATA[  { "name": "<given>Mary</given> <surname>Smith</surname>" }]]></programlisting>
+        <programlisting><![CDATA[  { "name": "<given>Mary</given> <surname>Smith</surname>" }]]></programlisting>
 
-<para>If the string value is desired, instead of escaped markup, write the
-expression such that it returns the string values:</para>
+        <para>If the string value is desired, instead of escaped markup, write the expression such
+          that it returns the string values:</para>
 
-<programlisting
-><![CDATA[  <p:inline content-type="application/json">
+        <programlisting><![CDATA[  <p:inline content-type="application/json">
     {{ "name": "{$name/node()/string()}" }}
   </p:inline>]]></programlisting>
 
-<para>To produce:</para>
+        <para>To produce:</para>
 
-<programlisting
-><![CDATA[  { "name": "Mary Smith" }]]></programlisting>
+        <programlisting><![CDATA[  { "name": "Mary Smith" }]]></programlisting>
 
-</simplesect>
-</section>
-</section>
+      </simplesect>
+    </section>
+  </section>
 
   <section xml:id="variables-options-background">
     <title>Variables and Options</title>
@@ -2390,141 +2398,154 @@ expression such that it returns the string values:</para>
       <para>Pipeline authors can create variables to hold computed values.</para>
 
       <para>
-        <termdef xml:id="dt-variable">A <firstterm>variable</firstterm> is a name/value pair. The name
-            <rfc2119>must</rfc2119> be an <link xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
-            name</link>. The value may be any XPath data model value.</termdef>
-Variable names are always expressed as
-        literal values, pipelines cannot construct variable names dynamically.
-      </para>
+        <termdef xml:id="dt-variable">A <firstterm>variable</firstterm> is a name/value pair. The
+          name <rfc2119>must</rfc2119> be an <link
+            xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded name</link>. The
+          value may be any XPath data model value.</termdef> Variable names are always expressed as
+        literal values, pipelines cannot construct variable names dynamically. </para>
 
-      <para>The names of variables and options are not distinct and are lexically scoped. <termdef xml:id="dt-shadow">We
-          say that a variable <firstterm baseform="shadow">shadows</firstterm> another variable (or option) if it has
-          the same name and appears later in the same lexical scope.</termdef></para>
+      <para>The names of variables and options are not distinct and are lexically scoped. <termdef
+          xml:id="dt-shadow">We say that a variable <firstterm baseform="shadow">shadows</firstterm>
+          another variable (or option) if it has the same name and appears later in the same lexical
+          scope.</termdef></para>
 
       <para>Consider this pipeline:</para>
 
       <programlisting language="xml"><xi:include href="../../../build/examples/shadow.txt" parse="text"/></programlisting>
 
-      <para>If no overriding value is provided for <varname>$bname</varname> at runtime, the pipeline will produce three
-        messages: “NAME1=1”, “NAME2=2”, and “NAME3=7”. (If an overriding value is provided at runtime, “NAME1” will have
-        that value, “NAME2” will have one more than that value, and “NAME3” will have the value 7. </para>
+      <para>If no overriding value is provided for <varname>$bname</varname> at runtime, the
+        pipeline will produce three messages: “NAME1=1”, “NAME2=2”, and “NAME3=7”. (If an overriding
+        value is provided at runtime, “NAME1” will have that value, “NAME2” will have one more than
+        that value, and “NAME3” will have the value 7. </para>
 
     </section>
 
     <section xml:id="options">
       <title>Options</title>
 
-      <para>Some steps accept options. The value of an option is the default value
-        specified in its declaration, or a value provided by the caller of the step (overriding the default). If it has
-        neither a default value nor a provided value, its value is the empty sequence.</para>
+      <para>Some steps accept options. The value of an option is the default value specified in its
+        declaration, or a value provided by the caller of the step (overriding the default). If it
+        has neither a default value nor a provided value, its value is the empty sequence.</para>
 
-      <para><termdef xml:id="dt-option">An <firstterm>option</firstterm> is a name/value pair. The name
-            <rfc2119>must</rfc2119> be an <link xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded
-            name</link>. The value may be any XPath data model value.</termdef> Option names are always expressed as
+      <para><termdef xml:id="dt-option">An <firstterm>option</firstterm> is a name/value pair. The
+          name <rfc2119>must</rfc2119> be an <link
+            xlink:href="http://www.w3.org/TR/REC-xml-names/#dt-expname">expanded name</link>. The
+          value may be any XPath data model value.</termdef> Option names are always expressed as
         literal values, pipelines cannot construct option names dynamically. </para>
 
-      <para><impl>How outside values are specified for pipeline options on the pipeline initially invoked by the
-          processor is <glossterm>implementation-defined</glossterm>.</impl> In other words, the command line options,
-        APIs, or other mechanisms available to specify such options values are outside the scope of this
-        specification.</para>
+      <para><impl>How outside values are specified for pipeline options on the pipeline initially
+          invoked by the processor is <glossterm>implementation-defined</glossterm>.</impl> In other
+        words, the command line options, APIs, or other mechanisms available to specify such options
+        values are outside the scope of this specification.</para>
 
-      <para>Some steps require a set of name/value pairs for the operations they perform. For example, an XSLT
-        stylesheet might have required parameters or an XQuery query might have external variables. In the XProc Step
-        Library, the standard way to pass such values to the step is to use an option named
-          “<literal>parameters</literal>” whose value is a map.</para>
+      <para>Some steps require a set of name/value pairs for the operations they perform. For
+        example, an XSLT stylesheet might have required parameters or an XQuery query might have
+        external variables. In the XProc Step Library, the standard way to pass such values to the
+        step is to use an option named “<literal>parameters</literal>” whose value is a map.</para>
     </section>
 
     <section xml:id="statics">
       <title>Static Options and Variables</title>
 
-      <para>Any <tag>p:variable</tag> that is part of the
-<glossterm>prologue</glossterm> of a step (as a direct child of
-          <tag>p:declare-step</tag> declared before the start of the sub-pipeline) <rfc2119>must</rfc2119> be declared
-        “static”. Any <tag>p:variable</tag> that is part of the sub-pipeline of a step <rfc2119>must not</rfc2119> be
-        declared “static”.</para>
+      <para>Any <tag>p:variable</tag> that is part of the <glossterm>prologue</glossterm> of a step
+        (as a direct child of <tag>p:declare-step</tag> declared before the start of the
+        sub-pipeline) <rfc2119>must</rfc2119> be declared “static”. Any <tag>p:variable</tag> that
+        is part of the sub-pipeline of a step <rfc2119>must not</rfc2119> be declared
+        “static”.</para>
       <para>A <tag>p:option</tag> may be declared “static”. </para>
-      <para><error code="S0109">It is a <glossterm>static error</glossterm> if options and variables that are the direct children of 
-        <tag>p:library</tag> are not declared “static”</error>.</para>
-      <para>The values of static options and variables are computed during <link linkend="initiating">static
-          analysis</link>.</para>
+      <para><error code="S0109">It is a <glossterm>static error</glossterm> if options and variables
+          that are the direct children of <tag>p:library</tag> are not declared
+        “static”</error>.</para>
+      <para>The values of static options and variables are computed during <link
+          linkend="initiating">static analysis</link>.</para>
     </section>
 
     <section xml:id="varopt-types">
       <title>Variable and option types</title>
 
-      <para>Variables and options may declare that they have a type using the <tag class="attribute">as</tag> attribute.
-        The attribute value <rfc2119>must</rfc2119> be an <biblioref linkend="xpath31"/>
-        <link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence type</link>. <error code="S0096">It
-          is a <glossterm>static error</glossterm> if the sequence type is not syntactically valid.</error> The sequence
-        type <literal>item()*</literal> is assumed if no explicit type is provided. </para>
+      <para>Variables and options may declare that they have a type using the <tag class="attribute"
+          >as</tag> attribute. The attribute value <rfc2119>must</rfc2119> be an <biblioref
+          linkend="xpath31"/>
+        <link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence type</link>.
+          <error code="S0096">It is a <glossterm>static error</glossterm> if the sequence type is
+          not syntactically valid.</error> The sequence type <literal>item()*</literal> is assumed
+        if no explicit type is provided. </para>
 
-      <para>If a variable or option declares a type, the supplied value of the variable or option is converted to the
-        required type, using the function conversion rules specified by XPath 3.1. <error code="D0036">It is a
-            <glossterm>dynamic error</glossterm> if the supplied or defaulted value of a variable or option cannot be converted to
-          the required type.</error></para>
-      
+      <para>If a variable or option declares a type, the supplied value of the variable or option is
+        converted to the required type, using the function conversion rules specified by XPath 3.1.
+          <error code="D0036">It is a <glossterm>dynamic error</glossterm> if the supplied or
+          defaulted value of a variable or option cannot be converted to the required
+        type.</error></para>
+
     </section>
-    
+
     <section xml:id="qname-handling">
       <title>QName handling</title>
-      
-      <para>Some steps have options whose values are QNames, for example “<tag class="attribute">attribute-name</tag>”
-        on <tag>p:add-attribute</tag>. If the type <type>xs:QName</type> was strictly enforced, they would be tedious to
-        specify. As a convenience for pipeline authors, the values of variables or options declared with the type
-        <type>xs:QName</type> are processed specially. The type <type>xs:QName</type> is treated as
-        <type>xs:anyAtomicType</type> for the purpose of atomization. The value (or values) are converted to
-        <type>xs:QName</type>s:</para>
-      
+
+      <para>Some steps have options whose values are QNames, for example “<tag class="attribute"
+          >attribute-name</tag>” on <tag>p:add-attribute</tag>. If the type <type>xs:QName</type>
+        was strictly enforced, they would be tedious to specify. As a convenience for pipeline
+        authors, the values of variables or options declared with the type <type>xs:QName</type> are
+        processed specially. The type <type>xs:QName</type> is treated as
+          <type>xs:anyAtomicType</type> for the purpose of atomization. The value (or values) are
+        converted to <type>xs:QName</type>s:</para>
+
       <orderedlist>
         <listitem>
-          <para>If the value supplied for the option is an instance of <type>xs:QName</type> then that value is used.
-          </para>
+          <para>If the value supplied for the option is an instance of <type>xs:QName</type> then
+            that value is used. </para>
         </listitem>
         <listitem>
-          <para>If the value supplied for the option is an instance of <type>xs:string</type> (or a type derived from
-            <type>xs:string</type>), the QName is constructed by following the <link
-              xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName production rules</link> in
-            <biblioref linkend="xpath31"/>. That is, it can be written as a local-name only, as a prefix plus
-            local-name, or as a URI qualified name (using the <code>Q{namespace}local-name</code> syntax). If it
-            is written as local-name only, the constructed QName will not have a namespace URI, i.e. the default 
-            namespace is not applied here. <error
-              code="D0061">It is a <glossterm>dynamic error</glossterm> if the string value is not syntactically an
-              EQName.</error>
-            <error code="D0069">It is a <glossterm>dynamic error</glossterm> if the string value contains a colon and
-              the designated prefix is not declared in the in-scope namespaces.</error>
+          <para>If the value supplied for the option is an instance of <type>xs:string</type> (or a
+            type derived from <type>xs:string</type>), the QName is constructed by following the
+              <link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">EQName
+              production rules</link> in <biblioref linkend="xpath31"/>. That is, it can be written
+            as a local-name only, as a prefix plus local-name, or as a URI qualified name (using the
+              <code>Q{namespace}local-name</code> syntax). If it is written as local-name only, the
+            constructed QName will not have a namespace URI, i.e. the default namespace is not
+            applied here. <error code="D0061">It is a <glossterm>dynamic error</glossterm> if the
+              string value is not syntactically an EQName.</error>
+            <error code="D0069">It is a <glossterm>dynamic error</glossterm> if the string value
+              contains a colon and the designated prefix is not declared in the in-scope
+              namespaces.</error>
           </para>
         </listitem>
         <listitem>
           <para>
-            <error code="D0068">It is a <glossterm>dynamic error</glossterm> if the supplied value is neither an
-              instance of <type>xs:QName</type> nor an instance of <type>xs:string</type>.</error>
+            <error code="D0068">It is a <glossterm>dynamic error</glossterm> if the supplied value
+              is neither an instance of <type>xs:QName</type> nor an instance of
+                <type>xs:string</type>.</error>
           </para>
         </listitem>
       </orderedlist>
-      
-      <para>As an additional convenience, if the specified sequence type of an option or a variable is a map with
-        <type>xs:QName</type> keys (<type>map(xs:QName, …)</type>), the supplied map value is processed specially.
-        This makes it possible to pass in maps using (easier to write) <type>xs:string</type> type keys that are
-        converted automatically into the required <type>xs:QName</type> keys.</para>
-      <para>Every key/value pair in a map supplied to a variable or an option with sequence type <type>map(xs:QName,
-        …)</type> is processed as follows:</para>
+
+      <para>As an additional convenience, if the specified sequence type of an option or a variable
+        is a map with <type>xs:QName</type> keys (<type>map(xs:QName, …)</type>), the supplied map
+        value is processed specially. This makes it possible to pass in maps using (easier to write)
+          <type>xs:string</type> type keys that are converted automatically into the required
+          <type>xs:QName</type> keys.</para>
+      <para>Every key/value pair in a map supplied to a variable or an option with sequence type
+          <type>map(xs:QName, …)</type> is processed as follows:</para>
       <itemizedlist>
         <listitem>
-          <para>If the entry's key is of type <type>xs:QName</type>, the entry is left unchanged.</para>
+          <para>If the entry's key is of type <type>xs:QName</type>, the entry is left
+            unchanged.</para>
         </listitem>
         <listitem>
-          <para>If the entry's key is an instance of type <type>xs:string</type> (or a type derived from
-            <type>xs:string</type>) it is transformed into an <type>xs:Qname</type> using the <link
-              xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">XPath EQName production rules</link>. That
-            is, it can be written as a local-name only, as a prefix plus local-name or as a URI plus local-name (using
-            the <code>Q{}</code> syntax).</para>
+          <para>If the entry's key is an instance of type <type>xs:string</type> (or a type derived
+            from <type>xs:string</type>) it is transformed into an <type>xs:Qname</type> using the
+              <link xlink:href="https://www.w3.org/TR/xpath-31/#doc-xpath31-EQName">XPath EQName
+              production rules</link>. That is, it can be written as a local-name only, as a prefix
+            plus local-name or as a URI plus local-name (using the <code>Q{}</code> syntax).</para>
           <para>
-            <error code="D0061">It is a <glossterm>dynamic error</glossterm> if the entry's key is of type
-              <type>xs:string</type> and cannot be converted into a <type>xs:Qname</type>.</error>
+            <error code="D0061">It is a <glossterm>dynamic error</glossterm> if the entry's key is
+              of type <type>xs:string</type> and cannot be converted into a
+              <type>xs:Qname</type>.</error>
           </para>
         </listitem>
         <listitem>
-          <para>If the entry's key is of any other type, the entry is ignored and will be removed from the map.</para>
+          <para>If the entry's key is of any other type, the entry is ignored and will be removed
+            from the map.</para>
         </listitem>
       </itemizedlist>
     </section>
@@ -2532,124 +2553,123 @@ Variable names are always expressed as
     <section xml:id="opt-bindings">
       <title>Namespaces on variables and options</title>
 
-      <para>Variable and option values carry with them not only their literal or computed value but also a set of
-        namespaces. To see why this is necessary, consider the following step:</para>
+      <para>Variable and option values carry with them not only their literal or computed value but
+        also a set of namespaces. To see why this is necessary, consider the following step:</para>
       <programlisting language="xml"><xi:include href="../../../build/examples/opns-1.txt" parse="text"/></programlisting>
-      <para>The <tag>p:delete</tag> step will delete elements that match the expression “<literal>html:div</literal>”,
-        but that expression can only be correctly interpreted if there's a namespace binding for the prefix
-          “<literal>html</literal>” so that binding has to travel with the option.</para>
+      <para>The <tag>p:delete</tag> step will delete elements that match the expression
+          “<literal>html:div</literal>”, but that expression can only be correctly interpreted if
+        there's a namespace binding for the prefix “<literal>html</literal>” so that binding has to
+        travel with the option.</para>
 
-      <para>The default namespace bindings associated with a variable or option value are computed as follows:</para>
+      <para>The default namespace bindings associated with a variable or option value are computed
+        as follows:</para>
       <orderedlist>
 
         <listitem>
-          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value and it consisted of a
-            single <literal>VariableReference</literal> (per <biblioref linkend="xpath31"/>), then the namespace
-            bindings from the referenced option or variable are used.</para>
+          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value
+            and it consisted of a single <literal>VariableReference</literal> (per <biblioref
+              linkend="xpath31"/>), then the namespace bindings from the referenced option or
+            variable are used.</para>
         </listitem>
         <listitem>
-          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value and it evaluated to a
-            node-set, then the in-scope namespaces from the first node in the selected node-set (or, if it's not an
-            element, its parent) are used.</para>
-          <para>The expression is evaluated in the appropriate context, See <xref linkend="xpath-context"/>.</para>
+          <para>If the <tag class="attribute">select</tag> attribute was used to specify the value
+            and it evaluated to a node-set, then the in-scope namespaces from the first node in the
+            selected node-set (or, if it's not an element, its parent) are used.</para>
+          <para>The expression is evaluated in the appropriate context, See <xref
+              linkend="xpath-context"/>.</para>
         </listitem>
         <listitem>
-          <para>Otherwise, the in-scope namespaces from the element providing the value are used. (For options specified
-            using <link linkend="option-shortcut">syntactic shortcuts</link>, the step element itself is providing the
-            value.)</para>
+          <para>Otherwise, the in-scope namespaces from the element providing the value are used.
+            (For options specified using <link linkend="option-shortcut">syntactic shortcuts</link>,
+            the step element itself is providing the value.)</para>
         </listitem>
       </orderedlist>
-      <para>The default namespace is never included in the namespace bindings for a variable or option value.
-        Unqualified names are always in no-namespace.</para>
-      <para>Unfortunately, in more complex situations, there may be no single variable or option that can reliably be
-        expected to have the correct set of namespace bindings. Consider this pipeline:</para>
+      <para>The default namespace is never included in the namespace bindings for a variable or
+        option value. Unqualified names are always in no-namespace.</para>
+      <para>Unfortunately, in more complex situations, there may be no single variable or option
+        that can reliably be expected to have the correct set of namespace bindings. Consider this
+        pipeline:</para>
       <programlisting language="xml"><xi:include href="../../../build/examples/opns-2.txt" parse="text"/></programlisting>
-      <para>It defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements that occur inside of
-        XHTML div elements. It might be used as follows:</para>
+      <para>It defines an atomic step (“<literal>ex:delete-in-div</literal>”) that deletes elements
+        that occur inside of XHTML div elements. It might be used as follows:</para>
 
       <programlisting language="xml"><xi:include href="../../../build/examples/opns-3.txt" parse="text"/></programlisting>
 
-      <para>In this case, the <varname>match</varname> option passed to the <tag>p:delete</tag> step needs
-          <emphasis>both</emphasis> the namespace binding of “<literal>h</literal>” specified in the
-          <tag>ex:delete-in-div</tag> pipeline definition <emphasis>and</emphasis> the namespace binding of
-          “<literal>html</literal>” specified in the <varname>divchild</varname> option on the call of that pipeline.
-        It's not sufficient to provide just one of the sets of bindings.</para>
+      <para>In this case, the <varname>match</varname> option passed to the <tag>p:delete</tag> step
+        needs <emphasis>both</emphasis> the namespace binding of “<literal>h</literal>” specified in
+        the <tag>ex:delete-in-div</tag> pipeline definition <emphasis>and</emphasis> the namespace
+        binding of “<literal>html</literal>” specified in the <varname>divchild</varname> option on
+        the call of that pipeline. It's not sufficient to provide just one of the sets of
+        bindings.</para>
 
-      <para>If pipeline authors cannot arrange for all of the necessary namespace bindings to be in scope, then EQNames
-        can be used to remove the dependency on namespace bindings:</para>
+      <para>If pipeline authors cannot arrange for all of the necessary namespace bindings to be in
+        scope, then EQNames can be used to remove the dependency on namespace bindings:</para>
 
       <programlisting language="xml"><xi:include href="../../../build/examples/opns-4.txt" parse="text"/></programlisting>
 
-      <para>In this example, the expression will match “<literal>p</literal>” elements in the XHTML namespace
-        irrespective of any bindings that may or may not be in scope.</para>
+      <para>In this example, the expression will match “<literal>p</literal>” elements in the XHTML
+        namespace irrespective of any bindings that may or may not be in scope.</para>
 
     </section>
 
   </section>
 
-    <section xml:id="security-considerations">
-      <title>Security Considerations</title>
-      <para>An XProc pipeline may attempt to access arbitrary network resources: steps such as
-          <tag>p:load</tag> and <tag>p:http-request</tag> can attempt to read from an arbitrary URI;
-        steps such as <tag>p:store</tag> can attempt to write to an arbitrary location;
-          <tag>p:exec</tag> can attempt to execute an arbitrary program. Note, also, that some
-        steps, such as <tag>p:xslt</tag> and <tag>p:xquery</tag>, include extension mechanisms which
-        may attempt to execute arbitrary code. </para>
-      <para>In some environments, it may be inappropriate to provide the XProc pipeline with access
-        to these resources. In a server environment, for example, it may be impractical to allow
-        pipelines to store data. In environments where the pipeline cannot be trusted, allowing the
-        pipeline to access arbitrary resources or execute arbitrary code may be a security
-        risk.</para>
-      <para><error code="D0021">It is a <glossterm>dynamic error</glossterm> for a pipeline to
-          attempt to access a resource for which it has insufficient privileges or perform a step
-          which is forbidden.</error>
-        <impl>Which steps are forbidden, what privileges are needed to access resources, and under
-          what circumstances these security constraints apply is
-            <glossterm>implementation-dependent</glossterm>.</impl>
-      </para>
-      <para>Steps in a pipeline may call themselves recursively which could result in pipelines
-        which will never terminate.</para>
-      <para>A conformant XProc processor may limit the resources available to any or all steps in a
-        pipeline. A conformant implementation may raise dynamic errors, or take any other corrective
-        action, for any security problems that it detects.</para>
-    </section>
+  <section xml:id="security-considerations">
+    <title>Security Considerations</title>
+    <para>An XProc pipeline may attempt to access arbitrary network resources: steps such as
+        <tag>p:load</tag> and <tag>p:http-request</tag> can attempt to read from an arbitrary URI;
+      steps such as <tag>p:store</tag> can attempt to write to an arbitrary location;
+        <tag>p:exec</tag> can attempt to execute an arbitrary program. Note, also, that some steps,
+      such as <tag>p:xslt</tag> and <tag>p:xquery</tag>, include extension mechanisms which may
+      attempt to execute arbitrary code. </para>
+    <para>In some environments, it may be inappropriate to provide the XProc pipeline with access to
+      these resources. In a server environment, for example, it may be impractical to allow
+      pipelines to store data. In environments where the pipeline cannot be trusted, allowing the
+      pipeline to access arbitrary resources or execute arbitrary code may be a security
+      risk.</para>
+    <para>
+      <error code="D0021">It is a <glossterm>dynamic error</glossterm> for a pipeline to attempt to
+        access a resource for which it has insufficient privileges or perform a step which is
+        forbidden.</error>
+      <impl>Which steps are forbidden, what privileges are needed to access resources, and under
+        what circumstances these security constraints apply is
+          <glossterm>implementation-dependent</glossterm>.</impl>
+    </para>
+    <para>Steps in a pipeline may call themselves recursively which could result in pipelines which
+      will never terminate.</para>
+    <para>A conformant XProc processor may limit the resources available to any or all steps in a
+      pipeline. A conformant implementation may raise dynamic errors, or take any other corrective
+      action, for any security problems that it detects.</para>
+  </section>
 
-<section xml:id="versioning-considerations">
-<title>Versioning Considerations</title>
+  <section xml:id="versioning-considerations">
+    <title>Versioning Considerations</title>
 
-<para>A pipeline author <rfc2119>may</rfc2119> identify the version of XProc
-for which a particular pipeline was authored by setting the
-<tag class="attribute">version</tag> attribute. The
-<tag class="attribute">version</tag> attribute can be specified on
-<tag>p:declare-step</tag> or <tag>p:library</tag>.
-If specified, the value of
-the <tag class="attribute">version</tag> attribute <rfc2119>must</rfc2119> be a
-<type>xs:decimal</type>. <error code="S0063">It is a
-<glossterm>static error</glossterm> if the value of the
-<tag class="attribute">version</tag> attribute is not a
-<type>xs:decimal</type>.</error></para>
+    <para>A pipeline author <rfc2119>may</rfc2119> identify the version of XProc for which a
+      particular pipeline was authored by setting the <tag class="attribute">version</tag>
+      attribute. The <tag class="attribute">version</tag> attribute can be specified on
+        <tag>p:declare-step</tag> or <tag>p:library</tag>. If specified, the value of the <tag
+        class="attribute">version</tag> attribute <rfc2119>must</rfc2119> be a
+        <type>xs:decimal</type>. <error code="S0063">It is a <glossterm>static error</glossterm> if
+        the value of the <tag class="attribute">version</tag> attribute is not a
+          <type>xs:decimal</type>.</error></para>
 
-<para>The version of XProc defined
-by this specification is “<literal>3.0</literal>”.</para>
+    <para>The version of XProc defined by this specification is “<literal>3.0</literal>”.</para>
 
-<para>A pipeline author <rfc2119>must</rfc2119> identify the version of XProc
-on the document element of a pipeline document.
-<error code="S0062">It is a <glossterm>static error</glossterm> if a
-required
-<tag class="attribute">version</tag> attribute
-is not present.</error></para>
+    <para>A pipeline author <rfc2119>must</rfc2119> identify the version of XProc on the document
+      element of a pipeline document. <error code="S0062">It is a <glossterm>static
+          error</glossterm> if a required <tag class="attribute">version</tag> attribute is not
+        present.</error></para>
 
-<para>The version identified applies
-to the element on which the
-<tag class="attribute">version</tag> attribute appears and all of its descendants,
-unless or until another version is explicitly identified.</para>
+    <para>The version identified applies to the element on which the <tag class="attribute"
+        >version</tag> attribute appears and all of its descendants, unless or until another version
+      is explicitly identified.</para>
 
-<para>XProc 3.0 takes a draconian approach to versioning.
-<error code="S0060">It
-is a <glossterm>static error</glossterm> if the processor encounters
-an explicit request for a version of the language other than “3.0”.</error>
-</para>
-      </section>
+    <para>XProc 3.0 takes a draconian approach to versioning. <error code="S0060">It is a
+          <glossterm>static error</glossterm> if the processor encounters an explicit request for a
+        version of the language other than “3.0”.</error>
+    </para>
+  </section>
 
 
   <section xml:id="syntax">
@@ -2668,14 +2688,13 @@ an explicit request for a version of the language other than “3.0”.</error>
     <para>Elements in a pipeline document represent the pipeline, the steps it contains, the
       connections between those steps, the steps and connections contained within them, and so on.
       Each step is represented by an element; a combination of elements and attributes specify how
-      the inputs and outputs of each step are connected and how options are
-      passed. Outside of inline documents (<tag>p:inline</tag> elements explicitly or implicitly),
-text nodes that consist entirely of whitespace and XML comments are ignored. XML processing instructions are
-also generally ignored. <impl>It is
-<glossterm>implementation-defined</glossterm> if any processing instructions are significant
-to an implementation.</impl> In an inline document, all markup is treated as if it was a quoted
-part of the inline document and no special semantics apply except as noted elsewhere in this
-specification.</para>
+      the inputs and outputs of each step are connected and how options are passed. Outside of
+      inline documents (<tag>p:inline</tag> elements explicitly or implicitly), text nodes that
+      consist entirely of whitespace and XML comments are ignored. XML processing instructions are
+      also generally ignored. <impl>It is <glossterm>implementation-defined</glossterm> if any
+        processing instructions are significant to an implementation.</impl> In an inline document,
+      all markup is treated as if it was a quoted part of the inline document and no special
+      semantics apply except as noted elsewhere in this specification.</para>
     <para>Conceptually, we can speak of steps as objects that have inputs and outputs, that are
       connected together and which may contain additional steps. Syntactically, we need a mechanism
       for specifying these relationships.</para>
@@ -2690,7 +2709,9 @@ specification.</para>
       <para>There are three namespaces associated with XProc:</para>
       <variablelist>
         <varlistentry>
-          <term><uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri></term>
+          <term>
+            <uri type="xmlnamespace">http://www.w3.org/ns/xproc</uri>
+          </term>
           <listitem>
             <para>The namespace of the XProc XML vocabulary described by this specification; by
               convention, the namespace prefix “<literal>p:</literal>” is used for this
@@ -2698,7 +2719,9 @@ specification.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><uri type="xmlnamespace">http://www.w3.org/ns/xproc-step</uri></term>
+          <term>
+            <uri type="xmlnamespace">http://www.w3.org/ns/xproc-step</uri>
+          </term>
           <listitem>
             <para>The namespace used for documents that are inputs to and outputs from several
               standard and optional steps described in this specification. Some steps, such as
@@ -2708,7 +2731,9 @@ specification.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
-          <term><uri type="xmlnamespace">http://www.w3.org/ns/xproc-error</uri></term>
+          <term>
+            <uri type="xmlnamespace">http://www.w3.org/ns/xproc-error</uri>
+          </term>
           <listitem>
             <para>The namespace used for errors. The conventional prefix “<literal>err:</literal>”
               is used for this namespace. </para>
@@ -2717,45 +2742,43 @@ specification.</para>
       </variablelist>
       <para>This specification also makes use of the prefix “<literal>xs:</literal>” to refer to the
           <biblioref linkend="xmlschema-1"/> namespace <uri type="xmlnamespace"
-          >http://www.w3.org/2001/XMLSchema</uri> and the prefix “<literal>xsi:</literal>”
-          to refer to the namepace <uri type="xmlnamespace"
-          >http://www.w3.org/2001/XMLSchema-instance</uri>
+          >http://www.w3.org/2001/XMLSchema</uri> and the prefix “<literal>xsi:</literal>” to refer
+        to the namepace <uri type="xmlnamespace">http://www.w3.org/2001/XMLSchema-instance</uri>
       </para>
     </section>
     <section xml:id="scoping">
       <title>Scoping of Names</title>
 
-<para>Names are used to identify step types, steps, ports, options and
-variables. Step types, options, and variables are named with EQNames.
-Steps and ports are named with NCNames. The scope of a name is a
-measure of where it is available in a pipeline. <termdef
-xml:id="dt-visible">If two names are in the same scope, we say that
-they are <firstterm>visible</firstterm> to each other.
-</termdef></para>
+      <para>Names are used to identify step types, steps, ports, options and variables. Step types,
+        options, and variables are named with EQNames. Steps and ports are named with NCNames. The
+        scope of a name is a measure of where it is available in a pipeline. <termdef
+          xml:id="dt-visible">If two names are in the same scope, we say that they are
+            <firstterm>visible</firstterm> to each other. </termdef></para>
 
-    <para>Six kinds of things are named in XProc:</para>
-    <orderedlist spacing="compact">
-      <listitem>
-        <simpara>Step types,</simpara>
-      </listitem>
-      <listitem>
-        <simpara>Steps,</simpara>
-      </listitem>
-      <listitem>
-        <simpara>Input ports,</simpara>
-      </listitem>
-      <listitem>
-        <simpara>Output ports,</simpara>
-      </listitem>
-      <listitem>
-        <simpara>Options and variables</simpara>
-      </listitem>
-    </orderedlist>
+      <para>Six kinds of things are named in XProc:</para>
+      <orderedlist spacing="compact">
+        <listitem>
+          <simpara>Step types,</simpara>
+        </listitem>
+        <listitem>
+          <simpara>Steps,</simpara>
+        </listitem>
+        <listitem>
+          <simpara>Input ports,</simpara>
+        </listitem>
+        <listitem>
+          <simpara>Output ports,</simpara>
+        </listitem>
+        <listitem>
+          <simpara>Options and variables</simpara>
+        </listitem>
+      </orderedlist>
 
       <para>The scope of the names of the step types is the pipeline in which they are declared,
         including any declarations imported from libraries via <tag>p:import</tag>. Nested pipelines
         inherit the step types in scope for their parent.</para>
-      <para>In other words, the step types that are in scope in a <tag>p:declare-step</tag> are:</para>
+      <para>In other words, the step types that are in scope in a <tag>p:declare-step</tag>
+        are:</para>
       <itemizedlist>
         <listitem>
           <para>The standard, built-in types (<tag>p:declare-step</tag>, <tag>p:choose</tag>, etc.).
@@ -2765,11 +2788,11 @@ they are <firstterm>visible</firstterm> to each other.
           <para>Any implementation-provided types. </para>
         </listitem>
         <listitem>
-          <para>Any step types declared in the <tag>p:declare-step</tag> children of the pipeline element. </para>
+          <para>Any step types declared in the <tag>p:declare-step</tag> children of the pipeline
+            element. </para>
         </listitem>
         <listitem>
-          <para>The types of any <tag>p:declare-step</tag>s that are
-            imported. </para>
+          <para>The types of any <tag>p:declare-step</tag>s that are imported. </para>
         </listitem>
         <listitem>
           <para>Any types that are in the scope of any <tag>p:library</tag> that is imported.
@@ -2777,7 +2800,7 @@ they are <firstterm>visible</firstterm> to each other.
         </listitem>
         <listitem>
           <para>Any step types that are in scope for the pipeline's parent
-              <tag>p:declare-step</tag>, if it has one. </para>
+            <tag>p:declare-step</tag>, if it has one. </para>
         </listitem>
         <listitem>
           <para>The type of the pipeline itself, if it has one. </para>
@@ -2793,65 +2816,60 @@ they are <firstterm>visible</firstterm> to each other.
           <para>Any implementation-provided types. </para>
         </listitem>
         <listitem>
-          <para>Any step types declared in the library (the
-              <tag>p:declare-step</tag> children of the <tag>p:library</tag> element). </para>
+          <para>Any step types declared in the library (the <tag>p:declare-step</tag> children of
+            the <tag>p:library</tag> element). </para>
         </listitem>
         <listitem>
-          <para>The types of <tag>p:declare-step</tag>s that are imported
-            into the library. </para>
+          <para>The types of <tag>p:declare-step</tag>s that are imported into the library. </para>
         </listitem>
         <listitem>
           <para>Any types that are in the scope of any <tag>p:library</tag> that is imported.
           </para>
         </listitem>
       </itemizedlist>
-      <para><error code="S0036">All the step types in a pipeline or library <rfc2119>must</rfc2119>
-          have unique names: it is a <glossterm>static error</glossterm> if any step type name is
-          built-in and/or declared or defined more than once in the same scope.</error></para>
+      <para>
+        <error code="S0036">All the step types in a pipeline or library <rfc2119>must</rfc2119> have
+          unique names: it is a <glossterm>static error</glossterm> if any step type name is
+          built-in and/or declared or defined more than once in the same scope.</error>
+      </para>
 
-<para>The scope of the names of the steps themselves is determined by
-the <glossterm>environment</glossterm> of each step. In general, the
-name of a step, the names of its sibling steps, the names of any steps
-that it contains directly, the names of its ancestors, and the names
-of the siblings of its ancestors are all in a common scope. <error
-code="S0002">All steps in the same scope <rfc2119>must</rfc2119> have
-unique names: it is a <glossterm>static error</glossterm> if two steps
-with the same name appear in the same scope.</error></para>
+      <para>The scope of the names of the steps themselves is determined by the
+          <glossterm>environment</glossterm> of each step. In general, the name of a step, the names
+        of its sibling steps, the names of any steps that it contains directly, the names of its
+        ancestors, and the names of the siblings of its ancestors are all in a common scope. <error
+          code="S0002">All steps in the same scope <rfc2119>must</rfc2119> have unique names: it is
+          a <glossterm>static error</glossterm> if two steps with the same name appear in the same
+          scope.</error></para>
 
-<para>The scope of an input or output port name is the step on which
-it is defined. The names of all the ports on any step
-<rfc2119>must</rfc2119> be unique.</para>
+      <para>The scope of an input or output port name is the step on which it is defined. The names
+        of all the ports on any step <rfc2119>must</rfc2119> be unique.</para>
 
-<para>Taken together, these uniqueness constraints guarantee that the
-combination of a step name and a port name uniquely identifies exactly
-one port on exactly one in-scope step.</para>
+      <para>Taken together, these uniqueness constraints guarantee that the combination of a step
+        name and a port name uniquely identifies exactly one port on exactly one in-scope
+        step.</para>
 
-<para>The scope of option and variable names is determined by where
-they are declared. When an option is declared with <tag>p:option</tag>
-(or a variable with <tag>p:variable</tag>), unless otherwise
-specified, its scope consists of the sibling elements that follow its
-declaration and the descendants of those siblings.
-</para>
-</section>
+      <para>The scope of option and variable names is determined by where they are declared. When an
+        option is declared with <tag>p:option</tag> (or a variable with <tag>p:variable</tag>),
+        unless otherwise specified, its scope consists of the sibling elements that follow its
+        declaration and the descendants of those siblings. </para>
+    </section>
     <section xml:id="xml-base-attribute">
       <title>Base URIs and xml:base</title>
 
-<para>If a relative URI appears in an option of type <type>xs:anyURI</type>,
-the base URI against which it <rfc2119>must</rfc2119> be made absolute is the base
-URI of the <tag>p:option</tag> element. If the option value is
-specified using a <link linkend="option-shortcut">syntactic
-shortcut</link>, the base URI of the step element on which the shortcut
-attribute appears <rfc2119>must</rfc2119> be used. In general,
-whenever a relative URI appears in an <type>xs:anyURI</type>,
-its base URI is the base URI of the nearest ancestor element.</para>
+      <para>If a relative URI appears in an option of type <type>xs:anyURI</type>, the base URI
+        against which it <rfc2119>must</rfc2119> be made absolute is the base URI of the
+          <tag>p:option</tag> element. If the option value is specified using a <link
+          linkend="option-shortcut">syntactic shortcut</link>, the base URI of the step element on
+        which the shortcut attribute appears <rfc2119>must</rfc2119> be used. In general, whenever a
+        relative URI appears in an <type>xs:anyURI</type>, its base URI is the base URI of the
+        nearest ancestor element.</para>
 
-<para>The pipeline author can control the base URIs of elements within
-the pipeline document with the <tag class="attribute">xml:base</tag>
-attribute. The <tag class="attribute">xml:base</tag> attribute
-<rfc2119>may</rfc2119> appear on any element in a pipeline and has the
-semantics outlined in <biblioref linkend="xml-base"/>.</para>
+      <para>The pipeline author can control the base URIs of elements within the pipeline document
+        with the <tag class="attribute">xml:base</tag> attribute. The <tag class="attribute"
+          >xml:base</tag> attribute <rfc2119>may</rfc2119> appear on any element in a pipeline and
+        has the semantics outlined in <biblioref linkend="xml-base"/>.</para>
 
-</section>
+    </section>
     <section xml:id="xml-id-attribute">
       <title>Unique identifiers</title>
       <para>A pipeline author can provide a globally unique identifier for any element in a pipeline
@@ -2861,32 +2879,30 @@ semantics outlined in <biblioref linkend="xml-base"/>.</para>
         />.</para>
     </section>
 
-<section xml:id="syntax-docs-ports">
-<title>Associating Documents with Ports</title>
+    <section xml:id="syntax-docs-ports">
+      <title>Associating Documents with Ports</title>
 
-<para> A document or a sequence of documents can be connected to a
-port in four ways: <glossterm>by source</glossterm>, <glossterm>by
-URI</glossterm>, by providing an <glossterm>inline
-document</glossterm>, or by making it
-<glossterm baseform="empty-sequence">explicitly empty</glossterm>.
-Each of these mechanisms is allowed where connections may be made, except that
-<tag>p:input</tag> may not include a connection <glossterm>by source</glossterm>.</para>
+      <para> A document or a sequence of documents can be connected to a port in four ways:
+          <glossterm>by source</glossterm>, <glossterm>by URI</glossterm>, by providing an
+          <glossterm>inline document</glossterm>, or by making it <glossterm
+          baseform="empty-sequence">explicitly empty</glossterm>. Each of these mechanisms is
+        allowed where connections may be made, except that <tag>p:input</tag> may not include a
+        connection <glossterm>by source</glossterm>.</para>
 
-<variablelist>
-<varlistentry>
-<term>Specified by URI</term>
-<listitem>
-<para><termdef xml:id="dt-by-URI">A document is specified
-<firstterm>by URI</firstterm> if it is referenced with a
-URI.</termdef> The <tag class="attribute">href</tag> attribute on the
-<tag>p:document</tag> element is used to refer to
-documents by URI.</para>
+      <variablelist>
+        <varlistentry>
+          <term>Specified by URI</term>
+          <listitem>
+            <para><termdef xml:id="dt-by-URI">A document is specified <firstterm>by URI</firstterm>
+                if it is referenced with a URI.</termdef> The <tag class="attribute">href</tag>
+              attribute on the <tag>p:document</tag> element is used to refer to documents by
+              URI.</para>
             <para>In this example, the input to the <tag>p:identity</tag> step named
                 “<literal>otherstep</literal>” comes from “<uri>http://example.com/input.xml</uri>”. </para>
             <programlisting language="xml"><xi:include href="../../../build/examples/identity.txt" parse="text"/></programlisting>
 
             <para>See the description of <tag>p:document</tag> for a complete description of how
-            URIs may be specified.</para>
+              URIs may be specified.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
@@ -2912,21 +2928,22 @@ documents by URI.</para>
                 specified directly in the body of the element to which it connects.</termdef> The
               content of the <tag>p:inline</tag> element is used for this purpose. </para>
             <para>In this example, the “<literal>stylesheet</literal>” input to the XSLT step named
-                “<literal>xform</literal>” comes from the content of the <tag>p:with-input</tag> element
-              itself.</para>
+                “<literal>xform</literal>” comes from the content of the <tag>p:with-input</tag>
+              element itself.</para>
             <programlisting language="xml"><xi:include href="../../../build/examples/xslt.txt" parse="text"/></programlisting>
             <para>Inline documents are considered “quoted”. The pipeline processor passes them
               literally to the port, even if they contain elements from the XProc namespace or other
               namespaces that would have other semantics outside of the <tag>p:inline</tag>.</para>
 
             <para>See the description of <tag>p:inline</tag> for a complete description of how
-            inline documents may be specified.</para>
+              inline documents may be specified.</para>
           </listitem>
         </varlistentry>
         <varlistentry>
           <term>Specified explicitly empty</term>
           <listitem>
-            <para><termdef xml:id="dt-empty-sequence">An <firstterm>empty sequence</firstterm> of
+            <para>
+              <termdef xml:id="dt-empty-sequence">An <firstterm>empty sequence</firstterm> of
                 documents is specified with the <tag>p:empty</tag> element.</termdef>
             </para>
             <para>In this example, the “<literal>source</literal>” input to the XSLT 2.0 step named
@@ -2936,13 +2953,13 @@ documents by URI.</para>
                 <glossterm>default readable port</glossterm> will be assumed. Making the connection
               explicitly empty guarantees that the connection will be to an empty sequence of
               documents.</para>
-            <para>See the description of <tag>p:empty</tag> for a complete description of
-            empty connections.</para>
+            <para>See the description of <tag>p:empty</tag> for a complete description of empty
+              connections.</para>
           </listitem>
         </varlistentry>
       </variablelist>
-      <para>Note that a <tag>p:input</tag>, <tag>p:with-input</tag>, or <tag>p:output</tag> element may contain more than one
-          <tag>p:pipe</tag>, <tag>p:document</tag>, or <tag>p:inline</tag>
+      <para>Note that a <tag>p:input</tag>, <tag>p:with-input</tag>, or <tag>p:output</tag> element
+        may contain more than one <tag>p:pipe</tag>, <tag>p:document</tag>, or <tag>p:inline</tag>
         element. If more than one <glossterm>connection</glossterm> is provided, then the specified
         sequence of documents is made available on that port in the same order as the
         connections.</para>
@@ -2981,7 +2998,8 @@ documents by URI.</para>
 
     <section xml:id="extension-attributes">
       <title>Extension attributes</title>
-      <para><termdef xml:id="dt-extension-attribute">An element from the XProc namespace
+      <para>
+        <termdef xml:id="dt-extension-attribute">An element from the XProc namespace
             <rfc2119>may</rfc2119> have any attribute not from the XProc namespace, provided that
           the expanded-QName of the attribute has a non-null namespace URI. Such an attribute is
           called an <firstterm>extension attribute</firstterm>.</termdef>
@@ -2994,195 +3012,172 @@ documents by URI.</para>
           <rfc2119>must</rfc2119> behave as if the attribute was not present.</para>
     </section>
 
-<section xml:id="common-attr">
-<title>Common Attributes</title>
+    <section xml:id="common-attr">
+      <title>Common Attributes</title>
 
-<para>Several attributes can be used on any XProc step, or even any element in a pipeline.
-For convenience, they are all summarized here.</para>
+      <para>Several attributes can be used on any XProc step, or even any element in a pipeline. For
+        convenience, they are all summarized here.</para>
 
-<para>Attributes from the XML namespace are allowed anywhere. In particular:</para>
+      <para>Attributes from the XML namespace are allowed anywhere. In particular:</para>
 
-<itemizedlist>
-<listitem>
-  <para>An <tag class="attribute">xml:id</tag> attribute is allowed on any element. It has
-  the semantics of <biblioref linkend="xml-id"/>.</para>
-</listitem>
-<listitem>
-  <para>An <tag class="attribute">xml:base</tag> attribute is allowed on any element. It has
-  the semantics of <biblioref linkend="xml-base"/>.</para>
-</listitem>
-</itemizedlist>
+      <itemizedlist>
+        <listitem>
+          <para>An <tag class="attribute">xml:id</tag> attribute is allowed on any element. It has
+            the semantics of <biblioref linkend="xml-id"/>.</para>
+        </listitem>
+        <listitem>
+          <para>An <tag class="attribute">xml:base</tag> attribute is allowed on any element. It has
+            the semantics of <biblioref linkend="xml-base"/>.</para>
+        </listitem>
+      </itemizedlist>
 
-<para>The remaining elements are sometimes in no namespace and sometimes
-explicitly in the XProc namespace. They are in no namespace when they
-appear on an XProc element; they are in the XProc namespace when they
-are on an element in any other namespace. In this way, they do not
-conflict with the names used in other vocabularies.
-<error code="S0097">It is a <glossterm>static error</glossterm> if an
-attribute in the XProc namespace appears on an element in the XProc
-namespace.</error>
-</para>
+      <para>The remaining elements are sometimes in no namespace and sometimes explicitly in the
+        XProc namespace. They are in no namespace when they appear on an XProc element; they are in
+        the XProc namespace when they are on an element in any other namespace. In this way, they do
+        not conflict with the names used in other vocabularies. <error code="S0097">It is a
+            <glossterm>static error</glossterm> if an attribute in the XProc namespace appears on an
+          element in the XProc namespace.</error>
+      </para>
 
-<section xml:id="expand-text-attribute">
-<title>Expand text attributes</title>
+      <section xml:id="expand-text-attribute">
+        <title>Expand text attributes</title>
 
-<para>The <tag class="attribute">[p:]expand-text</tag> and
-<tag class="attribute">[p:]inline-expand-text</tag> attributes control
-whether or not text and attribute nodes in descendant
-<tag>p:inline</tag> elements and implicit inlines are designated as
-value templates. Note that they control both text
-<emphasis>and</emphasis> attribute value templates.</para>
-  
-<para>The <tag class="attribute">[p:]expand-text</tag> attribute can
-appear on all elements in the pipeline. It controls whether or not
-descendant inlines are designated as value templates. If the
-attribute <emphasis>itself</emphasis> appears
-among the descendants of a <tag>p:inline</tag> (or implicit inline), then
-it is a regular attribute and has no special semantics. In this case,
-the <tag class="attribute">[p:]inline-expand-text</tag> attribute comes
-into play.
-</para>
-  
-<para>The <tag class="attribute">[p:]inline-expand-text</tag> attribute
-appearing as descendant of a <tag>p:inline</tag> or in an implicit
-inline is treated as a special attribute, with the same semantics as
-the <tag class="attribute">[p:]expand-text</tag> attribute. The
-attribute will not be part of the result of the <tag>p:inline</tag> or
-implicit inline.</para>
+        <para>The <tag class="attribute">[p:]expand-text</tag> and <tag class="attribute"
+            >[p:]inline-expand-text</tag> attributes control whether or not text and attribute nodes
+          in descendant <tag>p:inline</tag> elements and implicit inlines are designated as value
+          templates. Note that they control both text <emphasis>and</emphasis> attribute value
+          templates.</para>
 
-<para>If the <tag class="attribute">[p:]expand-text</tag> or
-<tag class="attribute">[p:]inline-expand-text</tag> attribute appears on more
-than one element among the ancestors of a text or attribute node in a
-<tag>p:inline</tag> element or implicit inline, only the value on the
-nearest ancestor is considered.</para>
+        <para>The <tag class="attribute">[p:]expand-text</tag> attribute can appear on all elements
+          in the pipeline. It controls whether or not descendant inlines are designated as value
+          templates. If the attribute <emphasis>itself</emphasis> appears among the descendants of a
+            <tag>p:inline</tag> (or implicit inline), then it is a regular attribute and has no
+          special semantics. In this case, the <tag class="attribute">[p:]inline-expand-text</tag>
+          attribute comes into play. </para>
 
-<para>If the nearest <tag class="attribute">[p:]expand-text</tag> or
-<tag class="attribute" >[p:]inline-expand-text</tag> attribute has the
-value “<code>false</code>”, then the text and attribute nodes in a
-<tag>p:inline</tag> element or implicit inline are not value
-templates. If it has the value “<code>true</code>”, or if no such
-attribute is present among ancestors, then the text and attribute
-nodes <emphasis>are</emphasis> value templates.</para>
+        <para>The <tag class="attribute">[p:]inline-expand-text</tag> attribute appearing as
+          descendant of a <tag>p:inline</tag> or in an implicit inline is treated as a special
+          attribute, with the same semantics as the <tag class="attribute">[p:]expand-text</tag>
+          attribute. The attribute will not be part of the result of the <tag>p:inline</tag> or
+          implicit inline.</para>
 
-</section>
+        <para>If the <tag class="attribute">[p:]expand-text</tag> or <tag class="attribute"
+            >[p:]inline-expand-text</tag> attribute appears on more than one element among the
+          ancestors of a text or attribute node in a <tag>p:inline</tag> element or implicit inline,
+          only the value on the nearest ancestor is considered.</para>
 
-<section xml:id="use-when">
-<title>Conditional Element Exclusion</title>
+        <para>If the nearest <tag class="attribute">[p:]expand-text</tag> or <tag class="attribute"
+            >[p:]inline-expand-text</tag> attribute has the value “<code>false</code>”, then the
+          text and attribute nodes in a <tag>p:inline</tag> element or implicit inline are not value
+          templates. If it has the value “<code>true</code>”, or if no such attribute is present
+          among ancestors, then the text and attribute nodes <emphasis>are</emphasis> value
+          templates.</para>
 
-<para xml:id="p.use-when">The <tag
-class="attribute">[p:]use-when</tag> attribute controls whether or not
-an element (and its descendants) appear in the pipeline. The value of
-the attribute <rfc2119>must</rfc2119> contain an XPath expression that
-can be evaluated statically (See <link linkend="statics"/>.) <termdef
-xml:id="dt-effectively-excluded">If the effective boolean value of the
-<tag class="attribute">[p:]use-when</tag> expression is false, then
-the element and all of its descendants are <firstterm>effectively
-excluded</firstterm> from the pipeline document.</termdef> If a node is
-effectively excluded, the processor <rfc2119>must</rfc2119> behave as
-if the element was not present in the document.
-</para>
+      </section>
 
-<para>Conditional element exclusion occurs during <link
-linkend="initiating">static analysis</link> of the pipeline.</para>
+      <section xml:id="use-when">
+        <title>Conditional Element Exclusion</title>
 
-<note xml:id="note-excl-use-when">
-<para>The effective exclusion of <tag class="attribute">[p:]use-when</tag>
-processing occurs after XML parsing and has no effect on well-formedness
-or validation errors which will be reported in the usual way.</para>
-</note>
-</section>
+        <para xml:id="p.use-when">The <tag class="attribute">[p:]use-when</tag> attribute controls
+          whether or not an element (and its descendants) appear in the pipeline. The value of the
+          attribute <rfc2119>must</rfc2119> contain an XPath expression that can be evaluated
+          statically (See <link linkend="statics"/>.) <termdef xml:id="dt-effectively-excluded">If
+            the effective boolean value of the <tag class="attribute">[p:]use-when</tag> expression
+            is false, then the element and all of its descendants are <firstterm>effectively
+              excluded</firstterm> from the pipeline document.</termdef> If a node is effectively
+          excluded, the processor <rfc2119>must</rfc2119> behave as if the element was not present
+          in the document. </para>
 
-<section xml:id="depends">
-<title>Additional dependent connections</title>
+        <para>Conditional element exclusion occurs during <link linkend="initiating">static
+            analysis</link> of the pipeline.</para>
 
-<para xml:id="p.depends">The <tag class="attribute">[p:]depends</tag>
-attribute can appear on any step invocation. It adds an explicit
-dependency between steps. The value of the attribute is a space
-separated list of step names. <error code="S0073">It is a
-<glossterm>static error</glossterm> if any specified name is not the
-name of an in-scope step.</error></para>
+        <note xml:id="note-excl-use-when">
+          <para>The effective exclusion of <tag class="attribute">[p:]use-when</tag> processing
+            occurs after XML parsing and has no effect on well-formedness or validation errors which
+            will be reported in the usual way.</para>
+        </note>
+      </section>
 
-<para>In most pipelines, the dependencies that arise naturally
-from the connections between steps are sufficient. If step “B”
-consumes the output of step “A”, then clearly “A” must run before “B”.
-However, it is sometimes the case that one step depends on
-another in ways that are not apparent in the connections. Consider,
-for example, a pipeline that interacts with two different web
-services. It may very well be the case that one web service has to run
-before the other, even though the latter does not consume any output
-from the former.</para>
+      <section xml:id="depends">
+        <title>Additional dependent connections</title>
 
-<para>When <tag class="attribute">[p:]depends</tag> is used, if step
-“Y” depends on step “X”, then “X” must run before “Y”.
-</para>
+        <para xml:id="p.depends">The <tag class="attribute">[p:]depends</tag> attribute can appear
+          on any step invocation. It adds an explicit dependency between steps. The value of the
+          attribute is a space separated list of step names. <error code="S0073">It is a
+              <glossterm>static error</glossterm> if any specified name is not the name of an
+            in-scope step.</error></para>
 
-<para>The connections specified by the
-<tag class="attribute">[p:]depends</tag> attribute apply
-<emphasis>in addition to</emphasis> the dependencies that arise
-naturally from connections between steps. Taken together with the
-input and output connections, the graph must not contain any loops.
-</para>
-</section>
+        <para>In most pipelines, the dependencies that arise naturally from the connections between
+          steps are sufficient. If step “B” consumes the output of step “A”, then clearly “A” must
+          run before “B”. However, it is sometimes the case that one step depends on another in ways
+          that are not apparent in the connections. Consider, for example, a pipeline that interacts
+          with two different web services. It may very well be the case that one web service has to
+          run before the other, even though the latter does not consume any output from the
+          former.</para>
 
-<section xml:id="timeout">
-<title>Controlling long running steps</title>
+        <para>When <tag class="attribute">[p:]depends</tag> is used, if step “Y” depends on step
+          “X”, then “X” must run before “Y”. </para>
 
-<para xml:id="p.timeout">The <tag class="attribute">[p:]timeout</tag>
-attribute allows a pipeline author to suggest a length of time beyond
-which the pipeline processor should consider that a step has taken
-an excessive amount of time.</para>
+        <para>The connections specified by the <tag class="attribute">[p:]depends</tag> attribute
+          apply <emphasis>in addition to</emphasis> the dependencies that arise naturally from
+          connections between steps. Taken together with the input and output connections, the graph
+          must not contain any loops. </para>
+      </section>
 
-<para>The value of the <option>[p:]timeout</option> option must be a
-<type>xs:nonNegativeInteger</type>. It is interpreted as a number of
-seconds. The value zero may be used to indicate that no limit is
-expressed (this is the same as omitting the attribute, but may
-sometimes be more convenient for pipeline authors).
-</para>
+      <section xml:id="timeout">
+        <title>Controlling long running steps</title>
 
-<para><error code="D0053">It is a <glossterm>dynamic error</glossterm>
-if a step runs longer than its timeout value.</error></para>
+        <para xml:id="p.timeout">The <tag class="attribute">[p:]timeout</tag> attribute allows a
+          pipeline author to suggest a length of time beyond which the pipeline processor should
+          consider that a step has taken an excessive amount of time.</para>
 
-<para>The precise amount of time a step takes to perform its task
-depends on many factors (the hardware running the processor, the
-processor's execution strategy, the system load etc.) This feature can
-not be used as an exact timing tool in XProc. Developers are advised
-to calculate the value for <tag class="attribute">[p:]timeout</tag>
-generously, so the dynamic error is raised only in extreme cases.</para>
+        <para>The value of the <option>[p:]timeout</option> option must be a
+            <type>xs:nonNegativeInteger</type>. It is interpreted as a number of seconds. The value
+          zero may be used to indicate that no limit is expressed (this is the same as omitting the
+          attribute, but may sometimes be more convenient for pipeline authors). </para>
 
-<para><impl>It is
-<glossterm>implementation-defined</glossterm> whether a processor
-supports timeouts, and if it does, how precisely and precisely how the
-execution time of a step is measured.</impl>
-</para>
-</section>
+        <para>
+          <error code="D0053">It is a <glossterm>dynamic error</glossterm> if a step runs longer
+            than its timeout value.</error>
+        </para>
 
-<section xml:id="messages">
-<title>Status and debugging output</title>
+        <para>The precise amount of time a step takes to perform its task depends on many factors
+          (the hardware running the processor, the processor's execution strategy, the system load
+          etc.) This feature can not be used as an exact timing tool in XProc. Developers are
+          advised to calculate the value for <tag class="attribute">[p:]timeout</tag> generously, so
+          the dynamic error is raised only in extreme cases.</para>
 
-<para xml:id="p.message">The <tag class="attribute">[p:]message</tag>
-attribute can appear on any step invocation. It’s value is treated
-as an attribute value template (irrespective of any enclosing
-<tag class="attribute">[p:]expand-text</tag> setting) and the
-computed value is made available.</para>
+        <para>
+          <impl>It is <glossterm>implementation-defined</glossterm> whether a processor supports
+            timeouts, and if it does, how precisely and precisely how the execution time of a step
+            is measured.</impl>
+        </para>
+      </section>
 
-<para><impl>Precisely what “made available” means is
-<glossterm>implementation-defined</glossterm>.</impl> It will often
-be as simple as printing the message on some output channel. But for
-embedded systems or other environments where “print it for the user”
-is meaningless or inconvenient, some other mechanism may be used.
-</para>
+      <section xml:id="messages">
+        <title>Status and debugging output</title>
 
-<para>If a processor can make the message available, it
-<rfc2119>should</rfc2119> do so before execution of the step
-begins.</para>
-</section>
-</section>
+        <para xml:id="p.message">The <tag class="attribute">[p:]message</tag> attribute can appear
+          on any step invocation. It’s value is treated as an attribute value template (irrespective
+          of any enclosing <tag class="attribute">[p:]expand-text</tag> setting) and the computed
+          value is made available.</para>
 
-<section xml:id="syntax-summaries"><title>Syntax Summaries</title>
+        <para><impl>Precisely what “made available” means is
+              <glossterm>implementation-defined</glossterm>.</impl> It will often be as simple as
+          printing the message on some output channel. But for embedded systems or other
+          environments where “print it for the user” is meaningless or inconvenient, some other
+          mechanism may be used. </para>
 
-<para>The description of each element in the pipeline namespace is
-accompanied by a syntactic summary that provides a quick overview of
-the element's syntax:</para>
+        <para>If a processor can make the message available, it <rfc2119>should</rfc2119> do so
+          before execution of the step begins.</para>
+      </section>
+    </section>
+
+    <section xml:id="syntax-summaries">
+      <title>Syntax Summaries</title>
+
+      <para>The description of each element in the pipeline namespace is accompanied by a syntactic
+        summary that provides a quick overview of the element's syntax:</para>
 
       <e:rng-fragment name="SomeElement" role="nosummary">
         <grammar xmlns="http://relaxng.org/ns/structure/1.0">
@@ -3214,185 +3209,203 @@ the element's syntax:</para>
               </optional>
             </element>
           </define>
-          <define name="Some"><element name="some"><empty/></element></define>
-          <define name="Elements"><element name="elements"><empty/></element></define>
-          <define name="Allowed"><element name="allowed"><empty/></element></define>
-          <define name="OtherElements"><element name="other-elements"><empty/></element></define>
+          <define name="Some">
+            <element name="some">
+              <empty/>
+            </element>
+          </define>
+          <define name="Elements">
+            <element name="elements">
+              <empty/>
+            </element>
+          </define>
+          <define name="Allowed">
+            <element name="allowed">
+              <empty/>
+            </element>
+          </define>
+          <define name="OtherElements">
+            <element name="other-elements">
+              <empty/>
+            </element>
+          </define>
         </grammar>
       </e:rng-fragment>
 
       <para>The content model fragments in these tableaux are presented in a simple, compact
         notation. In brief:</para>
 
-<variablelist>
-<varlistentry>
-<term>Attributes</term>
-<listitem>
-<itemizedlist>
-        <listitem>
-          <para>Required attributes are bold. Optional attributes are followed by a question mark.</para>
-        </listitem>
-        <listitem>
-          <para>If an attribute value is an attribute value template, its type is shown
-          in curly brackets: “<code>{ some-type }</code>”. If <literal>some-type</literal> is 
-          <type>xs:QName</type> or a map type with key type <type>xs:QName</type> the conversion described in
-            <xref linkend="qname-handling"/> applies.</para>
-        </listitem>
+      <variablelist>
+        <varlistentry>
+          <term>Attributes</term>
           <listitem>
-            <para>An attribute value with a map type marks an <type>XPathExpression</type> expected to
-              deliver a map of the indicated type. If the map type has key type <type>xs:QName</type> 
-              the conversion described in <xref linkend="qname-handling"/> applies.</para>
+            <itemizedlist>
+              <listitem>
+                <para>Required attributes are bold. Optional attributes are followed by a question
+                  mark.</para>
+              </listitem>
+              <listitem>
+                <para>If an attribute value is an attribute value template, its type is shown in
+                  curly brackets: “<code>{ some-type }</code>”. If <literal>some-type</literal> is
+                    <type>xs:QName</type> or a map type with key type <type>xs:QName</type> the
+                  conversion described in <xref linkend="qname-handling"/> applies.</para>
+              </listitem>
+              <listitem>
+                <para>An attribute value with a map type marks an <type>XPathExpression</type>
+                  expected to deliver a map of the indicated type. If the map type has key type
+                    <type>xs:QName</type> the conversion described in <xref linkend="qname-handling"
+                  /> applies.</para>
+              </listitem>
+            </itemizedlist>
           </listitem>
-</itemizedlist>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term>Elements</term>
-<listitem>
-<itemizedlist>
-        <listitem>
-          <para>A name represent exactly one occurrence of an element with that name.</para>
-        </listitem>
-        <listitem>
-          <para>Parentheses are used for grouping. </para>
-        </listitem>
-        <listitem>
-          <para>Elements or groups separated by a comma (“,”) represent an ordered sequence: a
-            followed by b followed by c: (a,b,c).</para>
-        </listitem>
-        <listitem>
-          <para>Elements or groups separated by a vertical bar (“|”) represent a choice: a or b or
-            c: (a | b | c).</para>
-        </listitem>
-        <listitem>
-          <para>Elements or groups separated by an ampersand (“&amp;”) represent an unordered
-            sequence: a and b and c, in any order: (a &amp; b &amp; c).</para>
-        </listitem>
-        <listitem>
-          <para>An element or group followed by a question mark (“?”) is optional; it may or may not
-            occur but if it occurs it can occur only once.</para>
-        </listitem>
-        <listitem>
-          <para>An element or group followed by an asterisk (“*”) is optional and may be repeated;
-            it may or may not occur and if it occurs it can occur any number of times. </para>
-        </listitem>
-        <listitem>
-          <para>An element or group followed by a plus (“+”) is required and may be repeated; it
-            must occur at least once, and it can occur any number of times. </para>
-        </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Elements</term>
+          <listitem>
+            <itemizedlist>
+              <listitem>
+                <para>A name represent exactly one occurrence of an element with that name.</para>
+              </listitem>
+              <listitem>
+                <para>Parentheses are used for grouping. </para>
+              </listitem>
+              <listitem>
+                <para>Elements or groups separated by a comma (“,”) represent an ordered sequence: a
+                  followed by b followed by c: (a,b,c).</para>
+              </listitem>
+              <listitem>
+                <para>Elements or groups separated by a vertical bar (“|”) represent a choice: a or
+                  b or c: (a | b | c).</para>
+              </listitem>
+              <listitem>
+                <para>Elements or groups separated by an ampersand (“&amp;”) represent an unordered
+                  sequence: a and b and c, in any order: (a &amp; b &amp; c).</para>
+              </listitem>
+              <listitem>
+                <para>An element or group followed by a question mark (“?”) is optional; it may or
+                  may not occur but if it occurs it can occur only once.</para>
+              </listitem>
+              <listitem>
+                <para>An element or group followed by an asterisk (“*”) is optional and may be
+                  repeated; it may or may not occur and if it occurs it can occur any number of
+                  times. </para>
+              </listitem>
+              <listitem>
+                <para>An element or group followed by a plus (“+”) is required and may be repeated;
+                  it must occur at least once, and it can occur any number of times. </para>
+              </listitem>
 
-</itemizedlist>
-</listitem>
-</varlistentry>
-</variablelist>
+            </itemizedlist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>For clarity of exposition, the common attributes (see <xref
-linkend="common-attr"/>) are elided from the summaries as are the
-<tag>p:documentation</tag> and <tag>p:pipeinfo</tag> elements, which
-are allowed anywhere, and attributes that are
-<link linkend="option-shortcut">syntactic shortcuts for option values</link>.
-</para>
+      <para>For clarity of exposition, the common attributes (see <xref linkend="common-attr"/>) are
+        elided from the summaries as are the <tag>p:documentation</tag> and <tag>p:pipeinfo</tag>
+        elements, which are allowed anywhere, and attributes that are <link
+          linkend="option-shortcut">syntactic shortcuts for option values</link>. </para>
 
-<para>The types given for attributes should be understood as follows:</para>
-<itemizedlist>
-  <listitem>
-    <para><type>ID</type>, <type>NCName</type>, <type>NMTOKEN</type>,
-    <type>NMTOKENS</type>, <type>anyURI</type>, <type>boolean</type>,
-    <type>integer</type>, <type>string</type>: As per <biblioref
-    linkend="xmlschema-2"/> including whitespace normalization as
-    appropriate.</para>
-  </listitem>
-  <listitem>
-    <para><type>EQName</type>: With whitespace normalization as per
-    <biblioref linkend="xmlschema-2"/> for QNames. Note, however, that
-    QNames that have no prefix are always in no-namespace, irrespective of the
-    default namespace.
-    </para>
-  </listitem>
-  <listitem>
-    <para><type>EQNameList</type>: As a whitespace separated list of
-    EQNames, per the definition above.
-    </para>
-  </listitem>
-  <listitem>
-    <para><type>PrefixList</type>: As a list with <literal
-    role="infoset-property">item type</literal> <type>NMTOKEN</type>,
-    per <biblioref linkend="xmlschema-2"/>, including whitespace
-    normalization.
-    </para>
-  </listitem>
-  <listitem>
-    <para><type>ExcludeInlinePrefixes</type>: As a <type>PrefixList</type>
-    per the definition above, with the following extensions: the tokens
-    <literal>#all</literal> and <literal>#default</literal> may appear.
-    </para>
-  </listitem>
-  <listitem>
-    <para><type>XPathExpression</type>, <type>XSLTSelectionPattern</type>:
-    As a string per <biblioref linkend="xmlschema-2"/>, including
-    whitespace normalization, and the further requirement to be a
-    conformant Expression per <biblioref linkend="xpath31"/> or 
-            <glossterm>selection pattern</glossterm> per <biblioref linkend="xslt30"/>.
-    </para>
-  </listitem>
-  <listitem>
-    <para><type>MediaTypes</type>:
-    As a whitespace separated list of media types as defined in
-    <biblioref linkend="rfc2046"/>.
-    </para>
-  </listitem>
-</itemizedlist>
-</section>
+      <para>The types given for attributes should be understood as follows:</para>
+      <itemizedlist>
+        <listitem>
+          <para><type>ID</type>, <type>NCName</type>, <type>NMTOKEN</type>, <type>NMTOKENS</type>,
+              <type>anyURI</type>, <type>boolean</type>, <type>integer</type>, <type>string</type>:
+            As per <biblioref linkend="xmlschema-2"/> including whitespace normalization as
+            appropriate.</para>
+        </listitem>
+        <listitem>
+          <para><type>EQName</type>: With whitespace normalization as per <biblioref
+              linkend="xmlschema-2"/> for QNames. Note, however, that QNames that have no prefix are
+            always in no-namespace, irrespective of the default namespace. </para>
+        </listitem>
+        <listitem>
+          <para><type>EQNameList</type>: As a whitespace separated list of EQNames, per the
+            definition above. </para>
+        </listitem>
+        <listitem>
+          <para><type>PrefixList</type>: As a list with <literal role="infoset-property">item
+              type</literal>
+            <type>NMTOKEN</type>, per <biblioref linkend="xmlschema-2"/>, including whitespace
+            normalization. </para>
+        </listitem>
+        <listitem>
+          <para><type>ExcludeInlinePrefixes</type>: As a <type>PrefixList</type> per the definition
+            above, with the following extensions: the tokens <literal>#all</literal> and
+              <literal>#default</literal> may appear. </para>
+        </listitem>
+        <listitem>
+          <para><type>XPathExpression</type>, <type>XSLTSelectionPattern</type>: As a string per
+              <biblioref linkend="xmlschema-2"/>, including whitespace normalization, and the
+            further requirement to be a conformant Expression per <biblioref linkend="xpath31"/> or
+              <glossterm>selection pattern</glossterm> per <biblioref linkend="xslt30"/>. </para>
+        </listitem>
+        <listitem>
+          <para><type>MediaTypes</type>: As a whitespace separated list of media types as defined in
+              <biblioref linkend="rfc2046"/>. </para>
+        </listitem>
+      </itemizedlist>
+    </section>
 
     <section xml:id="common-errors">
       <title>Common errors</title>
       <para>A number of errors apply generally:</para>
       <itemizedlist>
         <listitem>
-          <para><error code="S0059">It is a <glossterm>static error</glossterm> if the pipeline
-              element is not <tag>p:declare-step</tag> or
-                <tag>p:library</tag>.</error>
+          <para>
+            <error code="S0059">It is a <glossterm>static error</glossterm> if the pipeline element
+              is not <tag>p:declare-step</tag> or <tag>p:library</tag>.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="S0008">It is a <glossterm>static error</glossterm> if any element in
-              the XProc namespace has attributes not defined by this specification unless they are
+          <para>
+            <error code="S0008">It is a <glossterm>static error</glossterm> if any element in the
+              XProc namespace has attributes not defined by this specification unless they are
                 <glossterm baseform="extension
 attribute">extension attributes</glossterm>.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="S0038">It is a <glossterm>static error</glossterm> if any required
+          <para>
+            <error code="S0038">It is a <glossterm>static error</glossterm> if any required
               attribute is not provided.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="S0077">It is a <glossterm>static error</glossterm> if the value on an
-            attribute of an XProc element does not satisfy the type required for that attribute.</error>
+          <para>
+            <error code="S0077">It is a <glossterm>static error</glossterm> if the value on an
+              attribute of an XProc element does not satisfy the type required for that
+              attribute.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="D0028">It is a <glossterm>dynamic error</glossterm> if any attribute
-              value does not satisfy the type required for that attribute.</error></para>
-        </listitem>
-        <listitem>
-          <para><error code="S0044">It is a <glossterm>static error</glossterm> if any step contains 
-            an atomic step for which there is no visible declaration.</error></para>
-        </listitem>
-        <listitem>
-          <para><error code="S0037">It is a <glossterm>static error</glossterm> if any user extension 
-            step or any element in the XProc namespace other than <tag>p:inline</tag> directly contains 
-            text nodes that do not consist entirely of whitespace.</error>
+          <para>
+            <error code="D0028">It is a <glossterm>dynamic error</glossterm> if any attribute value
+              does not satisfy the type required for that attribute.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="D0019">It is a <glossterm>dynamic error</glossterm> if any option value
+          <para>
+            <error code="S0044">It is a <glossterm>static error</glossterm> if any step contains an
+              atomic step for which there is no visible declaration.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <error code="S0037">It is a <glossterm>static error</glossterm> if any user extension
+              step or any element in the XProc namespace other than <tag>p:inline</tag> directly
+              contains text nodes that do not consist entirely of whitespace.</error>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <error code="D0019">It is a <glossterm>dynamic error</glossterm> if any option value
               does not satisfy the type required for that option.</error>
           </para>
         </listitem>
         <listitem>
-          <para><error code="S0015">It is a <glossterm>static error</glossterm> if a compound step
-              has no <glossterm>contained steps</glossterm>.</error>
+          <para>
+            <error code="S0015">It is a <glossterm>static error</glossterm> if a compound step has
+              no <glossterm>contained steps</glossterm>.</error>
           </para>
         </listitem>
         <listitem>
@@ -3412,21 +3425,21 @@ attribute">extension attributes</glossterm>.</error>
             extension steps are encouraged to use this code for general failures.</para>
         </listitem>
         <listitem>
-          <para>In most steps which use a select expression or <glossterm>selection pattern</glossterm>, any kind of node can
-            be identified by the expression or pattern. However, some expressions and patterns on
-            some steps are only applicable to some kinds of nodes (e.g., it doesn't make sense to
-            speak of adding attributes to a comment!). </para>
-          <para><error code="C0023">It is a <glossterm>dynamic error</glossterm> if a select
-            expression or <glossterm>selection pattern</glossterm> returns a node type that is not allowed by the
-              step.</error>
+          <para>In most steps which use a select expression or <glossterm>selection
+              pattern</glossterm>, any kind of node can be identified by the expression or pattern.
+            However, some expressions and patterns on some steps are only applicable to some kinds
+            of nodes (e.g., it doesn't make sense to speak of adding attributes to a comment!). </para>
+          <para>
+            <error code="C0023">It is a <glossterm>dynamic error</glossterm> if a select expression
+              or <glossterm>selection pattern</glossterm> returns a node type that is not allowed by
+              the step.</error>
           </para>
         </listitem>
         <listitem>
           <para><error code="S0100">It is a <glossterm>static error</glossterm> if the pipeline
-          document does not conform to the grammar for pipeline documents.</error>
-          This is a general error code indicating that the pipeline is syntactically incorrect
-          in some way not identified more precisely in this specification.
-          </para>
+              document does not conform to the grammar for pipeline documents.</error> This is a
+            general error code indicating that the pipeline is syntactically incorrect in some way
+            not identified more precisely in this specification. </para>
         </listitem>
       </itemizedlist>
       <para>If an XProc processor can determine statically that a dynamic error will
@@ -3439,85 +3452,74 @@ attribute">extension attributes</glossterm>.</error>
   </section>
   <section xml:id="steps">
     <title>Steps</title>
-    <para>This section describes the core language steps of XProc; the full
-vocabulary of standard, atomic steps is described in
-<biblioref linkend="steps30"/>.</para>
+    <para>This section describes the core language steps of XProc; the full vocabulary of standard,
+      atomic steps is described in <biblioref linkend="steps30"/>.</para>
 
-<section xml:id="pipelines">
-<title>Pipelines</title>
+    <section xml:id="pipelines">
+      <title>Pipelines</title>
 
-<para>The document element of a pipeline document is
-<tag>p:declare-step</tag> which declares a pipeline that can be
-evaluated by an XProc processor.</para>
+      <para>The document element of a pipeline document is <tag>p:declare-step</tag> which declares
+        a pipeline that can be evaluated by an XProc processor.</para>
 
-<para>It encapsulates the behavior of a
-<glossterm>subpipeline</glossterm>. Its children declare inputs,
-outputs, and options that the pipeline exposes and identify the steps
-in its subpipeline.
-</para>
+      <para>It encapsulates the behavior of a <glossterm>subpipeline</glossterm>. Its children
+        declare inputs, outputs, and options that the pipeline exposes and identify the steps in its
+        subpipeline. </para>
 
-<para>Viewed from the outside, a <tag>p:declare-step</tag> is a black
-box which performs some calculation on its inputs and produces its
-outputs. From the pipeline author's perspective, the computation
-performed by the pipeline is described in terms of
-<glossterm>contained steps</glossterm> which read the pipeline's
-inputs and produce the pipeline's outputs.</para>
+      <para>Viewed from the outside, a <tag>p:declare-step</tag> is a black box which performs some
+        calculation on its inputs and produces its outputs. From the pipeline author's perspective,
+        the computation performed by the pipeline is described in terms of <glossterm>contained
+          steps</glossterm> which read the pipeline's inputs and produce the pipeline's
+        outputs.</para>
 
-<para>A <tag>p:declare-step</tag> element can also be nested inside
-other <tag>p:declare-step</tag> or <tag>p:library</tag> elements in
-which case it simply declares a pipeline that will be run
-elsewhere.</para>
+      <para>A <tag>p:declare-step</tag> element can also be nested inside other
+          <tag>p:declare-step</tag> or <tag>p:library</tag> elements in which case it simply
+        declares a pipeline that will be run elsewhere.</para>
 
-<para>For more details, see <xref linkend="p.declare-step"/>.</para>
+      <para>For more details, see <xref linkend="p.declare-step"/>.</para>
 
-<section xml:id="example-pipeline"
-         role="tocsuppress">
-<title>Example</title>
-<para>A pipeline might accept a document as input; perform XInclude, validation, and
-transformation; and produce the transformed document as its output.</para>
-<example xml:id="ex.p.pipeline">
-  <title>A Sample Pipeline Document</title>
-  <programlisting language="xml"><xi:include href="../../../build/examples/pipeline.txt" parse="text"/></programlisting>
-</example>
-</section>
-</section>
+      <section xml:id="example-pipeline" role="tocsuppress">
+        <title>Example</title>
+        <para>A pipeline might accept a document as input; perform XInclude, validation, and
+          transformation; and produce the transformed document as its output.</para>
+        <example xml:id="ex.p.pipeline">
+          <title>A Sample Pipeline Document</title>
+          <programlisting language="xml"><xi:include href="../../../build/examples/pipeline.txt" parse="text"/></programlisting>
+        </example>
+      </section>
+    </section>
 
-<section xml:id="p.for-each">
-<title>p:for-each</title>
+    <section xml:id="p.for-each">
+      <title>p:for-each</title>
 
-<para>A for-each is specified by the <tag>p:for-each</tag> element. It
-is a <glossterm>compound step</glossterm> that processes a sequence of
-documents, applying its <glossterm>subpipeline</glossterm> to each
-document in turn.</para>
+      <para>A for-each is specified by the <tag>p:for-each</tag> element. It is a
+          <glossterm>compound step</glossterm> that processes a sequence of documents, applying its
+          <glossterm>subpipeline</glossterm> to each document in turn.</para>
 
-<e:rng-pattern name="ForEach"/>
+      <e:rng-pattern name="ForEach"/>
 
-<para>When a pipeline needs to process a sequence of documents using a
-subpipeline that only processes a single document, the
-<tag>p:for-each</tag> construct can be used as a wrapper around that
-subpipeline. The <tag>p:for-each</tag> will apply that subpipeline to
-each document in the sequence in turn.</para>
-<para>The result of the <tag>p:for-each</tag> is a
-        sequence of documents produced by processing each individual document in the input sequence.
-        If the <tag>p:for-each</tag> has one or more output ports, what appears on each of those
-        ports is the sequence of documents that is the concatenation of the sequence produced by
-        each iteration of the loop on the port to which it is connected. If the iteration source for
-        a <tag>p:for-each</tag> is an empty sequence, then the subpipeline is never run and an empty
-        sequence is produced on all of the outputs. </para>
+      <para>When a pipeline needs to process a sequence of documents using a subpipeline that only
+        processes a single document, the <tag>p:for-each</tag> construct can be used as a wrapper
+        around that subpipeline. The <tag>p:for-each</tag> will apply that subpipeline to each
+        document in the sequence in turn.</para>
+      <para>The result of the <tag>p:for-each</tag> is a sequence of documents produced by
+        processing each individual document in the input sequence. If the <tag>p:for-each</tag> has
+        one or more output ports, what appears on each of those ports is the sequence of documents
+        that is the concatenation of the sequence produced by each iteration of the loop on the port
+        to which it is connected. If the iteration source for a <tag>p:for-each</tag> is an empty
+        sequence, then the subpipeline is never run and an empty sequence is produced on all of the
+        outputs. </para>
 
-<para>The <tag>p:for-each</tag> has a single anonymous input: its
-<glossterm>connection</glossterm> is provided by the
-<tag>p:with-input</tag>. If no iteration sequence is explicitly provided,
-then the iteration source is read from the <glossterm>default readable
-port</glossterm>.</para>
+      <para>The <tag>p:for-each</tag> has a single anonymous input: its
+          <glossterm>connection</glossterm> is provided by the <tag>p:with-input</tag>. If no
+        iteration sequence is explicitly provided, then the iteration source is read from the
+          <glossterm>default readable port</glossterm>.</para>
 
-<para>The processor provides each document, one at a time, to the
+      <para>The processor provides each document, one at a time, to the
           <glossterm>subpipeline</glossterm> represented by the children of the
           <tag>p:for-each</tag> on a port named <port>current</port>.</para>
-<para>For each declared
-        output, the processor collects all the documents that are produced for that output from all
-        the iterations, in order, into a sequence. The result of the <tag>p:for-each</tag> on that
-        output is that sequence of documents.</para>
+      <para>For each declared output, the processor collects all the documents that are produced for
+        that output from all the iterations, in order, into a sequence. The result of the
+          <tag>p:for-each</tag> on that output is that sequence of documents.</para>
       <!--
 <para>The <glossterm>environment</glossterm> of a <tag>p:for-each</tag> is its
 inherited environment
@@ -3525,7 +3527,8 @@ with the <link linkend="dt-standard-modifications">standard modifications</link>
 -->
       <para>The environment inherited by the <glossterm>contained steps</glossterm> of a
           <tag>p:for-each</tag> is the <glossterm>inherited environment</glossterm> with these
-        modifications:</para><itemizedlist>
+        modifications:</para>
+      <itemizedlist>
         <listitem>
           <para>The port named “<port>current</port>” on the <tag>p:for-each</tag> is added to the
               <glossterm>readable ports</glossterm>.</para>
@@ -3534,22 +3537,22 @@ with the <link linkend="dt-standard-modifications">standard modifications</link>
           <para>The port named “<port>current</port>” on the <tag>p:for-each</tag> is made the
               <glossterm>default readable port</glossterm>.</para>
         </listitem>
-      </itemizedlist><para>If the <tag>p:for-each</tag> has a <glossterm>primary output
-          port</glossterm> (explicit or <link linkend="primary-input-output">supplied by
-          default</link>) and that port has no <glossterm>connection</glossterm>, then it is
-        connected to the <glossterm>primary output port</glossterm> of the <glossterm>last
-          step</glossterm> in the <glossterm>subpipeline</glossterm>. <error code="S0006">It is a
-            <glossterm>static error</glossterm> if the primary output port has no explicit
-          connection and the <glossterm>last step</glossterm> in the subpipeline does not have a
-          primary output port.</error></para>
-<para>Note that outputs declared for a
-          <tag>p:for-each</tag> serve a dual role. Inside the <tag>p:for-each</tag>, they are used
-        to read results from the subpipeline. Outside the <tag>p:for-each</tag>, they provide the
-        aggregated results.</para>
-<para>The <tag class="attribute">sequence</tag> attribute on a
-          <tag>p:output</tag> inside a <tag>p:for-each</tag> only applies inside the step. From the
-        outside, all of the outputs produce sequences.</para><section
-        xml:id="for-each-xpath-context">
+      </itemizedlist>
+      <para>If the <tag>p:for-each</tag> has a <glossterm>primary output port</glossterm> (explicit
+        or <link linkend="primary-input-output">supplied by default</link>) and that port has no
+          <glossterm>connection</glossterm>, then it is connected to the <glossterm>primary output
+          port</glossterm> of the <glossterm>last step</glossterm> in the
+          <glossterm>subpipeline</glossterm>. <error code="S0006">It is a <glossterm>static
+            error</glossterm> if the primary output port has no explicit connection and the
+            <glossterm>last step</glossterm> in the subpipeline does not have a primary output
+          port.</error></para>
+      <para>Note that outputs declared for a <tag>p:for-each</tag> serve a dual role. Inside the
+          <tag>p:for-each</tag>, they are used to read results from the subpipeline. Outside the
+          <tag>p:for-each</tag>, they provide the aggregated results.</para>
+      <para>The <tag class="attribute">sequence</tag> attribute on a <tag>p:output</tag> inside a
+          <tag>p:for-each</tag> only applies inside the step. From the outside, all of the outputs
+        produce sequences.</para>
+      <section xml:id="for-each-xpath-context">
         <title>XPath Context</title>
         <para>Within a <tag>p:for-each</tag>, the <function>p:iteration-position</function> and
             <function>p:iteration-size</function> are taken from the sequence of documents that will
@@ -3564,7 +3567,8 @@ with the <link linkend="dt-standard-modifications">standard modifications</link>
             to be calculated (and the entire input sequence does not, therefore, need to be buffered
             so that its size can be calculated before processing begins).</para>
         </note>
-      </section><section xml:id="example-for-each" role="tocsuppress">
+      </section>
+      <section xml:id="example-for-each" role="tocsuppress">
         <title>Example</title>
         <para>A <tag>p:for-each</tag> might accept a sequence of chapters as its input, process each
           chapter in turn with XSLT, a step that accepts only a single input document, and produce a
@@ -3578,56 +3582,51 @@ with the <link linkend="dt-standard-modifications">standard modifications</link>
           and FO documents are aggregated together and appear on the <literal>html-results</literal>
           and <literal>fo-results</literal> ports, respectively, of the <literal>chapters</literal>
           step itself.</para>
-      </section></section>
+      </section>
+    </section>
 
-<section xml:id="p.viewport">
-<title>p:viewport</title>
+    <section xml:id="p.viewport">
+      <title>p:viewport</title>
 
-<para>A viewport is specified by the <tag>p:viewport</tag> element. It
-is a <glossterm>compound step</glossterm> that processes a single XML
-document, applying its <glossterm>subpipeline</glossterm> to one or
-more subtrees of the document. </para>
+      <para>A viewport is specified by the <tag>p:viewport</tag> element. It is a
+          <glossterm>compound step</glossterm> that processes a single XML document, applying its
+          <glossterm>subpipeline</glossterm> to one or more subtrees of the document. </para>
 
-<e:rng-pattern name="Viewport"/>
+      <e:rng-pattern name="Viewport"/>
 
-<para>The result of the <tag>p:viewport</tag> is a copy of the
-original document where the selected subtrees have been replaced by
-the results of applying the subpipeline to them.</para>
+      <para>The result of the <tag>p:viewport</tag> is a copy of the original document where the
+        selected subtrees have been replaced by the results of applying the subpipeline to
+        them.</para>
 
-<para>The <tag>p:viewport</tag> has a single anonymous input: its
-<glossterm>connection</glossterm> is provided by the
-<tag>p:with-input</tag>. If no document is explicitly provided,
-then the viewport source is read from the <glossterm>default readable
-port</glossterm>. If the <tag>p:viewport</tag> input is a sequence,
-each document in the sequence is processed in turn producing a sequence
-on the output.</para>
+      <para>The <tag>p:viewport</tag> has a single anonymous input: its
+          <glossterm>connection</glossterm> is provided by the <tag>p:with-input</tag>. If no
+        document is explicitly provided, then the viewport source is read from the
+          <glossterm>default readable port</glossterm>. If the <tag>p:viewport</tag> input is a
+        sequence, each document in the sequence is processed in turn producing a sequence on the
+        output.</para>
 
-<para>The <tag class="attribute">match</tag> attribute specifies an
-XSLT <glossterm>selection pattern</glossterm>. Each matching node in
-the source document is wrapped in a document node, as necessary, and
-provided, one at a time, to the viewport's
-<glossterm>subpipeline</glossterm> on a port named
-<port>current</port>. The base URI of the resulting document that is
-passed to the subpipeline is the base URI of the matched element or
-document. <error code="D0010">It is a <glossterm>dynamic
-error</glossterm> if the <tag class="attribute">match</tag> expression
-on <tag>p:viewport</tag> does not match an element or
-document.</error></para>
+      <para>The <tag class="attribute">match</tag> attribute specifies an XSLT <glossterm>selection
+          pattern</glossterm>. Each matching node in the source document is wrapped in a document
+        node, as necessary, and provided, one at a time, to the viewport's
+          <glossterm>subpipeline</glossterm> on a port named <port>current</port>. The base URI of
+        the resulting document that is passed to the subpipeline is the base URI of the matched
+        element or document. <error code="D0010">It is a <glossterm>dynamic error</glossterm> if the
+            <tag class="attribute">match</tag> expression on <tag>p:viewport</tag> does not match an
+          element or document.</error></para>
 
-<note>
-<para>The <tag class="attribute">match</tag> attribute on
-<tag>p:viewport</tag> is a selection pattern and may contain references
-to in-scope variables and options, but it is
-not an <glossterm>attribute value template</glossterm>.
-</para>
-</note>
+      <note>
+        <para>The <tag class="attribute">match</tag> attribute on <tag>p:viewport</tag> is a
+          selection pattern and may contain references to in-scope variables and options, but it is
+          not an <glossterm>attribute value template</glossterm>. </para>
+      </note>
 
-<para>After a match is found, the entire subtree rooted at that match
-is processed as a unit. No further attempts are made to match nodes
-among the descendants of any matched node.</para>
-<para>The environment inherited by the <glossterm>contained steps</glossterm> of
-        a <tag>p:viewport</tag> is the <glossterm>inherited environment</glossterm> with these
-        modifications:</para><itemizedlist>
+      <para>After a match is found, the entire subtree rooted at that match is processed as a unit.
+        No further attempts are made to match nodes among the descendants of any matched
+        node.</para>
+      <para>The environment inherited by the <glossterm>contained steps</glossterm> of a
+          <tag>p:viewport</tag> is the <glossterm>inherited environment</glossterm> with these
+        modifications:</para>
+      <itemizedlist>
         <listitem>
           <para>The port named “<port>current</port>” on the <tag>p:viewport</tag> is added to the
               <glossterm>readable ports</glossterm>.</para>
@@ -3636,32 +3635,33 @@ among the descendants of any matched node.</para>
           <para>The port named “<port>current</port>” on the <tag>p:viewport</tag> is made the
               <glossterm>default readable port</glossterm>.</para>
         </listitem>
-      </itemizedlist><para>The <tag>p:viewport</tag> must contain a single, <glossterm>primary
-          output port</glossterm> declared explicitly or <link linkend="primary-input-output"
-          >supplied by default</link>. If that port has no <glossterm>connection</glossterm>, then
-        it is connected to the <glossterm>primary output port</glossterm> of the <glossterm>last
+      </itemizedlist>
+      <para>The <tag>p:viewport</tag> must contain a single, <glossterm>primary output
+          port</glossterm> declared explicitly or <link linkend="primary-input-output">supplied by
+          default</link>. If that port has no <glossterm>connection</glossterm>, then it is
+        connected to the <glossterm>primary output port</glossterm> of the <glossterm>last
           step</glossterm> in the <glossterm>subpipeline</glossterm>. <error code="S0006">It is a
             <glossterm>static error</glossterm> if the primary output port is unconnected and the
             <glossterm>last step</glossterm> in the subpipeline does not have a primary output
           port.</error></para>
-<para>What appears on the output from the <tag>p:viewport</tag> will
-        be a copy of the input document where each matching node is replaced by the result of
-        applying the subpipeline to the subtree rooted at that node. In other words, if the 
-        <glossterm>selection pattern</glossterm> matches a particular element then that element is wrapped in a document node and
-        provided on the <port>current</port> port, the subpipeline in the <tag>p:viewport</tag> is
-        evaluated, and the result that appears on the <port>output</port> port replaces the matched
-        element. </para>
-<para>If no documents appear on the <port>output</port> port, the matched
-        element will effectively be deleted. If exactly one document appears, the contents of that
-        document will replace the matched element. If a sequence of documents appears, then the
-        contents of each document in that sequence (in the order it appears in the sequence) will
-        replace the matched element.</para>
-<para>The output of the <tag>p:viewport</tag> itself is a
-        single document that appears on a port named “<literal>result</literal>”. Note that the
-        semantics of <tag>p:viewport</tag> are special. The <port>output</port> port in the
-          <tag>p:viewport</tag> is used only to access the results of the subpipeline. The output of
-        the step itself appears on a port with the fixed name “<literal>result</literal>” that is
-        never explicitly declared.</para><section xml:id="viewport-xpath-context">
+      <para>What appears on the output from the <tag>p:viewport</tag> will be a copy of the input
+        document where each matching node is replaced by the result of applying the subpipeline to
+        the subtree rooted at that node. In other words, if the <glossterm>selection
+          pattern</glossterm> matches a particular element then that element is wrapped in a
+        document node and provided on the <port>current</port> port, the subpipeline in the
+          <tag>p:viewport</tag> is evaluated, and the result that appears on the <port>output</port>
+        port replaces the matched element. </para>
+      <para>If no documents appear on the <port>output</port> port, the matched element will
+        effectively be deleted. If exactly one document appears, the contents of that document will
+        replace the matched element. If a sequence of documents appears, then the contents of each
+        document in that sequence (in the order it appears in the sequence) will replace the matched
+        element.</para>
+      <para>The output of the <tag>p:viewport</tag> itself is a single document that appears on a
+        port named “<literal>result</literal>”. Note that the semantics of <tag>p:viewport</tag> are
+        special. The <port>output</port> port in the <tag>p:viewport</tag> is used only to access
+        the results of the subpipeline. The output of the step itself appears on a port with the
+        fixed name “<literal>result</literal>” that is never explicitly declared.</para>
+      <section xml:id="viewport-xpath-context">
         <title>XPath Context</title>
         <para>Within a <tag>p:viewport</tag>, the <function>p:iteration-position</function> and
             <function>p:iteration-size</function> are taken from the sequence of documents that will
@@ -3676,7 +3676,8 @@ among the descendants of any matched node.</para>
             to be calculated (and the entire input sequence does not, therefore, need to be buffered
             so that its size can be calculated before processing begins).</para>
         </note>
-      </section><section xml:id="example-viewport" role="tocsuppress">
+      </section>
+      <section xml:id="example-viewport" role="tocsuppress">
         <title>Example</title>
         <para>A <tag>p:viewport</tag> might accept an XHTML document as its input, add an
             <tag>hr</tag> element at the beginning of all <tag>div</tag> elements that have the
@@ -3691,142 +3692,132 @@ among the descendants of any matched node.</para>
           the resulting version replaces the original <code>h:div</code>. The result of the whole
           step is a copy of the input document with a horizontal rule as the first child of each
           selected <code>h:div</code>.</para>
-      </section></section>
+      </section>
+    </section>
 
-<section xml:id="p.choose">
-<title>p:choose</title>
+    <section xml:id="p.choose">
+      <title>p:choose</title>
 
-<para>A choose step is specified by the <tag>p:choose</tag> element.
-It is a <glossterm>compound step</glossterm> that contains several, alternate subpipelines. One
-subpipeline is selected based on the evaluation of XPath
-expressions.</para>
+      <para>A choose step is specified by the <tag>p:choose</tag> element. It is a
+          <glossterm>compound step</glossterm> that contains several, alternate subpipelines. One
+        subpipeline is selected based on the evaluation of XPath expressions.</para>
 
-<e:rng-pattern name="Choose"/>
+      <e:rng-pattern name="Choose"/>
 
-<para>A <tag>p:choose</tag> contains an arbitrary number of
-alternative <glossterm
-baseform="subpipeline">subpipelines</glossterm>, at most one of which
-will be evaluated. <error code="S0074">It is a <glossterm>static
-error</glossterm> if a <tag>p:choose</tag> has neither a
-<tag>p:when</tag> nor a <tag>p:otherwise</tag>.</error></para>
+      <para>A <tag>p:choose</tag> contains an arbitrary number of alternative <glossterm
+          baseform="subpipeline">subpipelines</glossterm>, at most one of which will be evaluated.
+          <error code="S0074">It is a <glossterm>static error</glossterm> if a <tag>p:choose</tag>
+          has neither a <tag>p:when</tag> nor a <tag>p:otherwise</tag>.</error></para>
 
-<para>The list of alternative subpipelines consists of zero or more
-subpipelines guarded by an XPath expression, followed optionally by a
-single default subpipeline.</para>
+      <para>The list of alternative subpipelines consists of zero or more subpipelines guarded by an
+        XPath expression, followed optionally by a single default subpipeline.</para>
 
-<para>The <tag>p:choose</tag> considers each subpipeline in turn and
-selects the first (and only the first) subpipeline for which the guard
-expression evaluates to true in its context. After a subpipeline is
-selected, no further guard expressions are evaluated. If there are no
-subpipelines for which the expression evaluates to true then,
-if a default subpipeline was specified, it is selected, otherwise,
-no subpipeline is selected.</para>
+      <para>The <tag>p:choose</tag> considers each subpipeline in turn and selects the first (and
+        only the first) subpipeline for which the guard expression evaluates to true in its context.
+        After a subpipeline is selected, no further guard expressions are evaluated. If there are no
+        subpipelines for which the expression evaluates to true then, if a default subpipeline was
+        specified, it is selected, otherwise, no subpipeline is selected.</para>
 
-<para>After a <glossterm>subpipeline</glossterm> is selected, it is
-evaluated as if only it had been present.</para>
+      <para>After a <glossterm>subpipeline</glossterm> is selected, it is evaluated as if only it
+        had been present.</para>
 
-<para>The outputs of the <tag>p:choose</tag> are taken from the
-outputs of the selected <glossterm>subpipeline</glossterm>. The
-outputs <emphasis>available</emphasis> from the <tag>p:choose</tag>
-are union of all of the outputs declared in any of its alternative
-subpipelines. In order to maintain consistency with respect to the
-<glossterm>default readable port</glossterm>, if any subpipeline has a
-<glossterm>primary output port</glossterm>, even implicitly, then
-<emphasis>every</emphasis> subpipline must have a primary output
-port with the same name. In some cases, this may require making the implicit
-primary output explicit in order to assure that it has the same name.
-<error code="S0102">It is a <glossterm>static error</glossterm> if alternative
-subpipelines have different primary output ports.</error>
-</para>
+      <para>The outputs of the <tag>p:choose</tag> are taken from the outputs of the selected
+          <glossterm>subpipeline</glossterm>. The outputs <emphasis>available</emphasis> from the
+          <tag>p:choose</tag> are union of all of the outputs declared in any of its alternative
+        subpipelines. In order to maintain consistency with respect to the <glossterm>default
+          readable port</glossterm>, if any subpipeline has a <glossterm>primary output
+          port</glossterm>, even implicitly, then <emphasis>every</emphasis> subpipline must have a
+        primary output port with the same name. In some cases, this may require making the implicit
+        primary output explicit in order to assure that it has the same name. <error code="S0102">It
+          is a <glossterm>static error</glossterm> if alternative subpipelines have different
+          primary output ports.</error>
+      </para>
 
-<para>Consider a <tag>p:choose</tag> that has two alternative
-subpipelines where one declares output ports “A” and “B” and the other
-declares output ports “B” and “C”. The outputs available from the
-<tag>p:choose</tag> are “A”, “B”, and “C”. No documents appear on any
-outputs not declared in the subpipline actually selected.</para>
+      <para>Consider a <tag>p:choose</tag> that has two alternative subpipelines where one declares
+        output ports “A” and “B” and the other declares output ports “B” and “C”. The outputs
+        available from the <tag>p:choose</tag> are “A”, “B”, and “C”. No documents appear on any
+        outputs not declared in the subpipline actually selected.</para>
 
-<para>As a convenience to authors, it is not an error if some
-subpipelines declare outputs that can produce sequences and some do
-not. Each output of the <tag>p:choose</tag> is declared to produce a
-sequence. The content types that can appear on the port are the union
-of the content types that might be produced by any of the <tag>p:when</tag> 
-or the <tag>p:otherwise</tag>.
-</para>
+      <para>As a convenience to authors, it is not an error if some subpipelines declare outputs
+        that can produce sequences and some do not. Each output of the <tag>p:choose</tag> is
+        declared to produce a sequence. The content types that can appear on the port are the union
+        of the content types that might be produced by any of the <tag>p:when</tag> or the
+          <tag>p:otherwise</tag>. </para>
 
-<para>The <tag>p:choose</tag> can specify the context item against
-which the XPath expressions that occur on each branch are evaluated.
-The context item is specified as a <glossterm>connection</glossterm>
-in the <tag>p:with-input</tag>. If no explicit connection is provided,
-the <glossterm>default readable port</glossterm> is used. If the
-context item is connected to <tag>p:empty</tag>, or is connected to
-more than one document, or is unconnected and the <glossterm>default
-readable port</glossterm> is undefined, the context item is undefined.
-<error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error>
-</para>
+      <para>The <tag>p:choose</tag> can specify the context item against which the XPath expressions
+        that occur on each branch are evaluated. The context item is specified as a
+          <glossterm>connection</glossterm> in the <tag>p:with-input</tag>. If no explicit
+        connection is provided, the <glossterm>default readable port</glossterm> is used. If the
+        context item is connected to <tag>p:empty</tag>, or is connected to more than one document,
+        or is unconnected and the <glossterm>default readable port</glossterm> is undefined, the
+        context item is undefined. <error code="D0001">It is a <glossterm>dynamic error</glossterm>
+          if an XPath expression makes reference to the context item, size, or position when the
+          context item is undefined.</error>
+      </para>
 
-<para>Each conditional <glossterm>subpipeline</glossterm> is
-represented by a <tag>p:when</tag> element. The default branch is
-represented by a <tag>p:otherwise</tag> element. These elements are not
-sibling steps in the usual sense, the names of sibling <tag>p:when</tag>
-elements and the <tag>p:otherwise</tag> element are not in
-<link linkend="scoping">the same scope</link>.</para>
-  
-  <para>If the following conditions apply:</para>
+      <para>Each conditional <glossterm>subpipeline</glossterm> is represented by a
+          <tag>p:when</tag> element. The default branch is represented by a <tag>p:otherwise</tag>
+        element. These elements are not sibling steps in the usual sense, the names of sibling
+          <tag>p:when</tag> elements and the <tag>p:otherwise</tag> element are not in <link
+          linkend="scoping">the same scope</link>.</para>
+
+      <para>If the following conditions apply:</para>
       <itemizedlist>
         <listitem>
-          <para>The <tag>p:choose</tag> does not contain a <tag>p:otherwise</tag> child element</para>
+          <para>The <tag>p:choose</tag> does not contain a <tag>p:otherwise</tag> child
+            element</para>
         </listitem>
         <listitem>
-          <para>The <tag>p:when</tag> branches all define a primary output port (either implicitly or explicitly)</para>
+          <para>The <tag>p:when</tag> branches all define a primary output port (either implicitly
+            or explicitly)</para>
         </listitem>
         <listitem>
-          <para>None of the effective boolean values of the <tag>p:when</tag> test expressions evaluates to
-              <code>true</code></para>
+          <para>None of the effective boolean values of the <tag>p:when</tag> test expressions
+            evaluates to <code>true</code></para>
         </listitem>
 
       </itemizedlist>
-      <para>Then the <tag>p:choose</tag> copies any documents that appear on its default readable port to its primary output
-        port. No documents will be written to the primary output port if there isn’t a default readable port, but that
-        is not an error in this case. No documents will ever be written to any non-primary output ports in this case.</para>
-      <para>Informally: the default sub-pipeline for a missing <tag>p:otherwise</tag> is a <tag>p:identity</tag> step
-        (with the additional feature that it isn’t an error if there’s no default readable port). If the <tag>p:when</tag> branches do not have a primary output port, no output will be produced on any port.</para>
-  
-  
+      <para>Then the <tag>p:choose</tag> copies any documents that appear on its default readable
+        port to its primary output port. No documents will be written to the primary output port if
+        there isn’t a default readable port, but that is not an error in this case. No documents
+        will ever be written to any non-primary output ports in this case.</para>
+      <para>Informally: the default sub-pipeline for a missing <tag>p:otherwise</tag> is a
+          <tag>p:identity</tag> step (with the additional feature that it isn’t an error if there’s
+        no default readable port). If the <tag>p:when</tag> branches do not have a primary output
+        port, no output will be produced on any port.</para>
 
-<section xml:id="p.when"><title>p:when</title><para>A
-          when specifies one subpipeline guarded by a test expression. </para>
+
+
+      <section xml:id="p.when">
+        <title>p:when</title>
+        <para>A when specifies one subpipeline guarded by a test expression. </para>
         <e:rng-pattern name="When"/>
         <para>Each <tag>p:when</tag> branch of the <tag>p:choose</tag> has a <tag class="attribute"
             >test</tag> attribute which <rfc2119>must</rfc2119> contain an XPath expression. That
           XPath expression's effective boolean value is the guard for the
-            <glossterm>subpipeline</glossterm> contained within that
-          <tag>p:when</tag>.</para>
+            <glossterm>subpipeline</glossterm> contained within that <tag>p:when</tag>.</para>
 
-<para>The <tag>p:when</tag> can specify a context item against which
-its <tag class="attribute">test</tag> expression is to be evaluated.
-That context item is specified as a <glossterm>connection</glossterm>
-for the <tag>p:with-input</tag>. If no context is specified on the
-<tag>p:when</tag>, the context of the <tag>p:choose</tag> is
-used. The context item is undefined if the connection or
-the context of the <tag>p:choose</tag> provides no or more than one document.
-<error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error></para>
-<para>If the <tag class="attribute">collection</tag> attribute has the value true,
-then the default collection will contain all of the documents that appeared
-on that input and the context item will be undefined.
-</para>
-</section>
+        <para>The <tag>p:when</tag> can specify a context item against which its <tag
+            class="attribute">test</tag> expression is to be evaluated. That context item is
+          specified as a <glossterm>connection</glossterm> for the <tag>p:with-input</tag>. If no
+          context is specified on the <tag>p:when</tag>, the context of the <tag>p:choose</tag> is
+          used. The context item is undefined if the connection or the context of the
+            <tag>p:choose</tag> provides no or more than one document. <error code="D0001">It is a
+              <glossterm>dynamic error</glossterm> if an XPath expression makes reference to the
+            context item, size, or position when the context item is undefined.</error></para>
+        <para>If the <tag class="attribute">collection</tag> attribute has the value true, then the
+          default collection will contain all of the documents that appeared on that input and the
+          context item will be undefined. </para>
+      </section>
 
-<section xml:id="p.otherwise"
-><title>p:otherwise</title><para>An otherwise specifies the default
-branch; the subpipeline selected if no test expression on any
-preceding <tag>p:when</tag> evaluates to true.</para>
+      <section xml:id="p.otherwise">
+        <title>p:otherwise</title>
+        <para>An otherwise specifies the default branch; the subpipeline selected if no test
+          expression on any preceding <tag>p:when</tag> evaluates to true.</para>
 
         <e:rng-pattern name="Otherwise"/>
-      </section><section xml:id="example-choose" role="tocsuppress">
+      </section>
+      <section xml:id="example-choose" role="tocsuppress">
         <title>Example</title>
         <para>A <tag>p:choose</tag> might test the version attribute of the document element and
           validate with an appropriate schema.</para>
@@ -3834,419 +3825,372 @@ preceding <tag>p:when</tag> evaluates to true.</para>
           <title>A Sample Choose</title>
           <programlisting language="xml"><xi:include href="../../../build/examples/choose.txt" parse="text"/></programlisting>
         </example>
-      </section></section>
+      </section>
+    </section>
 
-<section xml:id="p.if">
-<title>p:if</title>
+    <section xml:id="p.if">
+      <title>p:if</title>
 
-<para>A <tag>p:if</tag> specifies a single subpipeline guarded by a test expression.</para>
+      <para>A <tag>p:if</tag> specifies a single subpipeline guarded by a test expression.</para>
 
-<e:rng-pattern name="If"/>
+      <e:rng-pattern name="If"/>
 
-<para>The <tag>p:if</tag> step has a <tag class="attribute">test</tag>
-attribute which <rfc2119>must</rfc2119> contain an XPath expression.
-That XPath expression's effective boolean value is the guard for the
-<glossterm>subpipeline</glossterm> contained within it.
-</para>
+      <para>The <tag>p:if</tag> step has a <tag class="attribute">test</tag> attribute which
+          <rfc2119>must</rfc2119> contain an XPath expression. That XPath expression's effective
+        boolean value is the guard for the <glossterm>subpipeline</glossterm> contained within it. </para>
 
-<para>The <tag>p:if</tag> step can specify a context item against which
-its <tag class="attribute">test</tag> expression is to be evaluated.
-That context node is specified as a <glossterm>connection</glossterm>
-for the <tag>p:with-input</tag>. If no context is specified on the
-<tag>p:if</tag>, the context comes from the
-<glossterm>default readable port</glossterm>. If no context is specified and
-there is no default readable port, the context item is undefined. The context
-item is also undefined, if no or more than one document is provided. 
-<error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error></para>
+      <para>The <tag>p:if</tag> step can specify a context item against which its <tag
+          class="attribute">test</tag> expression is to be evaluated. That context node is specified
+        as a <glossterm>connection</glossterm> for the <tag>p:with-input</tag>. If no context is
+        specified on the <tag>p:if</tag>, the context comes from the <glossterm>default readable
+          port</glossterm>. If no context is specified and there is no default readable port, the
+        context item is undefined. The context item is also undefined, if no or more than one
+        document is provided. <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
+          XPath expression makes reference to the context item, size, or position when the context
+          item is undefined.</error></para>
 
-<para>If the <tag class="attribute">collection</tag> attribute has the value true,
-then the default collection will contain all of the documents that appeared
-on that input and the context item will be undefined.
-</para>
+      <para>If the <tag class="attribute">collection</tag> attribute has the value true, then the
+        default collection will contain all of the documents that appeared on that input and the
+        context item will be undefined. </para>
 
-<para>The <tag>p:if</tag> must specify a primary output port (either implicitly
-or explicitly). <error code="S0108">It is a <glossterm>static error</glossterm>
-if the <tag>p:if</tag> step does not specify a primary output port.</error>
-</para>
+      <para>The <tag>p:if</tag> must specify a primary output port (either implicitly or
+        explicitly). <error code="S0108">It is a <glossterm>static error</glossterm> if the
+            <tag>p:if</tag> step does not specify a primary output port.</error>
+      </para>
 
-<para>The requirement for a primary output port stems from the semantics of
-<tag>p:if</tag>:</para>
+      <para>The requirement for a primary output port stems from the semantics of
+        <tag>p:if</tag>:</para>
 
-<itemizedlist>
-<listitem>
-<para>If the effective boolean value of the test expression is true, then
-the subpipline will be run. The output of the <tag>p:if</tag> in this case
-is determined by the output ports of the step and what the subpipeline sends
-to them.</para>
-</listitem>
-<listitem>
-<para>If the effective boolean value of the test expression is false, then
-<tag>p:if</tag> copies any documents that appear on its default readable port
-to its primary output port. No documents will be written to the primary output port
-if there isn’t a default readable port, but that is not an error in this case.
-No documents will ever be written to any non-primary output
-ports if the test expression is false.</para>
-</listitem>
-</itemizedlist>
+      <itemizedlist>
+        <listitem>
+          <para>If the effective boolean value of the test expression is true, then the subpipline
+            will be run. The output of the <tag>p:if</tag> in this case is determined by the output
+            ports of the step and what the subpipeline sends to them.</para>
+        </listitem>
+        <listitem>
+          <para>If the effective boolean value of the test expression is false, then <tag>p:if</tag>
+            copies any documents that appear on its default readable port to its primary output
+            port. No documents will be written to the primary output port if there isn’t a default
+            readable port, but that is not an error in this case. No documents will ever be written
+            to any non-primary output ports if the test expression is false.</para>
+        </listitem>
+      </itemizedlist>
 
-<para>Informally, if the test expression is false, then
-<tag>p:if</tag> acts like the identity step (with the additional
-feature that it isn’t an error if there’s no default readable port). A
-primary output port is required in order to make these semantics
-meaningful and consistent.</para>
-</section>
+      <para>Informally, if the test expression is false, then <tag>p:if</tag> acts like the identity
+        step (with the additional feature that it isn’t an error if there’s no default readable
+        port). A primary output port is required in order to make these semantics meaningful and
+        consistent.</para>
+    </section>
 
-    <section xml:id="p.group"><title>p:group</title><para>A group is specified by the
-          <tag>p:group</tag> element. It is a <glossterm>compound step</glossterm> that
-           encapsulates the behavior of its <glossterm>subpipeline</glossterm>.</para>
+    <section xml:id="p.group">
+      <title>p:group</title>
+      <para>A group is specified by the <tag>p:group</tag> element. It is a <glossterm>compound
+          step</glossterm> that encapsulates the behavior of its
+        <glossterm>subpipeline</glossterm>.</para>
       <e:rng-pattern name="Group"/>
-      <para>A <tag>p:group</tag> is a convenience wrapper for a collection of steps. </para><section
-        xml:id="example-group" role="tocsuppress">
+      <para>A <tag>p:group</tag> is a convenience wrapper for a collection of steps. </para>
+      <section xml:id="example-group" role="tocsuppress">
         <title>Example</title>
         <example xml:id="ex.p.group">
           <title>An Example Group</title>
           <programlisting language="xml"><xi:include href="../../../build/examples/group.txt" parse="text"/></programlisting>
         </example>
-      </section></section>
+      </section>
+    </section>
 
-<section xml:id="p.try">
-<title>p:try</title>
+    <section xml:id="p.try">
+      <title>p:try</title>
 
-<para>A try/catch step is specified by the <tag>p:try</tag> element.
-It is a <glossterm>compound step</glossterm> that isolates its initial
-subpipeline, preventing dynamic errors that arise within it from being
-exposed to the rest of the pipeline.
-The <tag>p:try</tag> includes alternate
-recovery subpipelines, and may include a “finally”
-subpipeline to perform post-processing irrespective of the outcome of
-the <tag>p:try</tag>.</para>
+      <para>A try/catch step is specified by the <tag>p:try</tag> element. It is a
+          <glossterm>compound step</glossterm> that isolates its initial subpipeline, preventing
+        dynamic errors that arise within it from being exposed to the rest of the pipeline. The
+          <tag>p:try</tag> includes alternate recovery subpipelines, and may include a “finally”
+        subpipeline to perform post-processing irrespective of the outcome of the
+        <tag>p:try</tag>.</para>
 
-<e:rng-pattern name="Try"/>
+      <e:rng-pattern name="Try"/>
 
-<para>The step begins with the initial subpipeline;
-the recovery (or “catch”) pipelines are identified with
-<tag>p:catch</tag> elements; a “finally” pipeline is identified with a
-<tag>p:finally</tag> element.</para>
+      <para>The step begins with the initial subpipeline; the recovery (or “catch”) pipelines are
+        identified with <tag>p:catch</tag> elements; a “finally” pipeline is identified with a
+          <tag>p:finally</tag> element.</para>
 
-<para><error code="S0075">It is a <glossterm>static error</glossterm>
-if a <tag>p:try</tag> does not have at least one subpipeline step,
-at least one of <tag>p:catch</tag> or <tag>p:finally</tag>, and at most
-one <tag>p:finally</tag>.</error></para>
+      <para>
+        <error code="S0075">It is a <glossterm>static error</glossterm> if a <tag>p:try</tag> does
+          not have at least one subpipeline step, at least one of <tag>p:catch</tag> or
+            <tag>p:finally</tag>, and at most one <tag>p:finally</tag>.</error>
+      </para>
 
-<para>The <tag>p:try</tag> step evaluates the initial subpipeline and,
-if no errors occur, the outputs of that pipeline are the outputs of
-the <tag>p:try</tag> step. However, if any errors occur, the
-<tag>p:try</tag> abandons the first subpipeline, discarding any output
-that it might have generated, and considers the recovery
-subpipelines.
-If there is no matching recovery subpipeline, the <tag>p:try</tag> fails.
-</para>
+      <para>The <tag>p:try</tag> step evaluates the initial subpipeline and, if no errors occur, the
+        outputs of that pipeline are the outputs of the <tag>p:try</tag> step. However, if any
+        errors occur, the <tag>p:try</tag> abandons the first subpipeline, discarding any output
+        that it might have generated, and considers the recovery subpipelines. If there is no
+        matching recovery subpipeline, the <tag>p:try</tag> fails. </para>
 
-<note>
-<para>If the initial subpipeline fails, none of its outputs will be
-visible outside of the <tag>p:try</tag>, but it's still possible for
-steps in the partially evaluated pipeline to have side effects that
-are visible outside the processor. For example, a web server might
-record that some interaction was performed, or a file on the local
-file system might have been modified.</para>
-</note>
+      <note>
+        <para>If the initial subpipeline fails, none of its outputs will be visible outside of the
+            <tag>p:try</tag>, but it's still possible for steps in the partially evaluated pipeline
+          to have side effects that are visible outside the processor. For example, a web server
+          might record that some interaction was performed, or a file on the local file system might
+          have been modified.</para>
+      </note>
 
-<para>If a recovery subpipeline is evaluated, the outputs of the
-recovery subpipeline are the outputs of the <tag>p:try</tag> step. If
-the recovery subpipeline is evaluated and a step within that
-subpipeline fails, the <tag>p:try</tag> fails.</para>
+      <para>If a recovery subpipeline is evaluated, the outputs of the recovery subpipeline are the
+        outputs of the <tag>p:try</tag> step. If the recovery subpipeline is evaluated and a step
+        within that subpipeline fails, the <tag>p:try</tag> fails.</para>
 
-<para>Irrespective of whether the initial subpipeline succeeds or fails,
-if any recovery pipeline is selected, and whether it succeeds or fails,
-the <tag>p:finally</tag> block is <emphasis>always</emphasis> run after
-all other processing of the <tag>p:try</tag> has finished.</para>
+      <para>Irrespective of whether the initial subpipeline succeeds or fails, if any recovery
+        pipeline is selected, and whether it succeeds or fails, the <tag>p:finally</tag> block is
+          <emphasis>always</emphasis> run after all other processing of the <tag>p:try</tag> has
+        finished.</para>
 
-<para>The outputs of the <tag>p:try</tag> are taken from the
-outputs of the initial <glossterm>subpipeline</glossterm> or the recovery
-subpipline if an error occurred in the initial subpipeline. The
-outputs <emphasis>available</emphasis> from the <tag>p:try</tag>
-are union of all of the outputs declared (explicitly or implicitly in the
-absence of any <tag>p:output</tag> elements if the <glossterm>last step</glossterm>
-has a primary output port) in any of its alternative
-subpipelines. In order to maintain consistency with respect to the
-<glossterm>default readable port</glossterm>, if any subpipeline has a
-<glossterm>primary output port</glossterm>, even implicitly, then
-<emphasis>every</emphasis> subpipline must have a primary output
-port with the same name. In some cases, this may require making the implicit
-primary output explicit in order to assure that it has the same name.
-<error code="S0102">It is a <glossterm>static error</glossterm> if alternative
-subpipelines have different primary output ports.</error>
-</para>
+      <para>The outputs of the <tag>p:try</tag> are taken from the outputs of the initial
+          <glossterm>subpipeline</glossterm> or the recovery subpipline if an error occurred in the
+        initial subpipeline. The outputs <emphasis>available</emphasis> from the <tag>p:try</tag>
+        are union of all of the outputs declared (explicitly or implicitly in the absence of any
+          <tag>p:output</tag> elements if the <glossterm>last step</glossterm> has a primary output
+        port) in any of its alternative subpipelines. In order to maintain consistency with respect
+        to the <glossterm>default readable port</glossterm>, if any subpipeline has a
+          <glossterm>primary output port</glossterm>, even implicitly, then
+          <emphasis>every</emphasis> subpipline must have a primary output port with the same name.
+        In some cases, this may require making the implicit primary output explicit in order to
+        assure that it has the same name. <error code="S0102">It is a <glossterm>static
+            error</glossterm> if alternative subpipelines have different primary output
+          ports.</error>
+      </para>
 
-<para>Consider a <tag>p:try</tag> that has an initial
-subpipeline that declares output ports “A” and “B” and a recovery
-subpipeline that
-declares output ports “B” and “C”. The outputs available from the
-<tag>p:try</tag> are “A”, “B”, and “C”. No documents appear on any
-outputs not declared in the subpipeline whose results are actually
-returned.</para>
+      <para>Consider a <tag>p:try</tag> that has an initial subpipeline that declares output ports
+        “A” and “B” and a recovery subpipeline that declares output ports “B” and “C”. The outputs
+        available from the <tag>p:try</tag> are “A”, “B”, and “C”. No documents appear on any
+        outputs not declared in the subpipeline whose results are actually returned.</para>
 
-<para>As a convenience to authors, it is not an error if an output
-port can produce a sequence in the initial subpipeline but not in the
-recovery subpipeline, or vice versa. Each output of the
-<tag>p:try</tag> is declared to produce a sequence. The content types 
-that can appear on the port are the union of the content types that 
-might be produced by the initial subpipeline and any of the recovery subpipelines.
-</para>
+      <para>As a convenience to authors, it is not an error if an output port can produce a sequence
+        in the initial subpipeline but not in the recovery subpipeline, or vice versa. Each output
+        of the <tag>p:try</tag> is declared to produce a sequence. The content types that can appear
+        on the port are the union of the content types that might be produced by the initial
+        subpipeline and any of the recovery subpipelines. </para>
 
-<para>A pipeline author can cause an error to occur with the
-<tag>p:error</tag> step.</para>
+      <para>A pipeline author can cause an error to occur with the <tag>p:error</tag> step.</para>
 
-<para>If we assume that an absent <tag>p:finally</tag> always succeeds, evaluation
-of a <tag>p:try</tag> falls into one of these cases:</para>
+      <para>If we assume that an absent <tag>p:finally</tag> always succeeds, evaluation of a
+          <tag>p:try</tag> falls into one of these cases:</para>
 
-<itemizedlist>
-<listitem>
-<para>If the initial pipeline succeeds:</para>
-<itemizedlist>
-<listitem>
-<para>If the <tag>p:finally</tag> succeeds,
-the <tag>p:try</tag> succeeds and the outputs of the initial subpipeline are
-the outputs of the <tag>p:try</tag>.
-</para>
-</listitem>
-<listitem>
-<para>If the <tag>p:finally</tag> fails,
-the <tag>p:try</tag> fails and the error raised by the <tag>p:finally</tag>
-is reported as the cause of the failure.</para>
-</listitem>
-</itemizedlist>
-</listitem>
-<listitem>
-<para>If the initial pipeline fails and a recovery subpipeline is selected:</para>
-<itemizedlist>
-<listitem>
-<para>If the recovery pipeline succeeds:</para>
-<itemizedlist>
-<listitem>
-<para>If the <tag>p:finally</tag> succeeds,
-the <tag>p:try</tag> succeeds and the outputs of the recovery subpipeline are
-the outputs of the <tag>p:try</tag>.
-</para>
-</listitem>
-<listitem>
-<para>If the <tag>p:finally</tag> fails,
-the <tag>p:try</tag> fails and the error raised by the <tag>p:finally</tag>
-is reported as the cause of the failure.</para>
-</listitem>
-</itemizedlist>
-</listitem>
-<listitem>
-<para>If the recovery pipeline fails:</para>
-<itemizedlist>
-<listitem>
-<para>If the <tag>p:finally</tag> succeeds,
-the <tag>p:try</tag> fails and the error raised by the recovery subpipeline
-is reported as the cause of the failure.</para>
-</listitem>
-<listitem>
-<para>If the <tag>p:finally</tag> fails,
-the <tag>p:try</tag> fails and the error raised by the <emphasis>recovery subpipeline</emphasis>
-<rfc2119>must</rfc2119> be reported as the cause of the failure. The error raised by
-the finally pipeline <rfc2119>may</rfc2119> also be reported in addition to the error
-raised by the recovery pipeline.</para>
-</listitem>
-</itemizedlist>
-</listitem>
-</itemizedlist>
-</listitem>
-<listitem>
-<para>If the initial pipeline fails and a recovery subpipeline is not selected:</para>
-<itemizedlist>
-<listitem>
-<para>If the <tag>p:finally</tag> succeeds,
-the <tag>p:try</tag> fails and the error raised by the initial subpipeline
-is reported as the cause of the failure.</para>
-</listitem>
-<listitem>
-<para>If the <tag>p:finally</tag> fails,
-the <tag>p:try</tag> fails and the error raised by the <emphasis>initial subpipeline</emphasis>
-<rfc2119>must</rfc2119> be reported as the cause of the failure. The error raised by
-the finally pipeline <rfc2119>may</rfc2119> also be reported in addition to the error
-raised by the initial subpipeline.</para>
-</listitem>
-</itemizedlist>
-</listitem>
-</itemizedlist>
+      <itemizedlist>
+        <listitem>
+          <para>If the initial pipeline succeeds:</para>
+          <itemizedlist>
+            <listitem>
+              <para>If the <tag>p:finally</tag> succeeds, the <tag>p:try</tag> succeeds and the
+                outputs of the initial subpipeline are the outputs of the <tag>p:try</tag>. </para>
+            </listitem>
+            <listitem>
+              <para>If the <tag>p:finally</tag> fails, the <tag>p:try</tag> fails and the error
+                raised by the <tag>p:finally</tag> is reported as the cause of the failure.</para>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+        <listitem>
+          <para>If the initial pipeline fails and a recovery subpipeline is selected:</para>
+          <itemizedlist>
+            <listitem>
+              <para>If the recovery pipeline succeeds:</para>
+              <itemizedlist>
+                <listitem>
+                  <para>If the <tag>p:finally</tag> succeeds, the <tag>p:try</tag> succeeds and the
+                    outputs of the recovery subpipeline are the outputs of the <tag>p:try</tag>.
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>If the <tag>p:finally</tag> fails, the <tag>p:try</tag> fails and the error
+                    raised by the <tag>p:finally</tag> is reported as the cause of the
+                    failure.</para>
+                </listitem>
+              </itemizedlist>
+            </listitem>
+            <listitem>
+              <para>If the recovery pipeline fails:</para>
+              <itemizedlist>
+                <listitem>
+                  <para>If the <tag>p:finally</tag> succeeds, the <tag>p:try</tag> fails and the
+                    error raised by the recovery subpipeline is reported as the cause of the
+                    failure.</para>
+                </listitem>
+                <listitem>
+                  <para>If the <tag>p:finally</tag> fails, the <tag>p:try</tag> fails and the error
+                    raised by the <emphasis>recovery subpipeline</emphasis>
+                    <rfc2119>must</rfc2119> be reported as the cause of the failure. The error
+                    raised by the finally pipeline <rfc2119>may</rfc2119> also be reported in
+                    addition to the error raised by the recovery pipeline.</para>
+                </listitem>
+              </itemizedlist>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+        <listitem>
+          <para>If the initial pipeline fails and a recovery subpipeline is not selected:</para>
+          <itemizedlist>
+            <listitem>
+              <para>If the <tag>p:finally</tag> succeeds, the <tag>p:try</tag> fails and the error
+                raised by the initial subpipeline is reported as the cause of the failure.</para>
+            </listitem>
+            <listitem>
+              <para>If the <tag>p:finally</tag> fails, the <tag>p:try</tag> fails and the error
+                raised by the <emphasis>initial subpipeline</emphasis>
+                <rfc2119>must</rfc2119> be reported as the cause of the failure. The error raised by
+                the finally pipeline <rfc2119>may</rfc2119> also be reported in addition to the
+                error raised by the initial subpipeline.</para>
+            </listitem>
+          </itemizedlist>
+        </listitem>
+      </itemizedlist>
 
-<para>The <tag>p:catch</tag> and <tag>p:finally</tag> elements are not
-sibling steps, the names of sibling <tag>p:catch</tag> elements and
-the <tag>p:finally</tag> element are not in <link
-linkend="scoping">the same scope</link>. The elements of the initial
-subpipeline are also not in the same scope as the <tag>p:catch</tag>
-and <tag>p:finally</tag> elements or their descendants.</para>
+      <para>The <tag>p:catch</tag> and <tag>p:finally</tag> elements are not sibling steps, the
+        names of sibling <tag>p:catch</tag> elements and the <tag>p:finally</tag> element are not in
+          <link linkend="scoping">the same scope</link>. The elements of the initial subpipeline are
+        also not in the same scope as the <tag>p:catch</tag> and <tag>p:finally</tag> elements or
+        their descendants.</para>
 
-<section xml:id="p.catch">
-<title>p:catch</title>
+      <section xml:id="p.catch">
+        <title>p:catch</title>
 
-<para>A <tag>p:catch</tag> is a recovery subpipeline.</para>
+        <para>A <tag>p:catch</tag> is a recovery subpipeline.</para>
 
-<e:rng-pattern name="Catch"/>
+        <e:rng-pattern name="Catch"/>
 
-<para>The environment inherited by the <glossterm>contained
-steps</glossterm> of the <tag>p:catch</tag> is the
-<glossterm>inherited environment</glossterm> with these
-modifications:</para>
+        <para>The environment inherited by the <glossterm>contained steps</glossterm> of the
+            <tag>p:catch</tag> is the <glossterm>inherited environment</glossterm> with these
+          modifications:</para>
 
-<itemizedlist>
-<listitem>
-<para>A primary input port named “<port>error</port>”
-is added to the <glossterm>readable ports</glossterm>
-on the <tag>p:catch</tag>.</para>
-</listitem>
-  <listitem>
-    <para>Output ports and variables from the <tag>p:try</tag>'s subpipeline are not available.</para>
-  </listitem>
-</itemizedlist>
+        <itemizedlist>
+          <listitem>
+            <para>A primary input port named “<port>error</port>” is added to the
+                <glossterm>readable ports</glossterm> on the <tag>p:catch</tag>.</para>
+          </listitem>
+          <listitem>
+            <para>Output ports and variables from the <tag>p:try</tag>'s subpipeline are not
+              available.</para>
+          </listitem>
+        </itemizedlist>
 
-<para>All except the last <tag>p:catch</tag> pipeline <rfc2119>must</rfc2119> 
-have a <tag class="attribute">code</tag> attribute.
-<error code="S0064">It is a <glossterm>static error</glossterm>
-if the <tag class="attribute">code</tag> attribute is missing from
-any but the last <tag>p:catch</tag> or if any error code occurs
-in more than one <tag class="attribute">code</tag> attribute among
-sibling <tag>p:catch</tag> elements.</error>
-<error code="S0083">It is a <glossterm>static 
-error</glossterm> if the value of the <tag class="attribute">code</tag>
-attribute is not a whitespace separated list of EQNames.</error></para>
+        <para>All except the last <tag>p:catch</tag> pipeline <rfc2119>must</rfc2119> have a <tag
+            class="attribute">code</tag> attribute. <error code="S0064">It is a <glossterm>static
+              error</glossterm> if the <tag class="attribute">code</tag> attribute is missing from
+            any but the last <tag>p:catch</tag> or if any error code occurs in more than one <tag
+              class="attribute">code</tag> attribute among sibling <tag>p:catch</tag>
+            elements.</error>
+          <error code="S0083">It is a <glossterm>static error</glossterm> if the value of the <tag
+              class="attribute">code</tag> attribute is not a whitespace separated list of
+            EQNames.</error></para>
 
-<para>When a <tag>p:try</tag> considers the recovery subpipelines,
-if any of the specified error codes in a <tag>p:catch</tag> match
-the error that was raised in the initial subpipeline, then
-that <tag>p:catch</tag> is selected as the recovery pipeline.
-If the last <tag>p:catch</tag> does not have a <tag class="attribute">code</tag>
-attribute, it is selected if no other <tag>p:catch</tag> has a
-matching error code.
-</para>
+        <para>When a <tag>p:try</tag> considers the recovery subpipelines, if any of the specified
+          error codes in a <tag>p:catch</tag> match the error that was raised in the initial
+          subpipeline, then that <tag>p:catch</tag> is selected as the recovery pipeline. If the
+          last <tag>p:catch</tag> does not have a <tag class="attribute">code</tag> attribute, it is
+          selected if no other <tag>p:catch</tag> has a matching error code. </para>
 
-<para>What appears on the <port>error</port> input port is an <link
-linkend="err-vocab">error document</link>. The error document may
-contain messages generated by steps that were part of the initial
-subpipeline. Not all messages that appear are indicative of errors;
-for example, it is common for all <tag>xsl:message</tag> output from
-the XSLT component to appear on the <port>error</port> input port. It
-is possible that the component which fails may not produce any
-messages at all. It is also possible that the failure of one component
-may cause others to fail so that there may be multiple failure
-messages in the document.</para>
+        <para>What appears on the <port>error</port> input port is an <link linkend="err-vocab"
+            >error document</link>. The error document may contain messages generated by steps that
+          were part of the initial subpipeline. Not all messages that appear are indicative of
+          errors; for example, it is common for all <tag>xsl:message</tag> output from the XSLT
+          component to appear on the <port>error</port> input port. It is possible that the
+          component which fails may not produce any messages at all. It is also possible that the
+          failure of one component may cause others to fail so that there may be multiple failure
+          messages in the document.</para>
 
-</section>
-<section xml:id="p.finally">
-<title>p:finally</title>
+      </section>
+      <section xml:id="p.finally">
+        <title>p:finally</title>
 
-<para>The last thing that the <tag>p:try</tag> step does is evaluate
-the <tag>p:finally</tag> pipeline.</para>
+        <para>The last thing that the <tag>p:try</tag> step does is evaluate the
+            <tag>p:finally</tag> pipeline.</para>
 
-<e:rng-pattern name="Finally"/>
+        <e:rng-pattern name="Finally"/>
 
-<para>The environment inherited by the <glossterm>contained
-steps</glossterm> of the <tag>p:finally</tag> is the
-<glossterm>inherited environment</glossterm> with these
-modifications:</para>
+        <para>The environment inherited by the <glossterm>contained steps</glossterm> of the
+            <tag>p:finally</tag> is the <glossterm>inherited environment</glossterm> with these
+          modifications:</para>
 
-<itemizedlist>
-<listitem>
-<para>A primary input port named “<port>error</port>”
-is added to the <glossterm>readable ports</glossterm>
-on the <tag>p:finally</tag>.</para>
-</listitem>
-  <listitem>
-    <para>Output ports and variables from the <tag>p:try</tag>'s subpipeline are not available.</para>
-  </listitem>
-</itemizedlist>
+        <itemizedlist>
+          <listitem>
+            <para>A primary input port named “<port>error</port>” is added to the
+                <glossterm>readable ports</glossterm> on the <tag>p:finally</tag>.</para>
+          </listitem>
+          <listitem>
+            <para>Output ports and variables from the <tag>p:try</tag>'s subpipeline are not
+              available.</para>
+          </listitem>
+        </itemizedlist>
 
-<para>If no error occurred, there will be no documents on the
-<port>error</port> port.
-</para>
+        <para>If no error occurred, there will be no documents on the <port>error</port> port. </para>
 
-<para>The <tag>p:finally</tag> exists only to handle recovery and
-resource cleanup tasks. Because the <tag>p:finally</tag> will always
-be evaluated, it must not have output ports that might conflict with
-the output ports of either the initial subpipline or any <tag>p:catch</tag>.
-<error code="S0072">It is a <glossterm>static error</glossterm>
-if the name of any output port on the <tag>p:finally</tag> is the same
-as the name of any other output port in the <tag>p:try</tag> or any
-of its sibling <tag>p:catch</tag> elements.</error>
-<error code="S0112">It is a <glossterm>static error</glossterm> if
-<tag>p:finally</tag> declares a primary output port either explicitly
-or implicitly.</error>
-</para>
-</section>
+        <para>The <tag>p:finally</tag> exists only to handle recovery and resource cleanup tasks.
+          Because the <tag>p:finally</tag> will always be evaluated, it must not have output ports
+          that might conflict with the output ports of either the initial subpipline or any
+            <tag>p:catch</tag>. <error code="S0072">It is a <glossterm>static error</glossterm> if
+            the name of any output port on the <tag>p:finally</tag> is the same as the name of any
+            other output port in the <tag>p:try</tag> or any of its sibling <tag>p:catch</tag>
+            elements.</error>
+          <error code="S0112">It is a <glossterm>static error</glossterm> if <tag>p:finally</tag>
+            declares a primary output port either explicitly or implicitly.</error>
+        </para>
+      </section>
 
-<section xml:id="err-vocab">
-<title>The Error Vocabulary</title>
+      <section xml:id="err-vocab">
+        <title>The Error Vocabulary</title>
 
-<para>In general, it is very difficult to predict error behavior. Step
-failure may be catastrophic (programmer error), or it may be the
-result of user error, resource failures, etc. Steps may detect more
-than one error, and the failure of one step may cause other steps to
-fail as well.</para>
+        <para>In general, it is very difficult to predict error behavior. Step failure may be
+          catastrophic (programmer error), or it may be the result of user error, resource failures,
+          etc. Steps may detect more than one error, and the failure of one step may cause other
+          steps to fail as well.</para>
 
-<para>The <tag>p:try</tag>/<tag>p:catch</tag> mechanism gives pipeline
-authors the opportunity to process the errors that caused the
-<tag>p:try</tag> to fail. In order to facilitate some modicum of
-interoperability among processors, errors that are reported on the
-<literal>error</literal> input port of a <tag>p:catch</tag>
-<rfc2119>should</rfc2119> conform to the format described here.
-</para>
+        <para>The <tag>p:try</tag>/<tag>p:catch</tag> mechanism gives pipeline authors the
+          opportunity to process the errors that caused the <tag>p:try</tag> to fail. In order to
+          facilitate some modicum of interoperability among processors, errors that are reported on
+          the <literal>error</literal> input port of a <tag>p:catch</tag>
+          <rfc2119>should</rfc2119> conform to the format described here. </para>
 
-<section xml:id="cv.errors">
-<title>c:errors</title>
+        <section xml:id="cv.errors">
+          <title>c:errors</title>
 
-<para>The error vocabulary consists of a root element,
-<tag>c:errors</tag> which contains zero or more <tag>c:error</tag>
-elements.</para>
+          <para>The error vocabulary consists of a root element, <tag>c:errors</tag> which contains
+            zero or more <tag>c:error</tag> elements.</para>
 
-<e:rng-pattern name="Errors"/>
+          <e:rng-pattern name="Errors"/>
 
-</section>
+        </section>
 
-<section xml:id="cv.error">
-<title>c:error</title>
+        <section xml:id="cv.error">
+          <title>c:error</title>
 
-<para>Each specific error is represented by an <tag>c:error</tag>
-element:</para>
+          <para>Each specific error is represented by an <tag>c:error</tag> element:</para>
 
-<e:rng-pattern name="Error"/>
+          <e:rng-pattern name="Error"/>
 
-<para>The <tag class="attribute">name</tag> and <tag
-class="attribute">type</tag> attributes identify the name and type,
-respectively, of the step which failed.</para>
+          <para>The <tag class="attribute">name</tag> and <tag class="attribute">type</tag>
+            attributes identify the name and type, respectively, of the step which failed.</para>
 
-<para>The <tag class="attribute">code</tag> is an EQName which
-identifies the error. For steps which have defined error codes, this
-is an opportunity for the step to identify the error in a
-machine-processable fashion. Many steps omit this because they do not
-include the concept of errors identified by EQNames.</para>
+          <para>The <tag class="attribute">code</tag> is an EQName which identifies the error. For
+            steps which have defined error codes, this is an opportunity for the step to identify
+            the error in a machine-processable fashion. Many steps omit this because they do not
+            include the concept of errors identified by EQNames.</para>
 
-<para>If the error was caused by a specific document, or by the
-location of some erroneous construction in a specific document, the
-<tag class="attribute">href</tag>, <tag class="attribute" >line</tag>,
-<tag class="attribute">column</tag>, and <tag class="attribute"
->offset</tag> attributes identify this location. Generally, the error
-location is identified either with line and column numbers or with an
-offset from the beginning of the document, but not usually
-both.</para>
+          <para>If the error was caused by a specific document, or by the location of some erroneous
+            construction in a specific document, the <tag class="attribute">href</tag>, <tag
+              class="attribute">line</tag>, <tag class="attribute">column</tag>, and <tag
+              class="attribute">offset</tag> attributes identify this location. Generally, the error
+            location is identified either with line and column numbers or with an offset from the
+            beginning of the document, but not usually both.</para>
 
-<para>The content of the <tag>c:error</tag> element is any well-formed
-XML. Specific steps, or specific implementations, may provide more
-detail about the format of the content of an error
-message.</para>
+          <para>The content of the <tag>c:error</tag> element is any well-formed XML. Specific
+            steps, or specific implementations, may provide more detail about the format of the
+            content of an error message.</para>
 
-</section>
-<section xml:id="error-example">
-<title>Error Example</title>
+        </section>
+        <section xml:id="error-example">
+          <title>Error Example</title>
 
-<para>Consider the following XSLT stylesheet:</para>
+          <para>Consider the following XSLT stylesheet:</para>
 
-<programlisting language="xml"><![CDATA[<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          <programlisting language="xml"><![CDATA[<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 version="1.0">
 
 <xsl:template match="/">
@@ -4259,540 +4203,577 @@ message.</para>
 
 </xsl:stylesheet>]]></programlisting>
 
-<para>If it was used in a step named “xform” in a <tag>p:try</tag>,
-the following error document might be produced:</para>
+          <para>If it was used in a step named “xform” in a <tag>p:try</tag>, the following error
+            document might be produced:</para>
 
-<programlisting language="xml"><![CDATA[<c:errors xmlns:c="http://www.w3.org/ns/xproc-step">
+          <programlisting language="xml"><![CDATA[<c:errors xmlns:c="http://www.w3.org/ns/xproc-step">
   <c:error name="xform" type="p:xslt"
              href="style.xsl" line="6">This stylesheet is <emph>pointless</emph>.</c:error>
 </c:errors>]]></programlisting>
 
-<para>It is not an error for steps to generate non-standard error
-output as long as it is well-formed.</para>
-</section>
-</section>
+          <para>It is not an error for steps to generate non-standard error output as long as it is
+            well-formed.</para>
+        </section>
+      </section>
 
-<section xml:id="example-try" role="tocsuppress">
-<title>Example</title>
-<para>A pipeline might attempt to process a document by dispatching it
-to some web service. If the web service succeeds, then those results
-are passed to the rest of the pipeline. However, if the web service
-cannot be contacted or reports an error, the <tag>p:catch</tag> step
-can provide some sort of default for the rest of the pipeline.</para>
+      <section xml:id="example-try" role="tocsuppress">
+        <title>Example</title>
+        <para>A pipeline might attempt to process a document by dispatching it to some web service.
+          If the web service succeeds, then those results are passed to the rest of the pipeline.
+          However, if the web service cannot be contacted or reports an error, the
+            <tag>p:catch</tag> step can provide some sort of default for the rest of the
+          pipeline.</para>
 
-<example xml:id="ex.p.trycatch">
-<title>An Example Try/Catch</title>
-<programlisting language="xml"><xi:include href="../../../build/examples/trycatch.txt" parse="text"/></programlisting>
-</example>
-</section>
-</section>
+        <example xml:id="ex.p.trycatch">
+          <title>An Example Try/Catch</title>
+          <programlisting language="xml"><xi:include href="../../../build/examples/trycatch.txt" parse="text"/></programlisting>
+        </example>
+      </section>
+    </section>
 
-<section xml:id="p.atomic"><title>Atomic Steps</title><para>In addition to the six step types
-        described in the preceding sections, XProc provides a standard library of atomic step types.
-        The full vocabulary of standards steps is described in <biblioref linkend="steps30"/>.</para>
-<para>All of the standard, atomic steps are invoked in the same way:</para>
+    <section xml:id="p.atomic">
+      <title>Atomic Steps</title>
+      <para>In addition to the six step types described in the preceding sections, XProc provides a
+        standard library of atomic step types. The full vocabulary of standards steps is described
+        in <biblioref linkend="steps30"/>.</para>
+      <para>All of the standard, atomic steps are invoked in the same way:</para>
       <e:rng-pattern name="OtherAtomicStep"/>
       <para>Where “<replaceable>p:atomic-step</replaceable>” <rfc2119>must</rfc2119> be in the XProc
         namespace and <rfc2119>must</rfc2119> be declared in either the standard library for the
         XProc version supported by the processor or explicitly imported by the surrounding pipeline
-        (see <xref linkend="versioning-considerations"/>). </para></section>
-    <section xml:id="p.extension"><title>Extension Steps</title><para>Pipeline authors may also have
-        access to additional steps not defined or described by this specification. Atomic extension
-        steps are invoked just like standard steps:</para>
+        (see <xref linkend="versioning-considerations"/>). </para>
+    </section>
+    <section xml:id="p.extension">
+      <title>Extension Steps</title>
+      <para>Pipeline authors may also have access to additional steps not defined or described by
+        this specification. Atomic extension steps are invoked just like standard steps:</para>
       <e:rng-pattern name="OtherAtomicStep"/>
       <para>Extension steps <rfc2119>must not</rfc2119> be in the XProc namespace and there
           <rfc2119>must</rfc2119> be a <glossterm>visible</glossterm> step declaration at the point
         of use (see <xref linkend="scoping"/>).</para>
-<para>If the relevant step declaration has no
-          <glossterm>subpipeline</glossterm>, then that step invokes the declared atomic step, which
-        the processor must know how to perform. These steps are implementation-defined extensions.
-        </para>
-<para>If the relevant step declaration has a <glossterm>subpipeline</glossterm>, then
-        that step runs the declared subpipeline. These steps are user- or implementation-defined
+      <para>If the relevant step declaration has no <glossterm>subpipeline</glossterm>, then that
+        step invokes the declared atomic step, which the processor must know how to perform. These
+        steps are implementation-defined extensions. </para>
+      <para>If the relevant step declaration has a <glossterm>subpipeline</glossterm>, then that
+        step runs the declared subpipeline. These steps are user- or implementation-defined
         extensions. Pipelines can refer to themselves (recursion is allowed), to pipelines defined
         in imported libraries, and to other pipelines in the same library if they are in a
         library.</para>
-<para><error code="S0010">It is a <glossterm>static error</glossterm> if a
-          pipeline contains a step whose specified inputs, outputs, and options do not <glossterm
-            baseform="matches">match</glossterm> the <glossterm>signature</glossterm> for steps of
-          that type.</error></para>
-<para><error code="D0017">It is a <glossterm>dynamic
-            error</glossterm> if the running pipeline attempts to invoke a step which the processor
-          does not know how to perform.</error></para>
-<para><impl>The presence of other <glossterm
-            baseform="compound step">compound steps</glossterm> is
-            <glossterm>implementation-defined</glossterm>; XProc provides no standard mechanism for
+      <para>
+        <error code="S0010">It is a <glossterm>static error</glossterm> if a pipeline contains a
+          step whose specified inputs, outputs, and options do not <glossterm baseform="matches"
+            >match</glossterm> the <glossterm>signature</glossterm> for steps of that type.</error>
+      </para>
+      <para>
+        <error code="D0017">It is a <glossterm>dynamic error</glossterm> if the running pipeline
+          attempts to invoke a step which the processor does not know how to perform.</error>
+      </para>
+      <para>
+        <impl>The presence of other <glossterm baseform="compound step">compound steps</glossterm>
+          is <glossterm>implementation-defined</glossterm>; XProc provides no standard mechanism for
           defining them or describing what they can contain.</impl>
         <error code="S0048">It is a <glossterm>static error</glossterm> to use a declared step as a
-            <glossterm>compound step</glossterm>.</error></para>
+            <glossterm>compound step</glossterm>.</error>
+      </para>
 
 
-</section>
-</section>
+    </section>
+  </section>
 
-<section xml:id="other-elements">
-<title>Other pipeline elements</title>
+  <section xml:id="other-elements">
+    <title>Other pipeline elements</title>
 
-<section xml:id="p.input">
-<title>p:input</title>
+    <section xml:id="p.input">
+      <title>p:input</title>
 
-<para>The declaration of an input identifies the name of the
-port, whether or not the port accepts a sequence, whether or not the
-port is a <glossterm>primary input port</glossterm>, what content types it
-accepts, and may provide a connection to default inputs for the port.</para>
+      <para>The declaration of an input identifies the name of the port, whether or not the port
+        accepts a sequence, whether or not the port is a <glossterm>primary input port</glossterm>,
+        what content types it accepts, and may provide a connection to default inputs for the
+        port.</para>
 
-<para>An input <emphasis>declaration</emphasis> has the following
-form:</para>
+      <para>An input <emphasis>declaration</emphasis> has the following form:</para>
 
-<e:rng-pattern name="Input"/>
+      <e:rng-pattern name="Input"/>
 
-<para>The attributes that can appear on <tag>p:input</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
+      <para>The attributes that can appear on <tag>p:input</tag> are <link linkend="common-attr">the
+          common attributes</link> and:</para>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">port</tag></term>
-<listitem>
-<para>The <tag class="attribute">port</tag> attribute defines the name
-of the port. <error code="S0011">It is a <glossterm>static
-error</glossterm> to identify two ports with the same name on the same
-step.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">sequence</tag></term>
-<listitem>
-<para>The <tag class="attribute" >sequence</tag> attribute determines
-whether or not a sequence of documents is allowed on the port.
-<error code="D0006">If <tag class="attribute">sequence</tag> is not
-specified, or has the value false, then it is a <glossterm>dynamic
-error</glossterm> unless exactly one document appears on the declared
-port.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">primary</tag></term>
-<listitem>
-<para>The <tag class="attribute">primary</tag> attribute is used to
-identify the <glossterm>primary input port</glossterm>. An input port
-is a <glossterm>primary input port</glossterm> if
-<tag class="attribute">primary</tag> is specified with the value
-<literal>true</literal> or if the step has only a single input port
-and <tag class="attribute">primary</tag> is not specified.
-<error code="S0030">It is a <glossterm>static error</glossterm> to specify
-that more than one input port is the primary.</error></para>
-</listitem>
-</varlistentry>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">port</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">port</tag> attribute defines the name of the port.
+                <error code="S0011">It is a <glossterm>static error</glossterm> to identify two
+                ports with the same name on the same step.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">sequence</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">sequence</tag> attribute determines whether or not a
+              sequence of documents is allowed on the port. <error code="D0006">If <tag
+                  class="attribute">sequence</tag> is not specified, or has the value false, then it
+                is a <glossterm>dynamic error</glossterm> unless exactly one document appears on the
+                declared port.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">primary</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">primary</tag> attribute is used to identify the
+                <glossterm>primary input port</glossterm>. An input port is a <glossterm>primary
+                input port</glossterm> if <tag class="attribute">primary</tag> is specified with the
+              value <literal>true</literal> or if the step has only a single input port and <tag
+                class="attribute">primary</tag> is not specified. <error code="S0030">It is a
+                  <glossterm>static error</glossterm> to specify that more than one input port is
+                the primary.</error></para>
+          </listitem>
+        </varlistentry>
 
-<varlistentry><term><tag class="attribute">select</tag></term>
-<listitem>
-<para>If a connection is provided in the declaration, then
-<tag class="attribute">select</tag> may be used to select a portion of the
-input identified by the <tag>p:empty</tag>, <tag>p:document</tag>,
-or <tag>p:inline</tag> elements in the
-<tag>p:input</tag>. This select expression <rfc2119>must</rfc2119> be an XPath
-expression.
-The selected nodes are returned as separate documents.
-If such a document consists exclusively of text nodes, then it has a content
-type of <literal>text/plain</literal>, otherwise it has a content type
-of <literal>application/xml</literal>. <error code="D0016">It is a
-<glossterm>dynamic error</glossterm> if the select expression on a p:input or
-p:with-input returns anything other than document nodes, element nodes,
-processing instruction nodes, comment nodes, text nodes or an empty sequence.</error></para>
+        <varlistentry>
+          <term>
+            <tag class="attribute">select</tag>
+          </term>
+          <listitem>
+            <para>If a connection is provided in the declaration, then <tag class="attribute"
+                >select</tag> may be used to select a portion of the input identified by the
+                <tag>p:empty</tag>, <tag>p:document</tag>, or <tag>p:inline</tag> elements in the
+                <tag>p:input</tag>. This select expression <rfc2119>must</rfc2119> be an XPath
+              expression. The selected nodes are returned as separate documents. If such a document
+              consists exclusively of text nodes, then it has a content type of
+                <literal>text/plain</literal>, otherwise it has a content type of
+                <literal>application/xml</literal>. <error code="D0016">It is a <glossterm>dynamic
+                  error</glossterm> if the select expression on a p:input or p:with-input returns
+                anything other than document nodes, element nodes, processing instruction nodes,
+                comment nodes, text nodes or an empty sequence.</error></para>
 
-<para>The
-<tag class="attribute">select</tag> expression applies
-<emphasis>only</emphasis> if the default connection is used. If an
-explicit connection is provided by the caller, then the default select
-expression is ignored.</para>
-</listitem>
-</varlistentry>
+            <para>The <tag class="attribute">select</tag> expression applies
+                <emphasis>only</emphasis> if the default connection is used. If an explicit
+              connection is provided by the caller, then the default select expression is
+              ignored.</para>
+          </listitem>
+        </varlistentry>
 
-<varlistentry><term><tag class="attribute">content-types</tag></term>
-<listitem>
-<para>The <tag class="attribute">content-types</tag> attribute lists one
-or more (space separated) content types that this input port will
-accept. If the attribute is not specified, <literal>*/*</literal> is assumed.
-See <xref linkend="specified-content-types"/>.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem>
-<para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
-author to exclude some namespace declarations in inline content, see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">content-types</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">content-types</tag> attribute lists one or more (space
+              separated) content types that this input port will accept. If the attribute is not
+              specified, <literal>*/*</literal> is assumed. See <xref
+                linkend="specified-content-types"/>. </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">href</tag>
+          </term>
+          <listitem>
+            <para>As described in <tag>p:with-input</tag>.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">exclude-inline-prefixes</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
+              author to exclude some namespace declarations in inline content, see
+                <tag>p:inline</tag>. </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>On a <tag>p:declare-step</tag> for an atomic step, the
-<tag>p:input</tag> can only declare the input port. <error
-code="S0042">It is a <glossterm>static error</glossterm> to attempt to
-provide a connection for an input port on the declaration of an atomic
-step.</error> On <tag>p:declare-step</tag>, any binding provided in
-<tag>p:input</tag> is a default connection for the port, if no other
-connection is provided, see <xref linkend="conn-prec"/>.</para>
+      <para>On a <tag>p:declare-step</tag> for an atomic step, the <tag>p:input</tag> can only
+        declare the input port. <error code="S0042">It is a <glossterm>static error</glossterm> to
+          attempt to provide a connection for an input port on the declaration of an atomic
+          step.</error> On <tag>p:declare-step</tag>, any binding provided in <tag>p:input</tag> is
+        a default connection for the port, if no other connection is provided, see <xref
+          linkend="conn-prec"/>.</para>
 
-<para xml:id="note-pipe-excl">The <tag>p:pipe</tag> element is
-explicitly excluded from a declaration because it would make the
-default value of an input dependent on the execution of some part of
-the pipeline. If a runtime binding is provided for an input port, implementations
-<rfc2119>must not</rfc2119> attempt to dereference the default
-bindings.</para>
+      <para xml:id="note-pipe-excl">The <tag>p:pipe</tag> element is explicitly excluded from a
+        declaration because it would make the default value of an input dependent on the execution
+        of some part of the pipeline. If a runtime binding is provided for an input port,
+        implementations <rfc2119>must not</rfc2119> attempt to dereference the default
+        bindings.</para>
 
-</section>
-<section xml:id="p.with-input">
-<title>p:with-input</title>
+    </section>
+    <section xml:id="p.with-input">
+      <title>p:with-input</title>
 
-<para>An input <emphasis>connection</emphasis> has the following
-form:</para>
+      <para>An input <emphasis>connection</emphasis> has the following form:</para>
 
-<e:rng-pattern name="WithInput"/>
+      <e:rng-pattern name="WithInput"/>
 
-<para>The attributes that can appear on <tag>p:with-input</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
+      <para>The attributes that can appear on <tag>p:with-input</tag> are <link
+          linkend="common-attr">the common attributes</link> and:</para>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">port</tag></term>
-<listitem>
-<para>If the <tag class="attribute">port</tag> is specified, then this
-is a binding for the specified port. If no port is specified, then:</para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">port</tag>
+          </term>
+          <listitem>
+            <para>If the <tag class="attribute">port</tag> is specified, then this is a binding for
+              the specified port. If no port is specified, then:</para>
 
-<itemizedlist>
-<listitem>
-<para>In a <tag>p:viewport</tag> or <tag>p:for-each</tag>, it is a
-binding for the step's single, anonymous input port.</para>
-</listitem>
-<listitem>
-<para>In a <tag>p:choose</tag> or <tag>p:when</tag>, it is a
-binding for the context item for the test expression(s).</para>
-</listitem>
-<listitem>
-<para>Elsewhere, it is a binding for the primary input port of the
-step in which it occurs.
-<error code="S0065">It is a <glossterm>static error</glossterm> if there
-is no primary input port.</error>
-</para>
-</listitem>
-</itemizedlist>
-<para><error code="S0086">It is a <glossterm>static error</glossterm>
-to provide more than one p:with-input for the same port.</error>
-</para>
+            <itemizedlist>
+              <listitem>
+                <para>In a <tag>p:viewport</tag> or <tag>p:for-each</tag>, it is a binding for the
+                  step's single, anonymous input port.</para>
+              </listitem>
+              <listitem>
+                <para>In a <tag>p:choose</tag> or <tag>p:when</tag>, it is a binding for the context
+                  item for the test expression(s).</para>
+              </listitem>
+              <listitem>
+                <para>Elsewhere, it is a binding for the primary input port of the step in which it
+                  occurs. <error code="S0065">It is a <glossterm>static error</glossterm> if there
+                    is no primary input port.</error>
+                </para>
+              </listitem>
+            </itemizedlist>
+            <para>
+              <error code="S0086">It is a <glossterm>static error</glossterm> to provide more than
+                one p:with-input for the same port.</error>
+            </para>
 
-<para>If no connection is provided for a <glossterm>primary input
-port</glossterm>, the input will be connected to the
-<glossterm>default readable port</glossterm>. <error code="S0032">It
-is a <glossterm>static error</glossterm> if no connection is provided
-and the <glossterm>default readable port</glossterm> is
-undefined.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">select</tag></term>
-<listitem>
-<para>A <tag class="attribute">select</tag> expression
-<rfc2119>may</rfc2119> also be provided with a connection.
-The <tag class="attribute">select</tag> expression, if specified, applies the
-specified XPath select expression to the document(s) that are read.</para>
+            <para>If no connection is provided for a <glossterm>primary input port</glossterm>, the
+              input will be connected to the <glossterm>default readable port</glossterm>. <error
+                code="S0032">It is a <glossterm>static error</glossterm> if no connection is
+                provided and the <glossterm>default readable port</glossterm> is
+              undefined.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">select</tag>
+          </term>
+          <listitem>
+            <para>A <tag class="attribute">select</tag> expression <rfc2119>may</rfc2119> also be
+              provided with a connection. The <tag class="attribute">select</tag> expression, if
+              specified, applies the specified XPath select expression to the document(s) that are
+              read.</para>
 
-<para>If the result from applying the select expression to the document(s) is
- an atomic value, a text node with the corresponding string value is created.</para>
+            <para>If the result from applying the select expression to the document(s) is an atomic
+              value, a text node with the corresponding string value is created.</para>
 
-  <para>Each selected node is wrapped in a document (unless it is a document)
-and provided to the input port. In other words,</para>
+            <para>Each selected node is wrapped in a document (unless it is a document) and provided
+              to the input port. In other words,</para>
 
-<programlisting language="xml"><xi:include href="../../../build/examples/input-doc.txt" parse="text"/></programlisting>
+            <programlisting language="xml"><xi:include href="../../../build/examples/input-doc.txt" parse="text"/></programlisting>
 
-<para>provides a single document, but</para>
+            <para>provides a single document, but</para>
 
-<programlisting language="xml"><xi:include href="../../../build/examples/input-select.txt" parse="text"/></programlisting>
+            <programlisting language="xml"><xi:include href="../../../build/examples/input-select.txt" parse="text"/></programlisting>
 
-<para>provides a sequence of zero or more documents, one for each
-<code>html:div</code> in <uri>http://example.org/input.html</uri>.
-(Note that in the case of nested <code>html:div</code> elements, this
-will result in the same content being returned in several
-documents.)</para>
+            <para>provides a sequence of zero or more documents, one for each <code>html:div</code>
+              in <uri>http://example.org/input.html</uri>. (Note that in the case of nested
+                <code>html:div</code> elements, this will result in the same content being returned
+              in several documents.)</para>
 
-<para>A select expression can equally be applied to input read from
-another step. This input:</para><programlisting
-language="xml"><xi:include href="../../../build/examples/input-port.txt"
-parse="text"/></programlisting><para>provides a sequence of zero or
-more documents, one for each <code>html:div</code> in the document (or
-each of the documents) that is read from the <literal>result</literal>
-port of the step named <literal>origin</literal>.</para>
+            <para>A select expression can equally be applied to input read from another step. This
+              input:</para>
+            <programlisting language="xml"><xi:include href="../../../build/examples/input-port.txt" parse="text"/></programlisting>
+            <para>provides a sequence of zero or more documents, one for each <code>html:div</code>
+              in the document (or each of the documents) that is read from the
+                <literal>result</literal> port of the step named <literal>origin</literal>.</para>
 
-<para>The base URI of the document that results from a select
-expression is the base URI of the matched element or document. The document
-does not have a base URI if it results from selecting an atomic value.</para>
+            <para>The base URI of the document that results from a select expression is the base URI
+              of the matched element or document. The document does not have a base URI if it
+              results from selecting an atomic value.</para>
 
-<para>If a document constructed by selection consists exclusively of
-text nodes, then it has a content type of
-<literal>text/plain</literal>, otherwise it has a content type of
-<literal>application/xml</literal>. If the selection result is a map or
-  an array or an atomic value, it is a JSON document. <error code="D0016">It is a
-<glossterm>dynamic error</glossterm> if the select expression on a p:input or
-p:with-input returns attribute nodes or function items.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem>
-<para>The <tag class="attribute">href</tag> attribute is a shortcut for
-a <tag>p:document</tag> child with an <tag class="attribute">href</tag> attribute
-having the same value as this <tag class="attribute">href</tag> attribute.
-</para>
+            <para>If a document constructed by selection consists exclusively of text nodes, then it
+              has a content type of <literal>text/plain</literal>, otherwise it has a content type
+              of <literal>application/xml</literal>. If the selection result is a map or an array or
+              an atomic value, it is a JSON document. <error code="D0016">It is a <glossterm>dynamic
+                  error</glossterm> if the select expression on a p:input or p:with-input returns
+                attribute nodes or function items.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">href</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">href</tag> attribute is a shortcut for a
+                <tag>p:document</tag> child with an <tag class="attribute">href</tag> attribute
+              having the same value as this <tag class="attribute">href</tag> attribute. </para>
 
-<para><error code="S0081">If <tag class="attribute">href</tag> is specified,
-it is a <glossterm>static error</glossterm> if
-any child elements other than <tag>p:documentation</tag> and
-<tag>p:pipeinfo</tag> are present.</error></para>
+            <para>
+              <error code="S0081">If <tag class="attribute">href</tag> is specified, it is a
+                  <glossterm>static error</glossterm> if any child elements other than
+                  <tag>p:documentation</tag> and <tag>p:pipeinfo</tag> are present.</error>
+            </para>
 
-<para><error code="S0085">It is a <glossterm>static error</glossterm> if both
-a <tag class="attribute">href</tag> attribute and a
-<tag class="attribute">pipe</tag> attribute are present.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">pipe</tag></term>
-<listitem>
-<para>The <tag class="attribute">pipe</tag> attribute is a shortcut for one or
-more <tag>p:pipe</tag> children. The attribute value <rfc2119>must</rfc2119> be
-whitespace-separated list of tokens or empty.
-<error code="S0090">It is a <glossterm>static error</glossterm> if the value
-of the <tag class="attribute">pipe</tag> attribute contains any tokens not
-of the form <replaceable>port-name</replaceable>,
-<replaceable>port-name@step-name</replaceable>, or <replaceable>@step-name</replaceable>.
-</error>
-If “<replaceable>port-name</replaceable>” is omitted,
-the connection is to the primary output port of
-the step named “<replaceable>step-name</replaceable>”.
-If “<literal>@<replaceable>step-name</replaceable></literal>” is omitted,
-the connection is to the specified port on the same step as the step associated with the
-default readable port. If the value is empty, the connection is to
-the default readable port.</para>
-<para><error code="S0082">If <tag class="attribute">pipe</tag> is specified,
-it is a <glossterm>static error</glossterm>
-any child elements other than <tag>p:documentation</tag> and
-<tag>p:pipeinfo</tag> are present.</error></para>
-<para><error code="S0085">It is a <glossterm>static error</glossterm> if both
-an <tag class="attribute">href</tag> attribute and a <tag class="attribute">pipe</tag>
-attribute are present.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
-author to exclude some namespace declarations in inline content, see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+            <para>
+              <error code="S0085">It is a <glossterm>static error</glossterm> if both a <tag
+                  class="attribute">href</tag> attribute and a <tag class="attribute">pipe</tag>
+                attribute are present.</error>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">pipe</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">pipe</tag> attribute is a shortcut for one or more
+                <tag>p:pipe</tag> children. The attribute value <rfc2119>must</rfc2119> be
+              whitespace-separated list of tokens or empty. <error code="S0090">It is a
+                  <glossterm>static error</glossterm> if the value of the <tag class="attribute"
+                  >pipe</tag> attribute contains any tokens not of the form
+                  <replaceable>port-name</replaceable>,
+                  <replaceable>port-name@step-name</replaceable>, or
+                  <replaceable>@step-name</replaceable>. </error> If
+                “<replaceable>port-name</replaceable>” is omitted, the connection is to the primary
+              output port of the step named “<replaceable>step-name</replaceable>”. If
+                  “<literal>@<replaceable>step-name</replaceable></literal>” is omitted, the
+              connection is to the specified port on the same step as the step associated with the
+              default readable port. If the value is empty, the connection is to the default
+              readable port.</para>
+            <para>
+              <error code="S0082">If <tag class="attribute">pipe</tag> is specified, it is a
+                  <glossterm>static error</glossterm> any child elements other than
+                  <tag>p:documentation</tag> and <tag>p:pipeinfo</tag> are present.</error>
+            </para>
+            <para>
+              <error code="S0085">It is a <glossterm>static error</glossterm> if both an <tag
+                  class="attribute">href</tag> attribute and a <tag class="attribute">pipe</tag>
+                attribute are present.</error>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">exclude-inline-prefixes</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
+              author to exclude some namespace declarations in inline content, see
+                <tag>p:inline</tag>. </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>A <tag>p:with-input</tag> element with no children
-(<foreignphrase>e.g.</foreignphrase>, “<code>&lt;p:with-input/&gt;</code>”)
-is treated implicitly as if it contained only “<code>&lt;p:pipe/&gt;</code>”, which is
-in turn equivalent to a binding to the default readable port.
-</para>
+      <para>A <tag>p:with-input</tag> element with no children (<foreignphrase>e.g.</foreignphrase>,
+          “<code>&lt;p:with-input/&gt;</code>”) is treated implicitly as if it contained only
+          “<code>&lt;p:pipe/&gt;</code>”, which is in turn equivalent to a binding to the default
+        readable port. </para>
 
-<para>If the <tag>p:with-input</tag> contains elements not in the XProc namespace,
-they are <link linkend="implicit-inlines">implicit inlines</link>.</para>
+      <para>If the <tag>p:with-input</tag> contains elements not in the XProc namespace, they are
+          <link linkend="implicit-inlines">implicit inlines</link>.</para>
 
-<section xml:id="conn-prec">
-<title>Connection precedence</title>
+      <section xml:id="conn-prec">
+        <title>Connection precedence</title>
 
-<para>XProc 3.0 introduces a number of new connection defaulting
-mechanisms to make pipeline authoring easier. Defaults only apply
-if there’s no explicit connection, and they apply differently to
-primary and secondary inputs.</para>
+        <para>XProc 3.0 introduces a number of new connection defaulting mechanisms to make pipeline
+          authoring easier. Defaults only apply if there’s no explicit connection, and they apply
+          differently to primary and secondary inputs.</para>
 
-<variablelist>
-<varlistentry>
-<term>Primary input ports</term>
-<listitem>
-<para>For a given primary input port:</para>
-<orderedlist>
-<listitem>
-<para>If there is a <tag>p:with-input</tag> for that port and it provides a
-binding, even an implicit one, that binding is used.
-</para>
-</listitem>
-<listitem>
-<para>If there’s no <tag>p:with-input</tag> for that port and there is a default
-readable port, the input will be connected to the default readable port.
-</para>
-</listitem>
-<listitem>
-<para>If there’s no <tag>p:with-input</tag> for that port and there’s no default
-readable port, then the default connection from the declaration’s <tag>p:input</tag>
-will be used. <error code="S0032">It will be a <glossterm>static error</glossterm> 
-if there is no default connection.</error>
-</para>
-</listitem>
-</orderedlist>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term>Secondary input ports</term>
-<listitem>
-<para>For a given secondary input port:</para>
-<orderedlist>
-<listitem>
-<para>If there is a <tag>p:with-input</tag> for that port and it provides a
-binding, even an implicit one, that binding is used.
-</para>
-</listitem>
-<listitem>
-<para>If there’s no <tag>p:with-input</tag> for that port
-then the default connection from the declaration’s <tag>p:input</tag>
-will be used. <error code="S0032">It will be a <glossterm>static 
-error</glossterm> if there is no default connection.</error>
-</para>
-</listitem>
-</orderedlist>
-</listitem>
-</varlistentry>
-</variablelist>
-</section>
-</section>
+        <variablelist>
+          <varlistentry>
+            <term>Primary input ports</term>
+            <listitem>
+              <para>For a given primary input port:</para>
+              <orderedlist>
+                <listitem>
+                  <para>If there is a <tag>p:with-input</tag> for that port and it provides a
+                    binding, even an implicit one, that binding is used. </para>
+                </listitem>
+                <listitem>
+                  <para>If there’s no <tag>p:with-input</tag> for that port and there is a default
+                    readable port, the input will be connected to the default readable port. </para>
+                </listitem>
+                <listitem>
+                  <para>If there’s no <tag>p:with-input</tag> for that port and there’s no default
+                    readable port, then the default connection from the declaration’s
+                      <tag>p:input</tag> will be used. <error code="S0032">It will be a
+                        <glossterm>static error</glossterm> if there is no default
+                      connection.</error>
+                  </para>
+                </listitem>
+              </orderedlist>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Secondary input ports</term>
+            <listitem>
+              <para>For a given secondary input port:</para>
+              <orderedlist>
+                <listitem>
+                  <para>If there is a <tag>p:with-input</tag> for that port and it provides a
+                    binding, even an implicit one, that binding is used. </para>
+                </listitem>
+                <listitem>
+                  <para>If there’s no <tag>p:with-input</tag> for that port then the default
+                    connection from the declaration’s <tag>p:input</tag> will be used. <error
+                      code="S0032">It will be a <glossterm>static error</glossterm> if there is no
+                      default connection.</error>
+                  </para>
+                </listitem>
+              </orderedlist>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </section>
+    </section>
 
-<!-- ============================================================ -->
+    <!-- ============================================================ -->
 
-<section xml:id="p.output">
-<title>p:output</title>
+    <section xml:id="p.output">
+      <title>p:output</title>
 
-<para>A <tag>p:output</tag> identifies an output port.</para>
+      <para>A <tag>p:output</tag> identifies an output port.</para>
 
-<e:rng-pattern name="AtomicOutputDeclaration"/>
+      <e:rng-pattern name="AtomicOutputDeclaration"/>
 
-<para>The attributes that can appear on <tag>p:output</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
+      <para>The attributes that can appear on <tag>p:output</tag> are <link linkend="common-attr"
+          >the common attributes</link> and:</para>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">port</tag></term>
-<listitem>
-<para>The <tag class="attribute">port</tag> attribute defines the name
-of the port. <error code="S0011">It is a <glossterm>static
-error</glossterm> to identify two ports with the same name on the same
-step.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">sequence</tag></term>
-<listitem>
-<para>An output declaration can indicate if a sequence of documents is
-allowed to appear on the declared port. If <tag class="attribute"
->sequence</tag> is specified with the value <literal>true</literal>,
-then a sequence is allowed. <error code="D0007">If <tag
-class="attribute">sequence</tag> is not specified on
-<tag>p:output</tag>, or has the value false, then it is a
-<glossterm>dynamic error</glossterm> if the step does not produce
-exactly one document on the declared port.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">primary</tag></term>
-<listitem>
-<para>The <tag class="attribute">primary</tag> attribute is used to
-identify the primary output port. An output port is a primary output
-port if <tag class="attribute">primary</tag> is specified with the
-value <literal>true</literal> or if the step has only a single output
-port and primary is not specified. <error code="S0014">It is a
-<glossterm>static error</glossterm> to identify more than one output
-port as primary.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">content-types</tag></term>
-<listitem>
-<para>An output declaration can indicate the content types of the
-  documents appearing on that port. If <tag class="attribute">content-types</tag>
-  is specified then only documents matching these content types are allowed
-  to appear on that port. If the attribute is not specified,
-  <literal>*/*</literal> is assumed. <error code="D0042">It is a <glossterm>dynamic error</glossterm>
-  if a document arrives on an output port whose content type is not accepted
-  by the output port specification.</error></para>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">port</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">port</tag> attribute defines the name of the port.
+                <error code="S0011">It is a <glossterm>static error</glossterm> to identify two
+                ports with the same name on the same step.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">sequence</tag>
+          </term>
+          <listitem>
+            <para>An output declaration can indicate if a sequence of documents is allowed to appear
+              on the declared port. If <tag class="attribute">sequence</tag> is specified with the
+              value <literal>true</literal>, then a sequence is allowed. <error code="D0007">If <tag
+                  class="attribute">sequence</tag> is not specified on <tag>p:output</tag>, or has
+                the value false, then it is a <glossterm>dynamic error</glossterm> if the step does
+                not produce exactly one document on the declared port.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">primary</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">primary</tag> attribute is used to identify the primary
+              output port. An output port is a primary output port if <tag class="attribute"
+                >primary</tag> is specified with the value <literal>true</literal> or if the step
+              has only a single output port and primary is not specified. <error code="S0014">It is
+                a <glossterm>static error</glossterm> to identify more than one output port as
+                primary.</error></para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">content-types</tag>
+          </term>
+          <listitem>
+            <para>An output declaration can indicate the content types of the documents appearing on
+              that port. If <tag class="attribute">content-types</tag> is specified then only
+              documents matching these content types are allowed to appear on that port. If the
+              attribute is not specified, <literal>*/*</literal> is assumed. <error code="D0042">It
+                is a <glossterm>dynamic error</glossterm> if a document arrives on an output port
+                whose content type is not accepted by the output port specification.</error></para>
 
-<note>
-<para>Implementations are free to perform static checking of the
-connected ports and indicate that the content types of the connected
-ports will not match, however they <rfc2119>must not</rfc2119> raise an
-error statically.
-</para>
-</note>
+            <note>
+              <para>Implementations are free to perform static checking of the connected ports and
+                indicate that the content types of the connected ports will not match, however they
+                  <rfc2119>must not</rfc2119> raise an error statically. </para>
+            </note>
 
-</listitem>
-</varlistentry>
-</variablelist>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>On <glossterm baseform="compound step">compound
-steps</glossterm>, the declaration <rfc2119>may</rfc2119> be
-accompanied by a <glossterm>connection</glossterm> for the
-output.</para>
+      <para>On <glossterm baseform="compound step">compound steps</glossterm>, the declaration
+          <rfc2119>may</rfc2119> be accompanied by a <glossterm>connection</glossterm> for the
+        output.</para>
 
-<e:rng-pattern name="CompoundOutputDeclaration"/>
+      <e:rng-pattern name="CompoundOutputDeclaration"/>
 
-<para>The additional attributes that can appear on an output declaration
-on a compound step are:</para>
+      <para>The additional attributes that can appear on an output declaration on a compound step
+        are:</para>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem>
-<para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">pipe</tag></term>
-<listitem>
-<para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
-author to exclude some namespace declarations in inline content, see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">href</tag>
+          </term>
+          <listitem>
+            <para>As described in <tag>p:with-input</tag>.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">pipe</tag>
+          </term>
+          <listitem>
+            <para>As described in <tag>p:with-input</tag>.</para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">exclude-inline-prefixes</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
+              author to exclude some namespace declarations in inline content, see
+                <tag>p:inline</tag>. </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>Finally, on a <tag>p:declare-step</tag> that declares a pipeline,
-the <tag>p:output</tag> can specify serialization options.
-</para>
+      <para>Finally, on a <tag>p:declare-step</tag> that declares a pipeline, the
+          <tag>p:output</tag> can specify serialization options. </para>
 
-<e:rng-pattern name="PipelineOutputDeclaration"/>
+      <e:rng-pattern name="PipelineOutputDeclaration"/>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">serialization</tag></term>
-<listitem>
-<para>The <tag class="attribute">serialization</tag> attribute can
-be used to provide <link linkend="serialization">serialization
-parameters</link>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">serialization</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">serialization</tag> attribute can be used to provide
+                <link linkend="serialization">serialization parameters</link>. </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
 
-<para><error code="S0029">It is a <glossterm>static error</glossterm>
-to specify a connection for a <tag>p:output</tag> inside a
-<tag>p:declare-step</tag> for an atomic step.</error></para>
+      <para>
+        <error code="S0029">It is a <glossterm>static error</glossterm> to specify a connection for
+          a <tag>p:output</tag> inside a <tag>p:declare-step</tag> for an atomic step.</error>
+      </para>
 
-<para>If a connection is provided for a <tag>p:output</tag>, documents
-are <emphasis>read from</emphasis> that connection and those documents
-form the output that <emphasis>is written</emphasis> to the output
-port. In other words, placing a <tag>p:document</tag> inside a
-<tag>p:output</tag> causes the processor to <emphasis>read that
-document</emphasis> and provide it on the output port. It
-<emphasis>does not</emphasis> cause the processor to
-<emphasis>write</emphasis> the output to that document.</para>
+      <para>If a connection is provided for a <tag>p:output</tag>, documents are <emphasis>read
+          from</emphasis> that connection and those documents form the output that <emphasis>is
+          written</emphasis> to the output port. In other words, placing a <tag>p:document</tag>
+        inside a <tag>p:output</tag> causes the processor to <emphasis>read that document</emphasis>
+        and provide it on the output port. It <emphasis>does not</emphasis> cause the processor to
+          <emphasis>write</emphasis> the output to that document.</para>
 
-<section xml:id="serialization">
-<title>Serialization parameters</title>
+      <section xml:id="serialization">
+        <title>Serialization parameters</title>
 
-<!-- This ID exists so that old links to the p.serialization section
+        <!-- This ID exists so that old links to the p.serialization section
      will come here. Not that it will matter, but that's why.
 -->
-<para xml:id="p.serialization">The <tag class="attribute">serialization</tag>
-attribute allows the user to request serialization parameters on an
-output port. These parameters control XML serialization as defined
-by <biblioref linkend="xml-serialization-31"/>.
-</para>
+        <para xml:id="p.serialization">The <tag class="attribute">serialization</tag> attribute
+          allows the user to request serialization parameters on an output port. These parameters
+          control serialization as defined by <biblioref linkend="xml-serialization-31"/>.</para>
 
         <para>If the pipeline processor serializes the output on a port, it <rfc2119
             feature="ser-must-use">must</rfc2119> use the serialization parameters specified. If a
@@ -4806,1553 +4787,1408 @@ by <biblioref linkend="xml-serialization-31"/>.
           is computed (and must therefore be statically and syntactically valid), but the processor
             <rfc2119 feature="ser-must-ignore">must not</rfc2119> raise an error if the output could
           not be serialized with those parameters. </para>
-
-<para><impl>The default value of any serialization parameters not specified on a particular output
-            is <glossterm>implementation-defined</glossterm>.</impl> However if the serialization
-          parameter <literal>method</literal> is not specified the processor
-            <rfc2119>should</rfc2119> select a method based on the document's
-            <literal>content-type</literal> property:</para>
-  <itemizedlist>
-    <listitem>
-      <para>For documents with content types <literal>application/xml</literal>,
-                <literal>text/xml</literal>, and <literal>application/*+xml</literal> (except for
-                <literal>application/xhtml+xml</literal>), serialization method
-                <literal>xml</literal> should be used.</para>
-    </listitem>
-    <listitem>
-      <para>For documents with content type <literal>application/xhtml+xml</literal> serialization
-              method <literal>xhtml</literal> should be used.</para>
-    </listitem>
-    <listitem>
-      <para>For documents with content type <literal>text/html</literal> serialization method
-                <literal>html</literal> should be used.</para>
-    </listitem>
-    <listitem>
-      <para>For documents with <glossterm baseform="text media type">text media types</glossterm> serialization method
-                <literal>text</literal> should be used.</para>
-    </listitem>
-    <listitem>
-      <para>For documents with <glossterm baseform="JSON media type">JSON media types</glossterm> serialization method
-                <literal>json</literal> should be used.</para>
-    </listitem>
-    <listitem>
-      <para><impl>The serialization method for documents with other media types is 
-        <glossterm>implementation-defined</glossterm>.</impl></para>
-    </listitem>
-  </itemizedlist>
-<para>If serialization method <literal>xml</literal> is choosen either explicitly or
-implicitly, the following default values <rfc2119>must</rfc2119> be used:</para>
-<itemizedlist>
-  <listitem><para>Parameter <literal>version</literal> is set to <literal>1.0</literal>.</para></listitem>
-  <listitem><para>Parameter <literal>encoding</literal> is set to <literal>UTF-8</literal>.</para></listitem>
-  <listitem><para>Parameter <literal>omit-xml-declaration</literal> is set to <literal>true</literal>.</para></listitem>
-</itemizedlist>
-<para>These default values also apply to serialization method <literal>XHTML</literal> (if it is supported).</para>
-<para><error code="D0020">It is a <glossterm>dynamic error</glossterm> if
-the combination of serialization options specified or defaulted is not
-allowed.</error> Implementations <rfc2119>must</rfc2119> check that
-all of the specified serialization options are allowed if they
-serialize the specified output. If the specified output is not being
-serialized implementations
-<rfc2119>may</rfc2119> but are not required to check that the
-specified options are allowed.</para>
-
-<para>For XML outputs, see <xref linkend="xproc-xml-serialization"/>.
-For non-XML outputs, see <xref linkend="xproc-non-xml-serialization"/>.</para>
-
-<section xml:id="xproc-xml-serialization">
-<title>XML serialization</title>
-
-<para>The names and values of XML serialization parameters are defined
-by <biblioref linkend="xml-serialization-31"/>.</para>
-
-<para>The following parameters may be present in the serialization
-map:</para>
-
-<variablelist>
-<varlistentry>
-<term><option>byte-order-mark</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a boolean.
-If it's not specified, the default varies by encoding: for UTF-16 it's
-true, for all others, it's false.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>cdata-section-elements</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a list of
-<type>EQName</type>s. They are interpreted as element names.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>doctype-public</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a string.
-The public identifier of the doctype.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>doctype-system</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be an
-<type>anyURI</type>. The system identifier of the doctype. It need not
-be absolute, and is not resolved.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>encoding</option></term>
-<listitem>
-<para>A character set name. <impl>If no <option>encoding</option> is
-specified, the encoding used is <glossterm>implementation-defined</glossterm>.
-If the <option>method</option> is
-“<literal>xml</literal>” or “<literal>xhtml</literal>”, the
-implementation defined encoding <rfc2119>must</rfc2119> be either
-UTF-8 or UTF-16.</impl></para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>escape-uri-attributes</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a
-boolean. It is ignored unless the specified method is
-“<literal>xhtml</literal>” or “<literal>html</literal>”.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>include-content-type</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a boolean.
-It is ignored unless the specified method is
-“<literal>xhtml</literal>” or “<literal>html</literal>”.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>indent</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a
-boolean.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>media-type</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a string. It
-specifies the media type (MIME content type). If not specified, the
-default varies according to the <option>method</option>:</para>
-
-<variablelist>
-<varlistentry><term><literal>xml</literal></term>
-<listitem><simpara><literal>application/xml</literal></simpara></listitem>
-</varlistentry>
-<varlistentry><term><literal>html</literal></term>
-<listitem><simpara><literal>text/html</literal></simpara></listitem>
-</varlistentry>
-<varlistentry><term><literal>xhtml</literal></term>
-<listitem><simpara><literal>application/xhtml+xml</literal></simpara></listitem>
-</varlistentry>
-<varlistentry><term><literal>text</literal></term>
-<listitem><simpara><literal>text/plain</literal></simpara></listitem>
-</varlistentry>
-  <varlistentry><term><literal>json</literal></term>
-    <listitem><simpara><literal>application/json</literal></simpara></listitem>
-  </varlistentry>
-</variablelist>
-
-<para><impl>For methods other than <literal>xml</literal>, <literal>html</literal>,
-<literal>xhtml</literal>, <literal>text</literal>, and <literal>json</literal>; the
-<option>media-type</option> is <glossterm>implementation-defined</glossterm>.
-</impl></para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>method</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be an
-<type>EQName</type>. It specifies the serialization method.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>normalization-form</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be an NMTOKEN,
-one of the enumerated values <code>NFC</code>, <code>NFD</code>,
-<code>NFKC</code>, <code>NFKD</code>, <code>fully-normalized</code>,
-<code>none</code> or an implementation-defined value.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>omit-xml-declaration</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a
-boolean.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>standalone</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be an NMTOKEN,
-one of the enumerated values <code>true</code>, <code>false</code>, or
-<code>omit</code>.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>undeclare-prefixes</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a
-boolean.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>use-character-maps</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a map
-(<code>map(xs:string, xs:string)</code>). The keys are the characters
-to be mapped (as <code>xs:string</code> instances). The corresponding
-value for each key is the string to be substituted for that character.
-</para>
-</listitem>
-</varlistentry>
-
-<varlistentry>
-<term><option>version</option></term>
-<listitem>
-<para>The value of this option <rfc2119>must</rfc2119> be a
-string.</para>
-</listitem>
-</varlistentry>
-</variablelist>
-
-<para>In order to be consistent with the rest of this specification,
-boolean values for the serialization parameters must use one of the
-XML Schema lexical forms for boolean: "true", "false", "1", or "0".
-This is different from the <biblioref linkend="xml-serialization-31"/>
-specification which uses “yes” and “no”. No change in
-semantics is implied by this different spelling.</para>
-
-<para>The <option>method</option> option controls the serialization
-method used by this component with standard values of 'html', 'xml',
-'xhtml', 'text' and 'json' but only the 'xml' value is required to be
-supported. The interpretation of the remaining options is as
-specified in <biblioref linkend="xml-serialization-31"/>.</para>
-
-<para><impl>Implementations may support other method values but their
-results are <glossterm>implementation-defined</glossterm>.</impl>
-</para>
-
-<para>A minimally conforming implementation must support the
-<code>xml</code> output method with the following option
-values:</para>
-
-<itemizedlist>
-   <listitem><para>The <code>version</code> must support the value <code>1.0</code>.</para></listitem>
-   <listitem><para>The <code>encoding</code> must support the values <code>UTF-8</code>.</para></listitem>
-   <listitem><para>The <code>omit-xml-declaration</code> must be supported.  If the value is not 
-     specified or has the value <code>no</code>, an XML declaration must be produced.</para></listitem>
-</itemizedlist>
-
-<para>All other option values may be ignored for the <code>xml</code>
-output method.</para>
-
-<para>If a processor chooses to implement an option for serialization,
-it must conform to the semantics defined in the <biblioref
-linkend="xml-serialization-31"/> specification.</para>
-
-</section>
-<section xml:id="xproc-non-xml-serialization">
-<title>Non-XML serialization</title>
-
-<para><impl>The names and values of non-XML serialization parameters are
-<glossterm>implementation-defined</glossterm>.</impl></para>
-</section>
-
-</section>
-</section>
-
-<!-- ============================================================ -->
-
-<section xml:id="variables-options">
-<title>Variables and Options</title>
-
-<para>Variables and options provide a mechanism for pipeline authors
-to construct temporary results and hold onto them for reuse.</para>
-
-<para>Variables are created in compound steps and, like XSLT
-variables, are single assignment, though they may be shadowed by
-subsequent declarations of other variables with the same name.</para>
-
-<para>Options can be declared on atomic or compound steps. The value
-of an option can be specified by the caller invoking the step. Any
-value specified by the caller takes precedence over the default value
-of the option.</para>
-
-<section xml:id="p.variable">
-<title>p:variable</title>
-
-<para>A <tag>p:variable</tag> declares a variable and associates a
-value with it. Variable declarations may optionally specify the type
-of the variable using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-</para>
-
-<e:rng-pattern name="GeneralVariable"/>
-
-<para>The attributes that can appear on <tag>p:variable</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
-
-<variablelist>
-<varlistentry><term><tag class="attribute">name</tag></term>
-<listitem>
-<para>The name of the variable <rfc2119>must</rfc2119> be an EQName. If
-it does not contain a prefix then it is in no namespace. <error
-code="S0028">It is a <glossterm>static error</glossterm> to declare an
-option or variable in the XProc namespace.</error> <error code="S0087">It is
-a <glossterm>static error</glossterm> if the name attribute on
-<tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is not
-bound to a namespace.</error>
-</para>
-<para><error code="S0088">It is
-a <glossterm>static error</glossterm> if the qualified name of a
-<tag>p:variable</tag> <glossterm baseform="shadow">shadows</glossterm>
-the name of a static variable or option.</error>
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">as</tag></term>
-<listitem>
-<para>The type of the value may be specified in the
-<tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">static</tag></term>
-<listitem>
-<para>An indication of whether the variable is to be evaluated
-statically or not. See <link linkend="statics"/>.
-If <tag class="attribute">static</tag> is not specified, it
-defaults to “<code>false</code>”.</para>
-<para><error code="S0098">It is a <glossterm>static error</glossterm> 
-if a variable is declared as static and the <tag>p:variable</tag> has 
-a <tag class="attribute">pipe</tag> attribute or <tag>p:pipe</tag> 
-children.</error></para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">select</tag></term>
-<listitem>
-<para>The variable's value is specified with a
-<tag class="attribute">select</tag> attribute. The
-<tag class="attribute">select</tag> attribute <rfc2119>must</rfc2119> be
-specified. The content of the <tag class="attribute">select</tag>
-attribute is an XPath expression which will be evaluated to provide
-the value of the variable.
-<error code="S0094">It is a <glossterm>static error</glossterm> if
-a <tag>p:variable</tag> does not have a select attribute.</error>
-</para>
-<para>The <tag class="attribute">select</tag> expression
-is evaluated as an XPath expression using the appropriate context as
-described in <xref linkend="xpath-context"/>, for the enclosing
-<glossterm>container</glossterm>.
-<impl>The precise details about what XPath expressions are allowed
-(for example, can the expression declare a function) is
-<glossterm>implementation-defined</glossterm>.</impl>
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">collection</tag></term>
-<listitem>
-<para>If <tag class="attribute">collection</tag> is
-unspecified or has the value <literal>false</literal>, then it has
-no effect.
-</para>
-
-<para>If <tag class="attribute">collection</tag> is <literal>true</literal>,
-the context item is undefined. All of the documents that appear on the
-connection for the <tag>p:variable</tag> will be available as the
-default collection within <tag class="attribute">select</tag> expression.</para>
-</listitem>
-</varlistentry>
-
-<varlistentry><term><tag class="attribute">visibility</tag></term>
-<listitem>
-<para>If the <tag>p:variable</tag> is a child of a <tag>p:library</tag>,
-the <tag class="attribute">visibility</tag> attribute controls whether
-the variable is visible to an importing pipeline. If
-<tag class="attribute">visibility</tag> is set to “<literal>private</literal>”,
-the variable is visible inside the <tag>p:library</tag> but not visible to
-any pipeline importing the <tag>p:library</tag>. If the visibility attribute is
-missing, “<literal>public</literal>” is assumed. If the <tag>p:variable</tag> is not a child 
-of <tag>a p:library</tag> the attribute has no effect and is ignored.
-</para>
-</listitem>
-</varlistentry>
-
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem>
-<para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">pipe</tag></term>
-<listitem>
-  <para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
-author to exclude some namespace declarations in inline content, see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
-
-<para>Steps are connected together by their input and output
-ports. Variables are connected to steps by their input, which provides
-the context node for the expression, and by the expressions that contain
-references to them. Any step which contains a reference to a variable
-effectively consumes the “output” of the variable.
-<error code="S0076">It is a <glossterm>static error</glossterm> if
-there are any loops in the connections between steps and variables:
-no step can refer to a variable if there is any sequence of connections
-from that step that leads back to the input that provides the context
-node for the expression that defines the value of the variable.</error>
-</para>
-
-<para>If <tag class="attribute">collection</tag> is true, the context
-item for the expression is undefined. Otherwise, the context item for
-the expression comes from the document connections, if they are
-specified. If they are not specified, the context item comes from the
-<glossterm>default readable port</glossterm> (computed as if
-<tag>p:variable</tag> was an atomic step). If no <glossterm>default
-readable port</glossterm> exists, the context item is
-undefined.</para>
-
-<para><error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error>
-<error code="D0065">It is a <glossterm>dynamic error</glossterm>
-to refer to the context item, size, or position if a sequence of documents
-appears on the connection that provides the context.</error>
-</para>
-
-<para>Since all <glossterm>in-scope bindings</glossterm> are present
-in the Processor XPath Context as variable bindings, <tag
-class="attribute">select</tag> expressions may refer to the value of
-<glossterm>in-scope bindings</glossterm> by variable reference.</para>
-</section>
-
-<!-- ============================================================ -->
-
-<section xml:id="p.option">
-<title>p:option</title>
-
-<para>A <tag>p:option</tag> declares an option and associates a
-default value with it. Option declarations may optionally specify the type
-of the option using an
-<biblioref linkend="xpath31"/>
-<link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>.
-</para>
-
-<e:rng-pattern name="Option"/>
-
-<para>The attributes that can appear on <tag>p:option</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
-
-<variablelist>
-<varlistentry><term><tag class="attribute">name</tag></term>
-<listitem>
-<para>The name of the option <rfc2119>must</rfc2119> be an EQName. If
-it does not contain a prefix then it is in no namespace.
-<error code="S0028">It is a <glossterm>static error</glossterm> to declare an
-option or variable in the XProc namespace.</error> <error code="S0087">It is
-a <glossterm>static error</glossterm> if the name attribute on
-<tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is not
-bound to a namespace.</error>
-</para>
-<para><error code="S0088">It is
-a <glossterm>static error</glossterm> if the qualified name of a
-<tag>p:option</tag> <glossterm baseform="shadow">shadows</glossterm>
-the name of a static variable or option.</error>
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">as</tag></term>
-<listitem>
-<para>The type of the value may be specified in the
-<tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">values</tag></term>
-<listitem>
-<para>A list of acceptable values may be specified in the <tag
-class="attribute">values</tag> attribute. If specified, the value
-of the <tag class="attribute">values</tag> attribute
-<rfc2119>must</rfc2119> be a list of atomic values expressed as an XPath sequence,
-for example: <code>('one', 'two', 'three')</code>.
-<error code="S0101">It is a <glossterm>static error</glossterm> if the
-values list is not an XPath sequence of atomic values.</error>
-</para>
-<para>The values list is an additional constraint on the acceptable values
-for the option. The option value must satisfy the <tag class="attribute">as</tag>
-type, if one is provided, and must be equal to (XPath “<code>eq</code>”) one of the listed
-<tag class="attribute">values</tag>.
-It is possible to combine <tag class="attribute">as</tag> and
-<tag class="attribute">values</tag> in ways that exclude all
-actual values (for example, <code>as="xs:integer"</code> and
-<code>values="(1.5,’pi’)"</code>). Doing so will make it impossible
-to specify a value for the option.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">static</tag></term>
-<listitem>
-<para>An indication of whether the option is to be evaluated
-statically or not. See <link linkend="statics"/>.
-If <tag class="attribute">static</tag> is not specified, it
-defaults to “<code>false</code>”.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">required</tag></term>
-<listitem>
-<para>An option may declare that it is required by specifying
-the value <literal>true</literal> for the
-<tag class="attribute">required</tag> attribute. <error code="S0018">If an
-option is required, it is a <glossterm>static error</glossterm> to
-invoke the step without specifying a value for that
-option.</error> If <tag class="attribute">required</tag> is not specified,
-it defaults to “<code>false</code>”.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">select</tag></term>
-<listitem>
-<para>If an option is not required, its default value may be specified with a
-<tag class="attribute">select</tag> attribute.
-If no default value is specified, the default value is the empty sequence.
-</para>
-
-<para>If specified, the content of the
-<tag class="attribute">select</tag> attribute is an XPath expression
-which will be evaluated to provide the default value for the option.
-</para>
-
-<para>The default value of an option is specified with an XPath
-expression on the <tag>p:declare-step</tag> that defines the step
-signature. It must be a statically valid expression at that point.
-Consequently, if it contains variable references, they can only be
-references to preceding options on the step or to in-scope static variables.
-<error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error></para>
-
-<para><impl>The precise details about what XPath expressions are allowed
-(for example, can the expression declare a function) is
-<glossterm>implementation-defined</glossterm>.</impl>
-</para>
-</listitem>
-</varlistentry>
-
-<varlistentry><term><tag class="attribute">visibility</tag></term>
-<listitem>
-<para>If the <tag>p:option</tag> is a child of a <tag>p:library</tag>,
-the <tag class="attribute">visibility</tag> attribute controls whether
-the option is visible to an importing pipeline. If
-<tag class="attribute">visibility</tag> is set to “<literal>private</literal>”,
-the option is visible inside the <tag>p:library</tag> but not visible to
-any pipeline importing the <tag>p:library</tag>. If the visibility attribute is
-  missing, “<literal>public</literal>” is assumed. If the <tag>p:option</tag> is not a child 
-  of <tag>a p:library</tag> the attribute has no effect and is ignored.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
-
-<para><error code="S0004">It is a <glossterm>static error</glossterm>
-to declare two or more options on the same step with the same
-name.</error></para>
-
-<para>The following errors apply to options:</para>
-
-<itemizedlist>
-<listitem>
-<para><error code="S0017">It is a <glossterm>static error</glossterm>
-to specify that an option is both <tag class="attribute">required</tag>
-<emphasis>and</emphasis> has a default value.</error></para>
-</listitem>
-<listitem>
-<para><error code="S0095">It is a <glossterm>static error</glossterm>
-to specify that an option is both <tag class="attribute">required</tag>
-<emphasis>and</emphasis> static.</error></para>
-</listitem>
-</itemizedlist>
-
-<para>The pipeline author may use <tag>p:with-option</tag> on a step
-when it is invoked. Values specified with <tag>p:with-option</tag>
-override any default values specified.</para>
-</section>
-
-<!-- ============================================================ -->
-
-<section xml:id="p.with-option">
-<title>p:with-option</title>
-
-<para>A <tag>p:with-option</tag> provides an actual value for an
-option when a step is invoked.</para>
-
-<e:rng-pattern name="WithOption"/>
-
-<para>The attributes that can appear on <tag>p:with-option</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
-
-<variablelist>
-<varlistentry><term><tag class="attribute">name</tag></term>
-<listitem>
-<para>The name of the option <rfc2119>must</rfc2119> be a EQName. If it
-does not contain a prefix then it is in no namespace.
-<error code="S0031">It is a <glossterm>static error</glossterm> to use an
-option name in <tag>p:with-option</tag> if the step type being invoked
-has not declared an option with that name.</error>
-</para>
-
-<para><error code="S0080">It is a <glossterm>static error</glossterm>
-to include more than one <tag>p:with-option</tag> with the same option
-name as part of the same step invocation.</error></para>
-
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">as</tag></term>
-<listitem>
-<para>The type of the value may be specified in the
-<tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">select</tag></term>
-<listitem>
-<para>The actual value is specified with a
-<tag class="attribute">select</tag> attribute. The
-<tag class="attribute">select</tag> attribute <rfc2119>must</rfc2119> be
-specified. The value of the <tag class="attribute">select</tag>
-attribute is an XPath expression which will be evaluated to provide
-the value of the variable.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">collection</tag></term>
-<listitem>
-<para>If <tag class="attribute">collection</tag> is
-unspecified or has the value <literal>false</literal>, then it has
-no effect.</para>
-<para>If <tag class="attribute">collection</tag> is <literal>true</literal>,
-the context item is undefined. All of the documents that appear on the
-connection for the <tag>p:with-option</tag> will be available as the
-default collection within <tag class="attribute">select</tag> expression.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem>
-<para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">pipe</tag></term>
-<listitem>
-  <para>As described in <tag>p:with-input</tag>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
-author to exclude some namespace declarations in inline content, see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
-
-<para>Any <tag>p:with-option</tag> which contains a reference to a variable
-effectively consumes the “output” of the <tag>p:variable</tag> or
-<tag>p:option</tag> that defines that variable.
-<error code="S0076">It is a <glossterm>static error</glossterm> if
-there are any loops in the connections between steps and variables:
-no step can refer to a variable if there is any sequence of connections
-from that step that leads back to the input that provides the context
-node for the expression that defines the value of the variable.</error>
-</para>
-
-<para>If <tag class="attribute">collection</tag> is true, the context
-item for the expression is undefined. Otherwise, the context item for
-the expression comes from the document connections, if they are
-specified. If they are not specified, the context item comes from the
-<glossterm>default readable port</glossterm> of the step.
-If no <glossterm>default
-readable port</glossterm> exists, the context item is
-undefined.</para>
-
-<para><error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
-XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error>
-<error code="D0065">It is a <glossterm>dynamic error</glossterm>
-to refer to the context item, size, or position if a sequence of documents
-appears on the connection that provides the context.</error>
-</para>
-
-<para>Since all <glossterm>in-scope bindings</glossterm> are present
-in the Processor XPath Context as variable bindings, <tag
-class="attribute">select</tag> expressions may refer to the value of
-<glossterm>in-scope bindings</glossterm> by variable reference.
-</para>
-
-<para><error code="S0092">It is a <glossterm>static
-error</glossterm> if a <tag>p:with-option</tag> attempts to change
-the value of an option that is declared static.</error>
-See <xref linkend="statics"/>.</para>
-  
-  <section xml:id="option-shortcut">
-    <title>Syntactic Shortcut for Option Values</title>
-    
-    <para>Namespace qualified attributes on a step are <glossterm
-      baseform="extension attribute" >extension attributes</glossterm>.
-      Attributes, other than <tag class="attribute" >name</tag>, that are
-      not namespace qualified are treated as a syntactic shortcut for
-      specifying the value of an option. In other words, the following two
-      steps are equivalent:</para>
-    
-    <para>The first step uses the standard <tag>p:with-option</tag>
-      syntax:</para>
-    
-    <programlisting language="xml"><![CDATA[<ex:stepType>
+        
+        <para><error code="D0020">It is a <glossterm>dynamic error</glossterm> if the combination
+          of serialization options specified or defaulted is not allowed.</error>
+          Implementations <rfc2119>must</rfc2119> check that all of the specified serialization
+          options are allowed if they serialize the specified output. If the specified output is
+          not being serialized implementations <rfc2119>may</rfc2119> but are not required to
+          check that the specified options are allowed.</para>
+        
+        <para>In order to be consistent with the rest of this specification, values for boolean
+          serialization parameters can also use one of the XML Schema lexical forms for boolean:
+          <literal>true</literal>, <literal>false</literal>, <literal>1</literal>, or <literal>0</literal>. This is different from the <biblioref
+            linkend="xml-serialization-31"/> specification, which uses <literal>yes</literal> and <literal>no</literal>. No change in
+          semantics is implied by this different spelling.</para>
+        
+        <para><impl>The default value of any serialization parameters not specified on a
+          particular output is <glossterm>implementation-defined</glossterm>.</impl></para>
+
+        <section xml:id="serialization-method">
+          <title>Serialization method</title>
+
+          <para>The <option>method</option> option controls the serialization method used by this
+            component with standard values of <literal>html</literal>, <literal>xml</literal>,
+              <literal>xhtml</literal>, <literal>text</literal> and <literal>json</literal>. Only
+            the <literal>xml</literal> value is required to be supported. <impl>Implementations may
+              support other method values but their results are
+                <glossterm>implementation-defined</glossterm>.</impl></para>
+
+          <para>If the serialization parameter <literal>method</literal> is not specified, the
+            processor <rfc2119>should</rfc2119> select a method based on the document's
+              <literal>content-type</literal> property:</para>
+
+          <itemizedlist>
+            <listitem>
+              <para>For documents with content types <literal>application/xml</literal>,
+                  <literal>text/xml</literal>, and <literal>application/*+xml</literal> (except for
+                  <literal>application/xhtml+xml</literal>), serialization method
+                  <literal>xml</literal> should be used.</para>
+            </listitem>
+            <listitem>
+              <para>For documents with content type <literal>application/xhtml+xml</literal>
+                serialization method <literal>xhtml</literal> should be used.</para>
+            </listitem>
+            <listitem>
+              <para>For documents with content type <literal>text/html</literal> serialization
+                method <literal>html</literal> should be used.</para>
+            </listitem>
+            <listitem>
+              <para>For documents with <glossterm baseform="text media type">text media
+                  types</glossterm> serialization method <literal>text</literal> should be
+                used.</para>
+            </listitem>
+            <listitem>
+              <para>For documents with <glossterm baseform="JSON media type">JSON media
+                  types</glossterm> serialization method <literal>json</literal> should be
+                used.</para>
+            </listitem>
+            <listitem>
+              <para>
+                <impl>The serialization method for documents with other media types is
+                    <glossterm>implementation-defined</glossterm>.</impl>
+              </para>
+            </listitem>
+          </itemizedlist>
+          <para>If serialization method <literal>xml</literal> or <literal>html</literal> (if
+            supported) is choosen, either explicitly or implicitly, the following default values
+              <rfc2119>must</rfc2119> be used:</para>
+          <itemizedlist>
+            <listitem>
+              <para>Parameter <literal>version</literal> is set to <literal>1.0</literal>.</para>
+            </listitem>
+            <listitem>
+              <para>Parameter <literal>encoding</literal> is set to <literal>UTF-8</literal>.</para>
+            </listitem>
+            <listitem>
+              <para>Parameter <literal>omit-xml-declaration</literal> is set to
+                  <literal>true</literal>.</para>
+            </listitem>
+          </itemizedlist>
+
+        </section>
+
+        <section xml:id="serialization-minimal-conformance">
+          <title>Minimal conformance</title>
+
+          <para>A minimally conforming implementation must support the <code>xml</code> output
+            method with the following option values:</para>
+
+          <itemizedlist>
+            <listitem>
+              <para>The <code>version</code> must support the value <code>1.0</code>.</para>
+            </listitem>
+            <listitem>
+              <para>The <code>encoding</code> must support the value <code>UTF-8</code>.</para>
+            </listitem>
+            <listitem>
+              <para>The <code>omit-xml-declaration</code> must be supported. If the value is not
+                specified or has the value <code>no</code>, an XML declaration must be
+                produced.</para>
+            </listitem>
+          </itemizedlist>
+
+          <para>All other option values may be ignored for the <code>xml</code> output
+            method.</para>
+
+          <para>If a processor chooses to implement an option for serialization, it
+              <rfc2119>must</rfc2119> conform to the semantics defined in the <biblioref
+              linkend="xml-serialization-31"/> specification.</para>
+
+          
+
+
+          
+        </section>
+
+
+      </section>
+    </section>
+
+    <!-- ============================================================ -->
+
+    <section xml:id="variables-options">
+      <title>Variables and Options</title>
+
+      <para>Variables and options provide a mechanism for pipeline authors to construct temporary
+        results and hold onto them for reuse.</para>
+
+      <para>Variables are created in compound steps and, like XSLT variables, are single assignment,
+        though they may be shadowed by subsequent declarations of other variables with the same
+        name.</para>
+
+      <para>Options can be declared on atomic or compound steps. The value of an option can be
+        specified by the caller invoking the step. Any value specified by the caller takes
+        precedence over the default value of the option.</para>
+
+      <section xml:id="p.variable">
+        <title>p:variable</title>
+
+        <para>A <tag>p:variable</tag> declares a variable and associates a value with it. Variable
+          declarations may optionally specify the type of the variable using an <biblioref
+            linkend="xpath31"/>
+          <link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>. </para>
+
+        <e:rng-pattern name="GeneralVariable"/>
+
+        <para>The attributes that can appear on <tag>p:variable</tag> are <link
+            linkend="common-attr">the common attributes</link> and:</para>
+
+        <variablelist>
+          <varlistentry>
+            <term>
+              <tag class="attribute">name</tag>
+            </term>
+            <listitem>
+              <para>The name of the variable <rfc2119>must</rfc2119> be an EQName. If it does not
+                contain a prefix then it is in no namespace. <error code="S0028">It is a
+                    <glossterm>static error</glossterm> to declare an option or variable in the
+                  XProc namespace.</error>
+                <error code="S0087">It is a <glossterm>static error</glossterm> if the name
+                  attribute on <tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is
+                  not bound to a namespace.</error>
+              </para>
+              <para>
+                <error code="S0088">It is a <glossterm>static error</glossterm> if the qualified
+                  name of a <tag>p:variable</tag>
+                  <glossterm baseform="shadow">shadows</glossterm> the name of a static variable or
+                  option.</error>
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">as</tag>
+            </term>
+            <listitem>
+              <para>The type of the value may be specified in the <tag class="attribute">as</tag>
+                attribute using an XProc sequence type, see <xref linkend="varopt-types"/>. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">static</tag>
+            </term>
+            <listitem>
+              <para>An indication of whether the variable is to be evaluated statically or not. See
+                  <link linkend="statics"/>. If <tag class="attribute">static</tag> is not
+                specified, it defaults to “<code>false</code>”.</para>
+              <para>
+                <error code="S0098">It is a <glossterm>static error</glossterm> if a variable is
+                  declared as static and the <tag>p:variable</tag> has a <tag class="attribute"
+                    >pipe</tag> attribute or <tag>p:pipe</tag> children.</error>
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">select</tag>
+            </term>
+            <listitem>
+              <para>The variable's value is specified with a <tag class="attribute">select</tag>
+                attribute. The <tag class="attribute">select</tag> attribute <rfc2119>must</rfc2119>
+                be specified. The content of the <tag class="attribute">select</tag> attribute is an
+                XPath expression which will be evaluated to provide the value of the variable.
+                  <error code="S0094">It is a <glossterm>static error</glossterm> if a
+                    <tag>p:variable</tag> does not have a select attribute.</error>
+              </para>
+              <para>The <tag class="attribute">select</tag> expression is evaluated as an XPath
+                expression using the appropriate context as described in <xref
+                  linkend="xpath-context"/>, for the enclosing <glossterm>container</glossterm>.
+                  <impl>The precise details about what XPath expressions are allowed (for example,
+                  can the expression declare a function) is
+                    <glossterm>implementation-defined</glossterm>.</impl>
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">collection</tag>
+            </term>
+            <listitem>
+              <para>If <tag class="attribute">collection</tag> is unspecified or has the value
+                  <literal>false</literal>, then it has no effect. </para>
+
+              <para>If <tag class="attribute">collection</tag> is <literal>true</literal>, the
+                context item is undefined. All of the documents that appear on the connection for
+                the <tag>p:variable</tag> will be available as the default collection within <tag
+                  class="attribute">select</tag> expression.</para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>
+              <tag class="attribute">visibility</tag>
+            </term>
+            <listitem>
+              <para>If the <tag>p:variable</tag> is a child of a <tag>p:library</tag>, the <tag
+                  class="attribute">visibility</tag> attribute controls whether the variable is
+                visible to an importing pipeline. If <tag class="attribute">visibility</tag> is set
+                to “<literal>private</literal>”, the variable is visible inside the
+                  <tag>p:library</tag> but not visible to any pipeline importing the
+                  <tag>p:library</tag>. If the visibility attribute is missing,
+                  “<literal>public</literal>” is assumed. If the <tag>p:variable</tag> is not a
+                child of <tag>a p:library</tag> the attribute has no effect and is ignored. </para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>
+              <tag class="attribute">href</tag>
+            </term>
+            <listitem>
+              <para>As described in <tag>p:with-input</tag>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">pipe</tag>
+            </term>
+            <listitem>
+              <para>As described in <tag>p:with-input</tag>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">exclude-inline-prefixes</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
+                author to exclude some namespace declarations in inline content, see
+                  <tag>p:inline</tag>. </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para>Steps are connected together by their input and output ports. Variables are connected
+          to steps by their input, which provides the context node for the expression, and by the
+          expressions that contain references to them. Any step which contains a reference to a
+          variable effectively consumes the “output” of the variable. <error code="S0076">It is a
+              <glossterm>static error</glossterm> if there are any loops in the connections between
+            steps and variables: no step can refer to a variable if there is any sequence of
+            connections from that step that leads back to the input that provides the context node
+            for the expression that defines the value of the variable.</error>
+        </para>
+
+        <para>If <tag class="attribute">collection</tag> is true, the context item for the
+          expression is undefined. Otherwise, the context item for the expression comes from the
+          document connections, if they are specified. If they are not specified, the context item
+          comes from the <glossterm>default readable port</glossterm> (computed as if
+            <tag>p:variable</tag> was an atomic step). If no <glossterm>default readable
+            port</glossterm> exists, the context item is undefined.</para>
+
+        <para>
+          <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an XPath expression
+            makes reference to the context item, size, or position when the context item is
+            undefined.</error>
+          <error code="D0065">It is a <glossterm>dynamic error</glossterm> to refer to the context
+            item, size, or position if a sequence of documents appears on the connection that
+            provides the context.</error>
+        </para>
+
+        <para>Since all <glossterm>in-scope bindings</glossterm> are present in the Processor XPath
+          Context as variable bindings, <tag class="attribute">select</tag> expressions may refer to
+          the value of <glossterm>in-scope bindings</glossterm> by variable reference.</para>
+      </section>
+
+      <!-- ============================================================ -->
+
+      <section xml:id="p.option">
+        <title>p:option</title>
+
+        <para>A <tag>p:option</tag> declares an option and associates a default value with it.
+          Option declarations may optionally specify the type of the option using an <biblioref
+            linkend="xpath31"/>
+          <link xlink:href="https://www.w3.org/TR/xpath-31/#dt-sequence-type">sequence Type</link>. </para>
+
+        <e:rng-pattern name="Option"/>
+
+        <para>The attributes that can appear on <tag>p:option</tag> are <link linkend="common-attr"
+            >the common attributes</link> and:</para>
+
+        <variablelist>
+          <varlistentry>
+            <term>
+              <tag class="attribute">name</tag>
+            </term>
+            <listitem>
+              <para>The name of the option <rfc2119>must</rfc2119> be an EQName. If it does not
+                contain a prefix then it is in no namespace. <error code="S0028">It is a
+                    <glossterm>static error</glossterm> to declare an option or variable in the
+                  XProc namespace.</error>
+                <error code="S0087">It is a <glossterm>static error</glossterm> if the name
+                  attribute on <tag>p:option</tag> or <tag>p:variable</tag> has a prefix which is
+                  not bound to a namespace.</error>
+              </para>
+              <para>
+                <error code="S0088">It is a <glossterm>static error</glossterm> if the qualified
+                  name of a <tag>p:option</tag>
+                  <glossterm baseform="shadow">shadows</glossterm> the name of a static variable or
+                  option.</error>
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">as</tag>
+            </term>
+            <listitem>
+              <para>The type of the value may be specified in the <tag class="attribute">as</tag>
+                attribute using an XProc sequence type, see <xref linkend="varopt-types"/>. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">values</tag>
+            </term>
+            <listitem>
+              <para>A list of acceptable values may be specified in the <tag class="attribute"
+                  >values</tag> attribute. If specified, the value of the <tag class="attribute"
+                  >values</tag> attribute <rfc2119>must</rfc2119> be a list of atomic values
+                expressed as an XPath sequence, for example: <code>('one', 'two', 'three')</code>.
+                  <error code="S0101">It is a <glossterm>static error</glossterm> if the values list
+                  is not an XPath sequence of atomic values.</error>
+              </para>
+              <para>The values list is an additional constraint on the acceptable values for the
+                option. The option value must satisfy the <tag class="attribute">as</tag> type, if
+                one is provided, and must be equal to (XPath “<code>eq</code>”) one of the listed
+                  <tag class="attribute">values</tag>. It is possible to combine <tag
+                  class="attribute">as</tag> and <tag class="attribute">values</tag> in ways that
+                exclude all actual values (for example, <code>as="xs:integer"</code> and
+                  <code>values="(1.5,’pi’)"</code>). Doing so will make it impossible to specify a
+                value for the option.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">static</tag>
+            </term>
+            <listitem>
+              <para>An indication of whether the option is to be evaluated statically or not. See
+                  <link linkend="statics"/>. If <tag class="attribute">static</tag> is not
+                specified, it defaults to “<code>false</code>”.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">required</tag>
+            </term>
+            <listitem>
+              <para>An option may declare that it is required by specifying the value
+                  <literal>true</literal> for the <tag class="attribute">required</tag> attribute.
+                  <error code="S0018">If an option is required, it is a <glossterm>static
+                    error</glossterm> to invoke the step without specifying a value for that
+                  option.</error> If <tag class="attribute">required</tag> is not specified, it
+                defaults to “<code>false</code>”.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">select</tag>
+            </term>
+            <listitem>
+              <para>If an option is not required, its default value may be specified with a <tag
+                  class="attribute">select</tag> attribute. If no default value is specified, the
+                default value is the empty sequence. </para>
+
+              <para>If specified, the content of the <tag class="attribute">select</tag> attribute
+                is an XPath expression which will be evaluated to provide the default value for the
+                option. </para>
+
+              <para>The default value of an option is specified with an XPath expression on the
+                  <tag>p:declare-step</tag> that defines the step signature. It must be a statically
+                valid expression at that point. Consequently, if it contains variable references,
+                they can only be references to preceding options on the step or to in-scope static
+                variables. <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
+                  XPath expression makes reference to the context item, size, or position when the
+                  context item is undefined.</error></para>
+
+              <para>
+                <impl>The precise details about what XPath expressions are allowed (for example, can
+                  the expression declare a function) is
+                    <glossterm>implementation-defined</glossterm>.</impl>
+              </para>
+            </listitem>
+          </varlistentry>
+
+          <varlistentry>
+            <term>
+              <tag class="attribute">visibility</tag>
+            </term>
+            <listitem>
+              <para>If the <tag>p:option</tag> is a child of a <tag>p:library</tag>, the <tag
+                  class="attribute">visibility</tag> attribute controls whether the option is
+                visible to an importing pipeline. If <tag class="attribute">visibility</tag> is set
+                to “<literal>private</literal>”, the option is visible inside the
+                  <tag>p:library</tag> but not visible to any pipeline importing the
+                  <tag>p:library</tag>. If the visibility attribute is missing,
+                  “<literal>public</literal>” is assumed. If the <tag>p:option</tag> is not a child
+                of <tag>a p:library</tag> the attribute has no effect and is ignored. </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para>
+          <error code="S0004">It is a <glossterm>static error</glossterm> to declare two or more
+            options on the same step with the same name.</error>
+        </para>
+
+        <para>The following errors apply to options:</para>
+
+        <itemizedlist>
+          <listitem>
+            <para>
+              <error code="S0017">It is a <glossterm>static error</glossterm> to specify that an
+                option is both <tag class="attribute">required</tag>
+                <emphasis>and</emphasis> has a default value.</error>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <error code="S0095">It is a <glossterm>static error</glossterm> to specify that an
+                option is both <tag class="attribute">required</tag>
+                <emphasis>and</emphasis> static.</error>
+            </para>
+          </listitem>
+        </itemizedlist>
+
+        <para>The pipeline author may use <tag>p:with-option</tag> on a step when it is invoked.
+          Values specified with <tag>p:with-option</tag> override any default values
+          specified.</para>
+      </section>
+
+      <!-- ============================================================ -->
+
+      <section xml:id="p.with-option">
+        <title>p:with-option</title>
+
+        <para>A <tag>p:with-option</tag> provides an actual value for an option when a step is
+          invoked.</para>
+
+        <e:rng-pattern name="WithOption"/>
+
+        <para>The attributes that can appear on <tag>p:with-option</tag> are <link
+            linkend="common-attr">the common attributes</link> and:</para>
+
+        <variablelist>
+          <varlistentry>
+            <term>
+              <tag class="attribute">name</tag>
+            </term>
+            <listitem>
+              <para>The name of the option <rfc2119>must</rfc2119> be a EQName. If it does not
+                contain a prefix then it is in no namespace. <error code="S0031">It is a
+                    <glossterm>static error</glossterm> to use an option name in
+                    <tag>p:with-option</tag> if the step type being invoked has not declared an
+                  option with that name.</error>
+              </para>
+
+              <para>
+                <error code="S0080">It is a <glossterm>static error</glossterm> to include more than
+                  one <tag>p:with-option</tag> with the same option name as part of the same step
+                  invocation.</error>
+              </para>
+
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">as</tag>
+            </term>
+            <listitem>
+              <para>The type of the value may be specified in the <tag class="attribute">as</tag>
+                attribute using an XProc sequence type, see <xref linkend="varopt-types"/>. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">select</tag>
+            </term>
+            <listitem>
+              <para>The actual value is specified with a <tag class="attribute">select</tag>
+                attribute. The <tag class="attribute">select</tag> attribute <rfc2119>must</rfc2119>
+                be specified. The value of the <tag class="attribute">select</tag> attribute is an
+                XPath expression which will be evaluated to provide the value of the
+                variable.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">collection</tag>
+            </term>
+            <listitem>
+              <para>If <tag class="attribute">collection</tag> is unspecified or has the value
+                  <literal>false</literal>, then it has no effect.</para>
+              <para>If <tag class="attribute">collection</tag> is <literal>true</literal>, the
+                context item is undefined. All of the documents that appear on the connection for
+                the <tag>p:with-option</tag> will be available as the default collection within <tag
+                  class="attribute">select</tag> expression.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">href</tag>
+            </term>
+            <listitem>
+              <para>As described in <tag>p:with-input</tag>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">pipe</tag>
+            </term>
+            <listitem>
+              <para>As described in <tag>p:with-input</tag>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">exclude-inline-prefixes</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">exclude-inline-prefixes</tag> allows the pipeline
+                author to exclude some namespace declarations in inline content, see
+                  <tag>p:inline</tag>. </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para>Any <tag>p:with-option</tag> which contains a reference to a variable effectively
+          consumes the “output” of the <tag>p:variable</tag> or <tag>p:option</tag> that defines
+          that variable. <error code="S0076">It is a <glossterm>static error</glossterm> if there
+            are any loops in the connections between steps and variables: no step can refer to a
+            variable if there is any sequence of connections from that step that leads back to the
+            input that provides the context node for the expression that defines the value of the
+            variable.</error>
+        </para>
+
+        <para>If <tag class="attribute">collection</tag> is true, the context item for the
+          expression is undefined. Otherwise, the context item for the expression comes from the
+          document connections, if they are specified. If they are not specified, the context item
+          comes from the <glossterm>default readable port</glossterm> of the step. If no
+            <glossterm>default readable port</glossterm> exists, the context item is
+          undefined.</para>
+
+        <para>
+          <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an XPath expression
+            makes reference to the context item, size, or position when the context item is
+            undefined.</error>
+          <error code="D0065">It is a <glossterm>dynamic error</glossterm> to refer to the context
+            item, size, or position if a sequence of documents appears on the connection that
+            provides the context.</error>
+        </para>
+
+        <para>Since all <glossterm>in-scope bindings</glossterm> are present in the Processor XPath
+          Context as variable bindings, <tag class="attribute">select</tag> expressions may refer to
+          the value of <glossterm>in-scope bindings</glossterm> by variable reference. </para>
+
+        <para><error code="S0092">It is a <glossterm>static error</glossterm> if a
+              <tag>p:with-option</tag> attempts to change the value of an option that is declared
+            static.</error> See <xref linkend="statics"/>.</para>
+
+        <section xml:id="option-shortcut">
+          <title>Syntactic Shortcut for Option Values</title>
+
+          <para>Namespace qualified attributes on a step are <glossterm
+              baseform="extension attribute">extension attributes</glossterm>. Attributes, other
+            than <tag class="attribute">name</tag>, that are not namespace qualified are treated as
+            a syntactic shortcut for specifying the value of an option. In other words, the
+            following two steps are equivalent:</para>
+
+          <para>The first step uses the standard <tag>p:with-option</tag> syntax:</para>
+
+          <programlisting language="xml"><![CDATA[<ex:stepType>
   <p:with-option name="option-name" select="'some value'"/>
 </ex:stepType>]]></programlisting>
-    
-    <para>The second step uses the syntactic shortcut:</para>
-    
-    <programlisting language="xml"><![CDATA[<ex:stepType option-name="some value"/>]]></programlisting>
-    
-    <para>There are some limitations to this shortcut
-      syntax:</para>
-    
-    <orderedlist>
-      <listitem>
-        <para>It only applies to option names that are not in a
-          namespace.</para>
-      </listitem>
-      <listitem>
-        <para>It only applies to option names that are not otherwise used on
-          the step, such as “<literal>name</literal>”.</para>
-      </listitem>
-    </orderedlist>
-    
-    <para>For the value of an option's syntactic shortcut attribute, the following applies:</para>
-    <itemizedlist>
-      <listitem>
-              <para><termdef xml:id="dt-map-attribute">A <firstterm>map attribute</firstterm> is an option's syntactic
-                  shortcut attribute for which the option's sequence type is a map or array.</termdef> The attribute's value
-                is interpreted directly as an XPath expression, which must result in a value of the applicable
-                datatype.</para>
-        
-      </listitem>
-      <listitem>
-        <para>For any other option's sequence type it is considered an <glossterm>attribute value template</glossterm>.
-                The context node for the attribute value template comes from the default readable port for the step on
-                which they occur. If there is no such port, the context node is undefined.</para>
-       
-            <para>The attribute's string value, after the attribute value template expansion, is used as
-              the value of the option. It must be possible to convert this string to the option's sequence type.</para>
-      </listitem>
-    </itemizedlist>
-    
-    
-<para><error code="S0027">It is a <glossterm>static error</glossterm>
-if an option is specified with both the shortcut form and the long
-form.</error>
-<error code="S0031">It is a <glossterm>static error</glossterm>
-to use an option on an <glossterm>atomic step</glossterm>
-that is not declared on steps of that type.</error>
-<error code="S0092">It is a <glossterm>static error</glossterm> to
-specify a value for an option that is declared static.</error>
-</para>
-    
-    <para>The syntactic shortcuts apply equally to standard atomic steps
-      and extension atomic steps.</para>
-  </section>
-</section>
-</section>
 
-<!-- ============================================================ -->
+          <para>The second step uses the syntactic shortcut:</para>
 
-<section xml:id="p.declare-step">
-<title>p:declare-step</title>
+          <programlisting language="xml"><![CDATA[<ex:stepType option-name="some value"/>]]></programlisting>
 
-<para>A <tag>p:declare-step</tag> provides the type and
-<glossterm>signature</glossterm> of a pipeline or
-an <glossterm>atomic step</glossterm>.
-Pipelines contain a subpipeline which defines what the declared
-step does. Atomic steps have an implementation defined elsewhere in some
-other way.</para>
+          <para>There are some limitations to this shortcut syntax:</para>
 
-<para><impl>When a declared step is evaluated directly by the XProc
-processor (as opposed to occurring as an atomic step in some
-<glossterm>container</glossterm>), how the input and output ports are
-connected to documents is
-<glossterm>implementation-defined</glossterm>.</impl></para>
+          <orderedlist>
+            <listitem>
+              <para>It only applies to option names that are not in a namespace.</para>
+            </listitem>
+            <listitem>
+              <para>It only applies to option names that are not otherwise used on the step, such as
+                  “<literal>name</literal>”.</para>
+            </listitem>
+          </orderedlist>
 
-<para>A step declaration is not a
-<link linkend="step-concept">step</link> in its own right. Sibling
-steps cannot refer to the inputs or outputs of a
-<tag>p:declare-step</tag> using <tag>p:pipe</tag>; only instances of
-the type can be referenced.</para>
+          <para>For the value of an option's syntactic shortcut attribute, the following
+            applies:</para>
+          <itemizedlist>
+            <listitem>
+              <para><termdef xml:id="dt-map-attribute">A <firstterm>map attribute</firstterm> is an
+                  option's syntactic shortcut attribute for which the option's sequence type is a
+                  map or array.</termdef> The attribute's value is interpreted directly as an XPath
+                expression, which must result in a value of the applicable datatype.</para>
 
-<para>Most pipeline authors use the <tag>p:declare-step</tag> element
-to declare a pipeline.</para>
+            </listitem>
+            <listitem>
+              <para>For any other option's sequence type it is considered an <glossterm>attribute
+                  value template</glossterm>. The context node for the attribute value template
+                comes from the default readable port for the step on which they occur. If there is
+                no such port, the context node is undefined.</para>
 
-<section xml:id="declare-pipelines">
-<title>Declaring pipelines</title>
+              <para>The attribute's string value, after the attribute value template expansion, is
+                used as the value of the option. It must be possible to convert this string to the
+                option's sequence type.</para>
+            </listitem>
+          </itemizedlist>
 
-<para>When a <tag>p:declare-step</tag> declares a pipeline, that
-pipeline encapsulates the behavior of the specified
-<glossterm>subpipeline</glossterm>. Its children declare inputs,
-outputs, and options that the pipeline exposes and identify the steps
-in its subpipeline.</para>
 
-<e:rng-pattern name="DeclarePipelineStep"/>
+          <para>
+            <error code="S0027">It is a <glossterm>static error</glossterm> if an option is
+              specified with both the shortcut form and the long form.</error>
+            <error code="S0031">It is a <glossterm>static error</glossterm> to use an option on an
+                <glossterm>atomic step</glossterm> that is not declared on steps of that
+              type.</error>
+            <error code="S0092">It is a <glossterm>static error</glossterm> to specify a value for
+              an option that is declared static.</error>
+          </para>
 
-<para>The attributes that can appear on <tag>p:declare-step</tag> are
-<link linkend="common-attr">the common attributes</link> and:</para>
+          <para>The syntactic shortcuts apply equally to standard atomic steps and extension atomic
+            steps.</para>
+        </section>
+      </section>
+    </section>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">name</tag></term>
-<listitem>
-<para>The <tag class="attribute">name</tag> attribute provides a
-name for the step. This name can be used within the subpipeline to
-refer back to the declaration, for example, to read from its inputs.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">type</tag></term>
-<listitem>
-<para>The <tag class="attribute">type</tag> attribute provides
-a type for the step. 
-The value of the <tag class="attribute">type</tag> can be from
-any namespace provided that the expanded-QName of the value has a
-non-null namespace URI. <error code="S0025">It is a <glossterm>static
-error</glossterm> if the expanded-QName value of the <tag
-class="attribute">type</tag> attribute is in no namespace or in the
-XProc namespace.</error> Neither
-users nor implementers may define additional steps in the XProc
-namespace.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">psvi-required</tag></term>
-<listitem>
-<para>The <tag class="attribute">psvi-required</tag> attribute allows
-the author to declare that a step relies on the processor's ability to
-pass PSVI annotations between steps,
-see <xref linkend="psvi-support"/>.
-If the attribute is not specified, the value
-“<literal>false</literal>” is assumed. </para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">xpath-version</tag></term>
-<listitem>
-<para>The requested <tag class="attribute">xpath-version</tag>
-<rfc2119>must</rfc2119> be used to evaluate XPath expressions subject
-to the constraints outlined in <xref linkend="xpath-context"/>. If the
-attribute is not specified, the value “<literal>3.1</literal>” is
-assumed. <error code="S0110">It is a <glossterm>static error</glossterm> if
-the requested XPath version is less than “<literal>3.1</literal>”</error>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">exclude-inline-prefixes</tag></term>
-<listitem>
-<para>The a description of <tag class="attribute">exclude-inline-prefixes</tag>,
-see <tag>p:inline</tag>.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">version</tag></term>
-<listitem>
-<para>The <tag class="attribute">version</tag> attribute identifies
-the version of XProc for which this step declaration was authored. If
-the <tag>p:declare-step</tag> has no ancestors in the XProc namespace,
-then it <rfc2119>must</rfc2119> have a
-<tag class="attribute">version</tag> attribute.
-<error code="S0062">It is a <glossterm>static error</glossterm> if
-a required version attribute is not present.</error>
-See <xref linkend="versioning-considerations"/>.</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">visibility</tag></term>
-<listitem>
+    <!-- ============================================================ -->
 
-<para>If the <tag>p:declare-step</tag> is a child of a <tag>p:library</tag>
-the <tag class="attribute">visibility</tag> attribute controls whether
-the step is visible to an importing pipeline.
-If <tag class="attribute">visibility</tag> is set to
-<literal>private</literal>, the step type is only visible inside the
-<tag>p:library</tag> and is not visible to any pipeline importing the
-<tag>p:library</tag>. If the <tag class="attribute">visibility</tag>
-attribute is missing, <literal>public</literal> is assumed. If the
-<tag>p:declare-step</tag> is not a child of a <tag>p:library</tag> the
-attribute has no effect and is ignored.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+    <section xml:id="p.declare-step">
+      <title>p:declare-step</title>
 
-<para>In the general case, the children of a <tag>p:declare-step</tag>
-can be grouped into several sections. All of these sections, except the
-subpipeline, may be empty.</para>
+      <para>A <tag>p:declare-step</tag> provides the type and <glossterm>signature</glossterm> of a
+        pipeline or an <glossterm>atomic step</glossterm>. Pipelines contain a subpipeline which
+        defines what the declared step does. Atomic steps have an implementation defined elsewhere
+        in some other way.</para>
 
-<orderedlist>
-<listitem>
-<para>Imports must come first.</para>
-</listitem>
-<listitem>
-<para>The prologue follows the imports.
-<termdef xml:id="dt-prologue">The <firstterm>prologue</firstterm> consists of
-the <tag>p:input</tag>, <tag>p:output</tag>, and <tag>p:option</tag> elements.
-The prologue may also contain <tag>p:variable</tag> elements, but if it does,
-they must be declared statically.</termdef>
-</para>
-</listitem>
-<listitem>
-<para>The prologue may be followed by any number of inline <tag>p:declare-step</tag>
-elements that declare additional steps.</para>
-</listitem>
-<listitem>
-<para>Finally, there must be at least one step in the subpipeline.</para>
-</listitem>
-</orderedlist>
+      <para>
+        <impl>When a declared step is evaluated directly by the XProc processor (as opposed to
+          occurring as an atomic step in some <glossterm>container</glossterm>), how the input and
+          output ports are connected to documents is
+          <glossterm>implementation-defined</glossterm>.</impl>
+      </para>
 
-<note>
-<para>In the absence of any inline declared steps, it is possible for the
-prologue to end with a <tag>p:variable</tag> and the subpipeline to begin
-with a <tag>p:variable</tag>. This does not introduce any ambiguity. In this
-case, the first non-static variable marks the beginning of the subpipeline.
-</para>
-</note>
+      <para>A step declaration is not a <link linkend="step-concept">step</link> in its own right.
+        Sibling steps cannot refer to the inputs or outputs of a <tag>p:declare-step</tag> using
+          <tag>p:pipe</tag>; only instances of the type can be referenced.</para>
 
-<para>Neither options nor variables in the prologue may shadow
-each other. <error code="S0091">It is a <glossterm>static
-error</glossterm> if a <tag>p:option</tag> or <tag>p:variable</tag>
-declared before the subpipeline begins shadows another option or
-variable declared within the same <tag>p:declare-step</tag>.</error>
-(Within the subpipeline, variables may shadow options and lexically
-preceding (non-static) variables.)
-</para>
+      <para>Most pipeline authors use the <tag>p:declare-step</tag> element to declare a
+        pipeline.</para>
 
-<para>The prologue ends with additional <tag>p:declare-step</tag>
-elements, if any, and is followed by the subpipeline. Any step
-imported or declared in the prologue of a pipeline may be invoked as a
-step within the subpipeline of that pipeline.</para>
+      <section xml:id="declare-pipelines">
+        <title>Declaring pipelines</title>
 
-<para>The environment inherited by the
-<glossterm>subpipeline</glossterm> is the <glossterm>empty
-environment</glossterm> with these modifications:</para>
+        <para>When a <tag>p:declare-step</tag> declares a pipeline, that pipeline encapsulates the
+          behavior of the specified <glossterm>subpipeline</glossterm>. Its children declare inputs,
+          outputs, and options that the pipeline exposes and identify the steps in its
+          subpipeline.</para>
 
-<itemizedlist>
-<listitem>
-<para>All of the declared inputs are added to the <glossterm>readable
-ports</glossterm> in the environment.</para>
-</listitem>
-<listitem>
-<para>If a <glossterm>primary input port</glossterm> is declared, that
-port is the <glossterm>default readable port</glossterm>, otherwise
-the default readable port is undefined.</para>
-</listitem>
-<listitem>
-<para>The <glossterm>in-scope bindings</glossterm> at the beginning of
-a <tag>p:declare-step</tag> are limited to the lexically preceding,
-statically declared options and variables.</para>
-</listitem>
-</itemizedlist>
+        <e:rng-pattern name="DeclarePipelineStep"/>
 
-<para>If a <glossterm>primary output port</glossterm> is declared and
-that port has no <glossterm>connection</glossterm>, then it is
-connected to the <glossterm>primary output port</glossterm> of the
-<glossterm>last step</glossterm> in the
-<glossterm>subpipeline</glossterm>. <error code="S0006">It is a
-<glossterm>static error</glossterm> if the primary output port is
-unconnected and the <glossterm>last step</glossterm> in the
-subpipeline does not have a primary output port.</error></para>
-</section>
+        <para>The attributes that can appear on <tag>p:declare-step</tag> are <link
+            linkend="common-attr">the common attributes</link> and:</para>
 
-<section xml:id="declare-atomic-steps">
-<title>Declaring atomic steps</title>
+        <variablelist>
+          <varlistentry>
+            <term>
+              <tag class="attribute">name</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">name</tag> attribute provides a name for the step.
+                This name can be used within the subpipeline to refer back to the declaration, for
+                example, to read from its inputs. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">type</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">type</tag> attribute provides a type for the step.
+                The value of the <tag class="attribute">type</tag> can be from any namespace
+                provided that the expanded-QName of the value has a non-null namespace URI. <error
+                  code="S0025">It is a <glossterm>static error</glossterm> if the expanded-QName
+                  value of the <tag class="attribute">type</tag> attribute is in no namespace or in
+                  the XProc namespace.</error> Neither users nor implementers may define additional
+                steps in the XProc namespace. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">psvi-required</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">psvi-required</tag> attribute allows the author to
+                declare that a step relies on the processor's ability to pass PSVI annotations
+                between steps, see <xref linkend="psvi-support"/>. If the attribute is not
+                specified, the value “<literal>false</literal>” is assumed. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">xpath-version</tag>
+            </term>
+            <listitem>
+              <para>The requested <tag class="attribute">xpath-version</tag>
+                <rfc2119>must</rfc2119> be used to evaluate XPath expressions subject to the
+                constraints outlined in <xref linkend="xpath-context"/>. If the attribute is not
+                specified, the value “<literal>3.1</literal>” is assumed. <error code="S0110">It is
+                  a <glossterm>static error</glossterm> if the requested XPath version is less than
+                    “<literal>3.1</literal>”</error>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">exclude-inline-prefixes</tag>
+            </term>
+            <listitem>
+              <para>The a description of <tag class="attribute">exclude-inline-prefixes</tag>, see
+                  <tag>p:inline</tag>. </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">version</tag>
+            </term>
+            <listitem>
+              <para>The <tag class="attribute">version</tag> attribute identifies the version of
+                XProc for which this step declaration was authored. If the <tag>p:declare-step</tag>
+                has no ancestors in the XProc namespace, then it <rfc2119>must</rfc2119> have a <tag
+                  class="attribute">version</tag> attribute. <error code="S0062">It is a
+                    <glossterm>static error</glossterm> if a required version attribute is not
+                  present.</error> See <xref linkend="versioning-considerations"/>.</para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <tag class="attribute">visibility</tag>
+            </term>
+            <listitem>
 
-<para>The distinction between an atomic step declaration and a
-pipeline declaration hinges on the presence or absense of a
-subpipeline. An atomic step declaration does not have a subpipeline.
-</para>
+              <para>If the <tag>p:declare-step</tag> is a child of a <tag>p:library</tag> the <tag
+                  class="attribute">visibility</tag> attribute controls whether the step is visible
+                to an importing pipeline. If <tag class="attribute">visibility</tag> is set to
+                  <literal>private</literal>, the step type is only visible inside the
+                  <tag>p:library</tag> and is not visible to any pipeline importing the
+                  <tag>p:library</tag>. If the <tag class="attribute">visibility</tag> attribute is
+                missing, <literal>public</literal> is assumed. If the <tag>p:declare-step</tag> is
+                not a child of a <tag>p:library</tag> the attribute has no effect and is ignored.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
 
-<para>Atomic step declarations may not import other pipelines or
-functions, may not declare static variables, and may not declare
-additional steps. In other words, the content of an atomic step
-declaration consists exclusively of <tag>p:input</tag>,
-<tag>p:output</tag>, and <tag>p:option</tag> elements.</para>
+        <para>In the general case, the children of a <tag>p:declare-step</tag> can be grouped into
+          several sections. All of these sections, except the subpipeline, may be empty.</para>
 
-<e:rng-pattern name="DeclareAtomicStep"/>
+        <orderedlist>
+          <listitem>
+            <para>Imports must come first.</para>
+          </listitem>
+          <listitem>
+            <para>The prologue follows the imports. <termdef xml:id="dt-prologue">The
+                  <firstterm>prologue</firstterm> consists of the <tag>p:input</tag>,
+                  <tag>p:output</tag>, and <tag>p:option</tag> elements. The prologue may also
+                contain <tag>p:variable</tag> elements, but if it does, they must be declared
+                statically.</termdef>
+            </para>
+          </listitem>
+          <listitem>
+            <para>The prologue may be followed by any number of inline <tag>p:declare-step</tag>
+              elements that declare additional steps.</para>
+          </listitem>
+          <listitem>
+            <para>Finally, there must be at least one step in the subpipeline.</para>
+          </listitem>
+        </orderedlist>
 
-<para><impl>Implementations may use
-<glossterm baseform="extension attribute">extension
-attributes</glossterm> to provide
-<glossterm>implementation-dependent</glossterm> information about a
-declared step.</impl> For example, such an attribute might identify
-the code which implements steps of this type.</para>
+        <note>
+          <para>In the absence of any inline declared steps, it is possible for the prologue to end
+            with a <tag>p:variable</tag> and the subpipeline to begin with a <tag>p:variable</tag>.
+            This does not introduce any ambiguity. In this case, the first non-static variable marks
+            the beginning of the subpipeline. </para>
+        </note>
 
-<para>It is not an error for a pipeline to include declarations for
-steps that a particular processor does not know how to implement. It
-is, of course, an error to attempt to evaluate such steps.</para>
-</section>
-</section>
+        <para>Neither options nor variables in the prologue may shadow each other. <error
+            code="S0091">It is a <glossterm>static error</glossterm> if a <tag>p:option</tag> or
+              <tag>p:variable</tag> declared before the subpipeline begins shadows another option or
+            variable declared within the same <tag>p:declare-step</tag>.</error> (Within the
+          subpipeline, variables may shadow options and lexically preceding (non-static) variables.) </para>
 
-<!-- ============================================================ -->
+        <para>The prologue ends with additional <tag>p:declare-step</tag> elements, if any, and is
+          followed by the subpipeline. Any step imported or declared in the prologue of a pipeline
+          may be invoked as a step within the subpipeline of that pipeline.</para>
 
-<section xml:id="p.library">
-<title>p:library</title>
+        <para>The environment inherited by the <glossterm>subpipeline</glossterm> is the
+            <glossterm>empty environment</glossterm> with these modifications:</para>
 
-<para>A <tag>p:library</tag> is a collection of static variables, static options,
-and step declarations.</para>
+        <itemizedlist>
+          <listitem>
+            <para>All of the declared inputs are added to the <glossterm>readable ports</glossterm>
+              in the environment.</para>
+          </listitem>
+          <listitem>
+            <para>If a <glossterm>primary input port</glossterm> is declared, that port is the
+                <glossterm>default readable port</glossterm>, otherwise the default readable port is
+              undefined.</para>
+          </listitem>
+          <listitem>
+            <para>The <glossterm>in-scope bindings</glossterm> at the beginning of a
+                <tag>p:declare-step</tag> are limited to the lexically preceding, statically
+              declared options and variables.</para>
+          </listitem>
+        </itemizedlist>
 
-<e:rng-pattern name="Library"/>
+        <para>If a <glossterm>primary output port</glossterm> is declared and that port has no
+            <glossterm>connection</glossterm>, then it is connected to the <glossterm>primary output
+            port</glossterm> of the <glossterm>last step</glossterm> in the
+            <glossterm>subpipeline</glossterm>. <error code="S0006">It is a <glossterm>static
+              error</glossterm> if the primary output port is unconnected and the <glossterm>last
+              step</glossterm> in the subpipeline does not have a primary output
+          port.</error></para>
+      </section>
 
-<para>The <tag class="attribute">version</tag> attribute identifies the version
-of XProc for which this library was authored. If the
-<tag>p:library</tag>
-has no ancestors in the XProc namespace, then it <rfc2119>must</rfc2119>
-have a <tag class="attribute">version</tag> attribute.
-See <xref linkend="versioning-considerations"/>.</para>
+      <section xml:id="declare-atomic-steps">
+        <title>Declaring atomic steps</title>
 
-<para>The requested <tag class="attribute">xpath-version</tag>
-          <rfc2119>must</rfc2119> be used to evaluate XPath expressions subject to the constraints
-          outlined in <xref linkend="xpath-context"/>. If the attribute is not specified, the value
-          “<literal>3.1</literal>” is assumed. <error code="S0110">It is a 
-            <glossterm>static error</glossterm> if the requested XPath version is less 
-            than “<literal>3.1</literal>”</error>.</para>
-        <para>The <tag class="attribute">psvi-required</tag> attribute allows the author to declare
-          that a step relies on the processor's ability to pass PSVI annotations between steps, see
-            <xref linkend="psvi-support"/>. If the attribute is not specified, the value
-            “<literal>false</literal>” is assumed. </para>
+        <para>The distinction between an atomic step declaration and a pipeline declaration hinges
+          on the presence or absense of a subpipeline. An atomic step declaration does not have a
+          subpipeline. </para>
+
+        <para>Atomic step declarations may not import other pipelines or functions, may not declare
+          static variables, and may not declare additional steps. In other words, the content of an
+          atomic step declaration consists exclusively of <tag>p:input</tag>, <tag>p:output</tag>,
+          and <tag>p:option</tag> elements.</para>
+
+        <e:rng-pattern name="DeclareAtomicStep"/>
+
+        <para><impl>Implementations may use <glossterm baseform="extension attribute">extension
+              attributes</glossterm> to provide <glossterm>implementation-dependent</glossterm>
+            information about a declared step.</impl> For example, such an attribute might identify
+          the code which implements steps of this type.</para>
+
+        <para>It is not an error for a pipeline to include declarations for steps that a particular
+          processor does not know how to implement. It is, of course, an error to attempt to
+          evaluate such steps.</para>
+      </section>
+    </section>
+
+    <!-- ============================================================ -->
+
+    <section xml:id="p.library">
+      <title>p:library</title>
+
+      <para>A <tag>p:library</tag> is a collection of static variables, static options, and step
+        declarations.</para>
+
+      <e:rng-pattern name="Library"/>
+
+      <para>The <tag class="attribute">version</tag> attribute identifies the version of XProc for
+        which this library was authored. If the <tag>p:library</tag> has no ancestors in the XProc
+        namespace, then it <rfc2119>must</rfc2119> have a <tag class="attribute">version</tag>
+        attribute. See <xref linkend="versioning-considerations"/>.</para>
+
+      <para>The requested <tag class="attribute">xpath-version</tag>
+        <rfc2119>must</rfc2119> be used to evaluate XPath expressions subject to the constraints
+        outlined in <xref linkend="xpath-context"/>. If the attribute is not specified, the value
+          “<literal>3.1</literal>” is assumed. <error code="S0110">It is a <glossterm>static
+            error</glossterm> if the requested XPath version is less than
+          “<literal>3.1</literal>”</error>.</para>
+      <para>The <tag class="attribute">psvi-required</tag> attribute allows the author to declare
+        that a step relies on the processor's ability to pass PSVI annotations between steps, see
+          <xref linkend="psvi-support"/>. If the attribute is not specified, the value
+          “<literal>false</literal>” is assumed. </para>
       <para>For a description of <tag class="attribute">psvi-required</tag>, see <xref
           linkend="psvi-support"/>; for <tag class="attribute">xpath-version</tag>, see <xref
           linkend="xpath-context"/>; for <tag class="attribute">exclude-inline-prefixes</tag>, see
           <tag>p:inline</tag>.</para>
 
-<note xml:id="note-step-decl">
+      <note xml:id="note-step-decl">
         <para>The steps declared in a pipeline library are referred to by their type. It is not an
-          error to put a <tag>p:declare-step</tag> without a <tag
-            class="attribute">type</tag> in a <tag>p:library</tag>, but there is no standard
-          mechanism for instantiating it or referring to it. It is effectively invisible.</para>
-      </note><para>Libraries can import pipelines and/or other libraries.
-See also <xref linkend="handling-imports"
-      />.</para></section>
+          error to put a <tag>p:declare-step</tag> without a <tag class="attribute">type</tag> in a
+            <tag>p:library</tag>, but there is no standard mechanism for instantiating it or
+          referring to it. It is effectively invisible.</para>
+      </note>
+      <para>Libraries can import pipelines and/or other libraries. See also <xref
+          linkend="handling-imports"/>.</para>
+    </section>
 
-<!-- ============================================================ -->
+    <!-- ============================================================ -->
 
-<section xml:id="p.import"><title>p:import</title><para>An <tag>p:import</tag> loads a pipeline
-        or pipeline library, making it available in the pipeline or library which contains the
-          <tag>p:import</tag>.</para>
+    <section xml:id="p.import">
+      <title>p:import</title>
+      <para>An <tag>p:import</tag> loads a pipeline or pipeline library, making it available in the
+        pipeline or library which contains the <tag>p:import</tag>.</para>
       <e:rng-pattern name="Import"/>
       <para>An import statement loads the specified IRI and makes any pipelines declared within it
         available to the current pipeline. </para>
-<para><error code="S0052">It is a
-            <glossterm>static error</glossterm> if the URI of a <tag>p:import</tag> cannot be
-          retrieved or if, once retrieved, it does not point to a <tag>p:library</tag> or
-            <tag>p:declare-step</tag>.</error>
+      <para>
+        <error code="S0052">It is a <glossterm>static error</glossterm> if the URI of a
+            <tag>p:import</tag> cannot be retrieved or if, once retrieved, it does not point to a
+            <tag>p:library</tag> or <tag>p:declare-step</tag>.</error>
         <error code="S0053">It is a <glossterm>static error</glossterm> to import a single pipeline
           if that pipeline does not have a <tag class="attribute">type</tag>.</error>
       </para>
-<para>Attempts to retrieve the library identified by the URI value may be redirected at
-        the parser level (for example, in an entity resolver) or below (at the protocol level, for
+      <para>Attempts to retrieve the library identified by the URI value may be redirected at the
+        parser level (for example, in an entity resolver) or below (at the protocol level, for
         example, via an HTTP Location: header). In the absence of additional information outside the
         scope of this specification within the resource, the base URI of the library is always the
         URI of the actual resource returned. In other words, it is the URI of the resource retrieved
         after all redirection has occurred.</para>
-<para>As imports are processed, a processor may
-        encounter new <tag>p:import</tag> elements whose library URI is the same as one it has
-        already processed in some other context. This may happen as a consequence of resolving the
-        URI. If the actual base URI is the same as one that has already been processed, the
-        implementation must recognize it as the same library and should not need to process the
-        resource. Also, a duplicate, circular chain of imports, or a re-entrant import is not an
-        error and implementations must take the necessary steps to avoid infinite loops and/or
-        incorrect notification of duplicate step definitions. It is not an error for a library to
-        import itself. An example of such steps is listed in <xref linkend="handling-imports"
-        />.</para>
-<para>A library is considered the same library if the URI of the resource
-        retrieved is the same. If a pipeline or library author uses two different URI values that
-        resolve to the same resource, they must not be considered the same imported
-        library.</para>
+      <para>As imports are processed, a processor may encounter new <tag>p:import</tag> elements
+        whose library URI is the same as one it has already processed in some other context. This
+        may happen as a consequence of resolving the URI. If the actual base URI is the same as one
+        that has already been processed, the implementation must recognize it as the same library
+        and should not need to process the resource. Also, a duplicate, circular chain of imports,
+        or a re-entrant import is not an error and implementations must take the necessary steps to
+        avoid infinite loops and/or incorrect notification of duplicate step definitions. It is not
+        an error for a library to import itself. An example of such steps is listed in <xref
+          linkend="handling-imports"/>.</para>
+      <para>A library is considered the same library if the URI of the resource retrieved is the
+        same. If a pipeline or library author uses two different URI values that resolve to the same
+        resource, they must not be considered the same imported library.</para>
 
-</section>
+    </section>
 
-<section xml:id="p.import-functions"><title>p:import-functions</title>
+    <section xml:id="p.import-functions">
+      <title>p:import-functions</title>
 
-<para>An <tag>p:import-functions</tag> element identifies a library of externally
-defined functions to be imported into the pipeline. After the functions have been
-imported, they are available in the processor XPath context.</para>
+      <para>An <tag>p:import-functions</tag> element identifies a library of externally defined
+        functions to be imported into the pipeline. After the functions have been imported, they are
+        available in the processor XPath context.</para>
 
-<e:rng-pattern name="ImportFunctions"/>
+      <e:rng-pattern name="ImportFunctions"/>
 
-<variablelist>
-<varlistentry><term><tag class="attribute">href</tag></term>
-<listitem><para>The <tag class="attribute">href</tag> attribute
-identifies the URI of the function library. <error code="S0103">It is
-a <glossterm>static error</glossterm> if the URI of a
-<tag>p:import-functions</tag> element cannot be retrieved or if, once
-retrieved, it points to a library that the processor cannot
-import.</error>
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">content-type</tag></term>
-<listitem>
-<para>The <tag class="attribute">content-type</tag> specifies what kind of library
-is expected at the URI. <impl>If no type is specified, the way that the processor
-determines the type of the library is <glossterm>implementation-defined</glossterm>.</impl>
-</para>
-</listitem>
-</varlistentry>
-<varlistentry><term><tag class="attribute">namespace</tag></term>
-<listitem>
-<para>If a <tag class="attribute">namespace</tag> is specified, it must be a whitespace
-separated list
-of namespace URIs. Only functions
-in those namespaces will be loaded.
-</para>
-</listitem>
-</varlistentry>
-</variablelist>
+      <variablelist>
+        <varlistentry>
+          <term>
+            <tag class="attribute">href</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">href</tag> attribute identifies the URI of the function
+              library. <error code="S0103">It is a <glossterm>static error</glossterm> if the URI of
+                a <tag>p:import-functions</tag> element cannot be retrieved or if, once retrieved,
+                it points to a library that the processor cannot import.</error>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">content-type</tag>
+          </term>
+          <listitem>
+            <para>The <tag class="attribute">content-type</tag> specifies what kind of library is
+              expected at the URI. <impl>If no type is specified, the way that the processor
+                determines the type of the library is
+                <glossterm>implementation-defined</glossterm>.</impl>
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>
+            <tag class="attribute">namespace</tag>
+          </term>
+          <listitem>
+            <para>If a <tag class="attribute">namespace</tag> is specified, it must be a whitespace
+              separated list of namespace URIs. Only functions in those namespaces will be loaded.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
 
-<para>The ability to import functions is optional. <impl>Whether or not a processor
-can import functions, and if it can, what kinds of function libraries it can import
-from is <glossterm>implementation-defined</glossterm>.</impl> Pipeline authors can
-use <function>p:function-library-importable</function> to test whether or not a particular
-kind of library can be loaded.
-</para>
+      <para>The ability to import functions is optional. <impl>Whether or not a processor can import
+          functions, and if it can, what kinds of function libraries it can import from is
+            <glossterm>implementation-defined</glossterm>.</impl> Pipeline authors can use
+          <function>p:function-library-importable</function> to test whether or not a particular
+        kind of library can be loaded. </para>
 
-<para>Importing functions from a library implies loading and processing that library
-according to its conventions (loading imports, resolving dependencies, etc.).
-<error code="S0104">It is a <glossterm>static error</glossterm> if the processor
-cannot load the function library.</error> This may occur because the format is
-unknown, because it is a version of the library that the processor does
-not recognize, or if it’s uninterpretable for any other reason.
-<error code="S0106">It is a
-<glossterm>static error</glossterm> if the processor detects that a
-particular library is unloadable.</error> This may occur
-if the processor is, in principle, able to load libraries of the specified format,
-but detects that the particuar library requested is somehow ill-formed
-(syntactically invalid, has unsatisfiable dependencies or circular
-imports, etc.).
-</para>
+      <para>Importing functions from a library implies loading and processing that library according
+        to its conventions (loading imports, resolving dependencies, etc.). <error code="S0104">It
+          is a <glossterm>static error</glossterm> if the processor cannot load the function
+          library.</error> This may occur because the format is unknown, because it is a version of
+        the library that the processor does not recognize, or if it’s uninterpretable for any other
+        reason. <error code="S0106">It is a <glossterm>static error</glossterm> if the processor
+          detects that a particular library is unloadable.</error> This may occur if the processor
+        is, in principle, able to load libraries of the specified format, but detects that the
+        particuar library requested is somehow ill-formed (syntactically invalid, has unsatisfiable
+        dependencies or circular imports, etc.). </para>
 
-<para>Imported functions must be unique (they must not have the same name, namespace, and
-arity). <error code="S0105">It is a <glossterm>static error</glossterm> if a function
-imported from a library has the same name and arity as a function already imported.</error>
-</para>
+      <para>Imported functions must be unique (they must not have the same name, namespace, and
+        arity). <error code="S0105">It is a <glossterm>static error</glossterm> if a function
+          imported from a library has the same name and arity as a function already
+          imported.</error>
+      </para>
 
 
-</section>
+    </section>
 
-<!-- ============================================================ -->
-<section xml:id="p.pipe">
-<title>p:pipe</title>
+    <!-- ============================================================ -->
+    <section xml:id="p.pipe">
+      <title>p:pipe</title>
 
-<para>A <tag>p:pipe</tag> connects an input to a port on another
-step.</para>
+      <para>A <tag>p:pipe</tag> connects an input to a port on another step.</para>
 
-<e:rng-pattern name="Pipe"/>
+      <e:rng-pattern name="Pipe"/>
 
-<para>The <tag>p:pipe</tag> element connects to a readable port of
-another step. It identifies the readable port to which it connects
-with the name of the step in the <tag class="attribute">step</tag>
-attribute and the name of the port on that step in the
-<tag class="attribute">port</tag> attribute. <error code="S0099">It
-is a <glossterm>static error</glossterm> if <tag class="attribute">step</tag> 
-or <tag class="attribute">port</tag> are not valid instances of 
-<literal>NCName</literal>.</error></para>
+      <para>The <tag>p:pipe</tag> element connects to a readable port of another step. It identifies
+        the readable port to which it connects with the name of the step in the <tag
+          class="attribute">step</tag> attribute and the name of the port on that step in the <tag
+          class="attribute">port</tag> attribute. <error code="S0099">It is a <glossterm>static
+            error</glossterm> if <tag class="attribute">step</tag> or <tag class="attribute"
+            >port</tag> are not valid instances of <literal>NCName</literal>.</error></para>
 
-<para>If the <tag class="attribute">step</tag> attribute is not specified,
-it defaults to the step which provides the default readable port.
-If the <tag class="attribute">port</tag> attribute is not specified,
-it defaults to the primary output port of the step identified (explicitly
-or implicitly).</para>
+      <para>If the <tag class="attribute">step</tag> attribute is not specified, it defaults to the
+        step which provides the default readable port. If the <tag class="attribute">port</tag>
+        attribute is not specified, it defaults to the primary output port of the step identified
+        (explicitly or implicitly).</para>
 
-<para>
-<error code="S0067">It is a <glossterm>static error</glossterm> if the
-<tag class="attribute">step</tag> attribute is not specified, and there
-is no default readable port.
-<error code="S0068">It is a <glossterm>static error</glossterm> if the
-<tag class="attribute">port</tag> attribute is not specified, and the
-step identified has no primary output port.</error>
-</error></para>
+      <para>
+        <error code="S0067">It is a <glossterm>static error</glossterm> if the <tag
+            class="attribute">step</tag> attribute is not specified, and there is no default
+          readable port. <error code="S0068">It is a <glossterm>static error</glossterm> if the <tag
+              class="attribute">port</tag> attribute is not specified, and the step identified has
+            no primary output port.</error>
+        </error>
+      </para>
 
-<para><error code="S0022">In all cases except when the
-<tag>p:pipe</tag> is within an <tag>p:output</tag> of a
-<glossterm>compound step</glossterm>, it is a <glossterm>static
-error</glossterm> if the port identified by the <tag>p:pipe</tag> is not
-in the <glossterm>readable ports</glossterm> of the step that contains
-the <tag>p:pipe</tag>.</error></para>
+      <para>
+        <error code="S0022">In all cases except when the <tag>p:pipe</tag> is within an
+            <tag>p:output</tag> of a <glossterm>compound step</glossterm>, it is a <glossterm>static
+            error</glossterm> if the port identified by the <tag>p:pipe</tag> is not in the
+            <glossterm>readable ports</glossterm> of the step that contains the
+          <tag>p:pipe</tag>.</error>
+      </para>
 
-<para>A <tag>p:pipe</tag> that is a <glossterm>connection</glossterm>
-for an <tag>p:output</tag> of a <glossterm>compound step</glossterm>
-may connect to one of the readable ports of the compound step or to an
-output port on one of the compound step's <glossterm>contained
-steps</glossterm>. In other words, the output of a compound step can
-simply be a copy of one of the available inputs or it can be the
-output of one of its children.</para>
+      <para>A <tag>p:pipe</tag> that is a <glossterm>connection</glossterm> for an
+          <tag>p:output</tag> of a <glossterm>compound step</glossterm> may connect to one of the
+        readable ports of the compound step or to an output port on one of the compound step's
+          <glossterm>contained steps</glossterm>. In other words, the output of a compound step can
+        simply be a copy of one of the available inputs or it can be the output of one of its
+        children.</para>
 
-<para><error code="S0078">When the <tag>p:pipe</tag> is within an
-<tag>p:output</tag> of a <glossterm>compound step</glossterm>, it is a
-<glossterm>static error</glossterm> if the port identified by the
-<tag>p:pipe</tag> is not in the <glossterm>readable ports</glossterm>
-of the compound step and is not a readable port of a contained
-step.</error>
-</para>
+      <para>
+        <error code="S0078">When the <tag>p:pipe</tag> is within an <tag>p:output</tag> of a
+            <glossterm>compound step</glossterm>, it is a <glossterm>static error</glossterm> if the
+          port identified by the <tag>p:pipe</tag> is not in the <glossterm>readable
+            ports</glossterm> of the compound step and is not a readable port of a contained
+          step.</error>
+      </para>
 
-</section>
+    </section>
 
-<section xml:id="p.inline">
-<title>p:inline</title>
+    <section xml:id="p.inline">
+      <title>p:inline</title>
 
-<para>A <tag>p:inline</tag> provides a document inline.</para>
+      <para>A <tag>p:inline</tag> provides a document inline.</para>
 
-<e:rng-pattern name="Inline"/>
+      <e:rng-pattern name="Inline"/>
 
-<para>The <tag class="attribute">content-type</tag> attribute can be used
-to set the content type of the provided document;
-the <tag class="attribute">document-properties</tag> attribute
-can be used to set the <glossterm>document properties</glossterm> of
-the provided document.</para>
+      <para>The <tag class="attribute">content-type</tag> attribute can be used to set the content
+        type of the provided document; the <tag class="attribute">document-properties</tag>
+        attribute can be used to set the <glossterm>document properties</glossterm> of the provided
+        document.</para>
 
-<para>The document's content type is determined statically.
-If a <tag class="attribute">content-type</tag> is specified, that is the
-content type. Otherwise, the content type is
-“<literal>application/xml</literal>”.
-</para>
+      <para>The document's content type is determined statically. If a <tag class="attribute"
+          >content-type</tag> is specified, that is the content type. Otherwise, the content type is
+          “<literal>application/xml</literal>”. </para>
 
-<para><error code="D0062">It is a <glossterm>dynamic error</glossterm> if
-the <tag class="attribute">document-properties</tag> map contains a
-<literal>content-type</literal> key and that key has a value that differs
-from the statically determined content type.</error></para>
+      <para>
+        <error code="D0062">It is a <glossterm>dynamic error</glossterm> if the <tag
+            class="attribute">document-properties</tag> map contains a
+            <literal>content-type</literal> key and that key has a value that differs from the
+          statically determined content type.</error>
+      </para>
 
-<para>The base URI of the document is the base URI of the
-<tag>p:inline</tag> element.</para>
+      <para>The base URI of the document is the base URI of the <tag>p:inline</tag> element.</para>
 
-<para>How the content of a <tag>p:inline</tag>
-element is interpreted depends on the document's content type and the
-<tag class="attribute">encoding</tag> attribute.
-</para>
+      <para>How the content of a <tag>p:inline</tag> element is interpreted depends on the
+        document's content type and the <tag class="attribute">encoding</tag> attribute. </para>
 
-<para><error code="D0054">It is a
-<glossterm>dynamic error</glossterm> if an encoding is specified
-and the content type is an <glossterm>XML media type</glossterm> or
-  an <glossterm>HTML media type</glossterm>.</error>
-</para>
+      <para>
+        <error code="D0054">It is a <glossterm>dynamic error</glossterm> if an encoding is specified
+          and the content type is an <glossterm>XML media type</glossterm> or an <glossterm>HTML
+            media type</glossterm>.</error>
+      </para>
 
-<para><error code="D0055">It is a <glossterm>dynamic error</glossterm>
-if the content type value specifies a character set and the <tag
-class="attribute">encoding</tag> attribute is absent.</error>
-</para>
+      <para>
+        <error code="D0055">It is a <glossterm>dynamic error</glossterm> if the content type value
+          specifies a character set and the <tag class="attribute">encoding</tag> attribute is
+          absent.</error>
+      </para>
 
-<para><error code="D0039">It is a <glossterm>dynamic error</glossterm>
-if the <tag class="attribute">encoding</tag> attribute is present and
-content type value specifies a character set that is not supported by
-the implementation.</error>
-</para>
+      <para>
+        <error code="D0039">It is a <glossterm>dynamic error</glossterm> if the <tag
+            class="attribute">encoding</tag> attribute is present and content type value specifies a
+          character set that is not supported by the implementation.</error>
+      </para>
 
-<para><error code="D0056">It is a <glossterm>dynamic error</glossterm>
-if an encoding is specified and the content of the <tag>p:inline</tag>
-contains any XML markup.</error>
-<error code="D0063">It is a <glossterm>dynamic error</glossterm>
-if the <tag>p:inline</tag> contains any XML markup and has a
-content type that is not an <glossterm>XML media type</glossterm> or
-  an <glossterm>HTML media type</glossterm>.</error>
-In other words, in these cases, the entire content
-must be a single text node. CDATA sections and character references do
-not count as markup for this purpose because they will already have
-been replaced by the XML parser that read the pipeline.</para>
+      <para><error code="D0056">It is a <glossterm>dynamic error</glossterm> if an encoding is
+          specified and the content of the <tag>p:inline</tag> contains any XML markup.</error>
+        <error code="D0063">It is a <glossterm>dynamic error</glossterm> if the <tag>p:inline</tag>
+          contains any XML markup and has a content type that is not an <glossterm>XML media
+            type</glossterm> or an <glossterm>HTML media type</glossterm>.</error> In other words,
+        in these cases, the entire content must be a single text node. CDATA sections and character
+        references do not count as markup for this purpose because they will already have been
+        replaced by the XML parser that read the pipeline.</para>
 
-<para>If the <tag class="attribute">encoding</tag> attribute is
-present, the content must be decoded. The encoding value
-“<literal>base64</literal>” <rfc2119>must</rfc2119> be supported and
-identifies the content as being base64-encoded.
-<impl>An implementation may
-support encodings other than <literal>base64</literal>, but these
-encodings and their names are
-<glossterm>implementation-defined</glossterm>.</impl>
-<error code="S0069">It is a <glossterm>static error</glossterm> if the
-encoding specified is not supported by the implementation.</error>
-<error code="D0040">It is a <glossterm>dynamic error</glossterm> if
-the body is not correctly encoded per the value of the <tag
-class="attribute">encoding</tag> attribute.</error>
-</para>
+      <para>If the <tag class="attribute">encoding</tag> attribute is present, the content must be
+        decoded. The encoding value “<literal>base64</literal>” <rfc2119>must</rfc2119> be supported
+        and identifies the content as being base64-encoded. <impl>An implementation may support
+          encodings other than <literal>base64</literal>, but these encodings and their names are
+            <glossterm>implementation-defined</glossterm>.</impl>
+        <error code="S0069">It is a <glossterm>static error</glossterm> if the encoding specified is
+          not supported by the implementation.</error>
+        <error code="D0040">It is a <glossterm>dynamic error</glossterm> if the body is not
+          correctly encoded per the value of the <tag class="attribute">encoding</tag>
+          attribute.</error>
+      </para>
 
-<para>If an <tag class="attribute">encoding</tag> attribute is present,
-value templates are never expanded. The value of
-<tag class="attribute">[p:]expand-text</tag> is irrelevant and always ignored.</para>
+      <para>If an <tag class="attribute">encoding</tag> attribute is present, value templates are
+        never expanded. The value of <tag class="attribute">[p:]expand-text</tag> is irrelevant and
+        always ignored.</para>
 
-<para>The interpretation of the (possibily decoded) content
-depends on the document's content type.
-</para>
-  <note>
-    <para>In the presence of
-      <glossterm baseform="text value template">text value templates</glossterm>, it is not possible to
-      interpret the non-XML characters until the templates have been
-      expanded.</para>
-  </note>
-  
-  <section xml:id="inline-xml-content">
-    <title>Inline XML and HTML content</title>
-    
-    <para>If <tag class="attribute">content-type</tag> is not
-      specified or specifies
-      an <glossterm>XML media type</glossterm> or an <glossterm>HTML media type</glossterm>, then
-      the content is XML. A new XML document is created by wrapping a document node
-      around the nodes which appear as children of <tag>p:inline</tag>.</para>
-    
-    <para>The in-scope namespaces of the inline document differ from the
-      in-scope namespace of the content of the <tag>p:inline</tag> element
-      in that bindings for all its <emphasis>excluded namespaces</emphasis>,
-      as defined below, are removed:</para>
-    
-    <itemizedlist>
-      <listitem>
-        <para>The XProc namespace itself (<uri>http://www.w3.org/ns/xproc</uri>) is
-          excluded.</para>
-      </listitem>
-      <listitem>
-        <para>A namespace URI designated by using an <tag class="attribute"
-          >exclude-inline-prefixes</tag> attribute on the enclosing <tag>p:inline</tag> is
-          excluded.</para>
-      </listitem>
-      <listitem>
-        <para>A namespace URI designated by using an <tag class="attribute"
-          >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag> or <tag>p:library</tag> is also excluded. (In other words, the
-          effect of several <tag class="attribute">exclude-inline-prefixes</tag> attributes among
-          the ancestors of <tag>p:inline</tag> is cumulative.)</para>
-      </listitem>
-    </itemizedlist>
-    
-    <para>The value of each prefix in the <tag
-      class="attribute">exclude-inline-prefixes</tag> attribute is
-      interpreted as follows:</para>
-    
-    <itemizedlist>
-      <listitem>
-        <para>The value of the attribute is either <literal>#all</literal>, or
-          a whitespace-separated list of tokens, each of which is either a
-          namespace prefix or <literal>#default</literal>. The namespace bound
-          to each of the prefixes is designated as an excluded namespace. <error
-            code="S0057">It is a <glossterm>static error</glossterm> if the <tag
-              class="attribute" >exclude-inline-prefixes</tag> attribute does not
-            contain a list of tokens or if any of those tokens (except
-            <literal>#all</literal> or <literal>#default</literal>) is not a
-            prefix bound to a namespace in the in-scope namespaces of the element
-            on which it occurs.</error></para>
-      </listitem>
-      <listitem>
-        <para>The default namespace of the element on which <tag
-          class="attribute">exclude-inline-prefixes</tag> occurs may be
-          designated as an excluded namespace by including
-          <literal>#default</literal> in the list of namespace prefixes. <error
-            code="S0058">It is a <glossterm>static error</glossterm> if the value
-            <literal>#default</literal> is used within the <tag class="attribute"
-              >exclude-inline-prefixes</tag> attribute and there is no default
-            namespace in scope.</error>
-        </para>
-      </listitem>
-      <listitem>
-        <para>The value <literal>#all</literal> indicates that all namespaces
-          that are in scope for the element on which <tag
-            class="attribute">exclude-inline-prefixes</tag> occurs are designated
-          as excluded namespaces.</para>
-      </listitem>
-    </itemizedlist>
-    
-    <para>The XProc processor <rfc2119>must</rfc2119> include all in-scope
-      prefixes that are not explicitly excluded. If the namespace associated with
-      an excluded prefix is used in the expanded-QName of a descendant
-      element or attribute,
-      the processor <rfc2119>may</rfc2119> include that prefix anyway, or it may
-      generate a new prefix.</para>
-    
-    <para>Consider this example:</para>
-    
-    <programlisting language="xml"><xi:include href="../../../build/examples/exclude-pfx.txt" parse="text"/></programlisting>
-    
-    <para>which might produce a result like this:</para>
-    
-    <programlisting language="xml"><![CDATA[ 
+      <para>The interpretation of the (possibily decoded) content depends on the document's content
+        type. </para>
+      <note>
+        <para>In the presence of <glossterm baseform="text value template">text value
+            templates</glossterm>, it is not possible to interpret the non-XML characters until the
+          templates have been expanded.</para>
+      </note>
+
+      <section xml:id="inline-xml-content">
+        <title>Inline XML and HTML content</title>
+
+        <para>If <tag class="attribute">content-type</tag> is not specified or specifies an
+            <glossterm>XML media type</glossterm> or an <glossterm>HTML media type</glossterm>, then
+          the content is XML. A new XML document is created by wrapping a document node around the
+          nodes which appear as children of <tag>p:inline</tag>.</para>
+
+        <para>The in-scope namespaces of the inline document differ from the in-scope namespace of
+          the content of the <tag>p:inline</tag> element in that bindings for all its
+            <emphasis>excluded namespaces</emphasis>, as defined below, are removed:</para>
+
+        <itemizedlist>
+          <listitem>
+            <para>The XProc namespace itself (<uri>http://www.w3.org/ns/xproc</uri>) is
+              excluded.</para>
+          </listitem>
+          <listitem>
+            <para>A namespace URI designated by using an <tag class="attribute"
+                >exclude-inline-prefixes</tag> attribute on the enclosing <tag>p:inline</tag> is
+              excluded.</para>
+          </listitem>
+          <listitem>
+            <para>A namespace URI designated by using an <tag class="attribute"
+                >exclude-inline-prefixes</tag> attribute on any ancestor <tag>p:declare-step</tag>
+              or <tag>p:library</tag> is also excluded. (In other words, the effect of several <tag
+                class="attribute">exclude-inline-prefixes</tag> attributes among the ancestors of
+                <tag>p:inline</tag> is cumulative.)</para>
+          </listitem>
+        </itemizedlist>
+
+        <para>The value of each prefix in the <tag class="attribute">exclude-inline-prefixes</tag>
+          attribute is interpreted as follows:</para>
+
+        <itemizedlist>
+          <listitem>
+            <para>The value of the attribute is either <literal>#all</literal>, or a
+              whitespace-separated list of tokens, each of which is either a namespace prefix or
+                <literal>#default</literal>. The namespace bound to each of the prefixes is
+              designated as an excluded namespace. <error code="S0057">It is a <glossterm>static
+                  error</glossterm> if the <tag class="attribute">exclude-inline-prefixes</tag>
+                attribute does not contain a list of tokens or if any of those tokens (except
+                  <literal>#all</literal> or <literal>#default</literal>) is not a prefix bound to a
+                namespace in the in-scope namespaces of the element on which it
+              occurs.</error></para>
+          </listitem>
+          <listitem>
+            <para>The default namespace of the element on which <tag class="attribute"
+                >exclude-inline-prefixes</tag> occurs may be designated as an excluded namespace by
+              including <literal>#default</literal> in the list of namespace prefixes. <error
+                code="S0058">It is a <glossterm>static error</glossterm> if the value
+                  <literal>#default</literal> is used within the <tag class="attribute"
+                  >exclude-inline-prefixes</tag> attribute and there is no default namespace in
+                scope.</error>
+            </para>
+          </listitem>
+          <listitem>
+            <para>The value <literal>#all</literal> indicates that all namespaces that are in scope
+              for the element on which <tag class="attribute">exclude-inline-prefixes</tag> occurs
+              are designated as excluded namespaces.</para>
+          </listitem>
+        </itemizedlist>
+
+        <para>The XProc processor <rfc2119>must</rfc2119> include all in-scope prefixes that are not
+          explicitly excluded. If the namespace associated with an excluded prefix is used in the
+          expanded-QName of a descendant element or attribute, the processor <rfc2119>may</rfc2119>
+          include that prefix anyway, or it may generate a new prefix.</para>
+
+        <para>Consider this example:</para>
+
+        <programlisting language="xml"><xi:include href="../../../build/examples/exclude-pfx.txt" parse="text"/></programlisting>
+
+        <para>which might produce a result like this:</para>
+
+        <programlisting language="xml"><![CDATA[ 
         <doc xmlns:c="http://example.com/c">
            <b:part xmlns:b="http://example.com/b"/>
         </doc>
  ]]></programlisting>
-    
-    <para>The declaration for “<literal>c</literal>” must
-      be present because it was not excluded. The “<literal>part</literal>” element
-      uses the namespace bound to “<literal>b</literal>”, so <emphasis>some</emphasis>
-      binding must be present. In this example, the original
-      prefix has been preserved, but it would be equally correct if a different
-      prefix had been used.</para>
-    
-    <para>The text-node descendants of a <tag>p:inline</tag> may be
-      <link linkend="text-value-templates">text value templates</link>. Attribute descendants may be <link
-        linkend="attribute-value-templates">attribute value templates</link>. This is controlled by the
-      <tag class="attribute">[p:]expand-text</tag> and the <tag class="attribute">p:inline-expand-text</tag> attribute. See
-      <xref linkend="expand-text-attribute"/>.</para>
-    
-  </section>
 
-<section xml:id="inline-text">
-<title>Inline text content</title>
+        <para>The declaration for “<literal>c</literal>” must be present because it was not
+          excluded. The “<literal>part</literal>” element uses the namespace bound to
+            “<literal>b</literal>”, so <emphasis>some</emphasis> binding must be present. In this
+          example, the original prefix has been preserved, but it would be equally correct if a
+          different prefix had been used.</para>
 
-<para>If the document's content type is a <glossterm>text media
-  type</glossterm>, then the content is text. A new text document is created by 
-  joining the text nodes which appear as children of p:inline together to a single
-  text node and wrapping a document node around it. Any preceding or following whitespace-only 
-  text nodes will be preserved.</para>
+        <para>The text-node descendants of a <tag>p:inline</tag> may be <link
+            linkend="text-value-templates">text value templates</link>. Attribute descendants may be
+            <link linkend="attribute-value-templates">attribute value templates</link>. This is
+          controlled by the <tag class="attribute">[p:]expand-text</tag> and the <tag
+            class="attribute">p:inline-expand-text</tag> attribute. See <xref
+            linkend="expand-text-attribute"/>.</para>
 
-</section>
+      </section>
 
-<section xml:id="inline-json">
-  <title>Inline JSON content</title>
-  
-<para>If the document's content type is a <glossterm>JSON media type</glossterm>,
-then the context is JSON. A new JSON document is created by joining the 
-text values of children of p:inline together and parse it as JSON.</para>
-  
-<para><error code="D0057">It is a <glossterm>dynamic error</glossterm> if the text content
-    does not conform to the JSON grammar.</error></para>
-  
-</section>
+      <section xml:id="inline-text">
+        <title>Inline text content</title>
 
-<section xml:id="inline-others">
-  <title>Other inline content</title>
-  <para><impl>How a processor interprets other media types is <glossterm>implementation-defined</glossterm>.
-  </impl></para>
-</section>
-  
-<section xml:id="implicit-inlines">
-<title>Implicit inlines</title>
+        <para>If the document's content type is a <glossterm>text media type</glossterm>, then the
+          content is text. A new text document is created by joining the text nodes which appear as
+          children of p:inline together to a single text node and wrapping a document node around
+          it. Any preceding or following whitespace-only text nodes will be preserved.</para>
 
-<para>As an authoring convenience, <tag>p:inline</tag> may be omitted
-if one or more element nodes, optionally preceded and/or followed by
-whitespace occurs where a <tag>p:inline</tag> is allowed. Whitespace
-around each element is ignored and the element is treated as if it was
-enclosed within a <tag>p:inline</tag> element (with no attributes).
-Elements in the XProc namespace are forbidden except for
-<tag>p:documentation</tag> and <tag>p:pipeinfo</tag> which are
-ignored.
-</para>
+      </section>
 
-<para>The following example demonstrates this implicit behaviour:</para>
+      <section xml:id="inline-json">
+        <title>Inline JSON content</title>
 
-<programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline1">
+        <para>If the document's content type is a <glossterm>JSON media type</glossterm>, then the
+          context is JSON. A new JSON document is created by joining the text values of children of
+          p:inline together and parse it as JSON.</para>
+
+        <para>
+          <error code="D0057">It is a <glossterm>dynamic error</glossterm> if the text content does
+            not conform to the JSON grammar.</error>
+        </para>
+
+      </section>
+
+      <section xml:id="inline-others">
+        <title>Other inline content</title>
+        <para>
+          <impl>How a processor interprets other media types is
+              <glossterm>implementation-defined</glossterm>. </impl>
+        </para>
+      </section>
+
+      <section xml:id="implicit-inlines">
+        <title>Implicit inlines</title>
+
+        <para>As an authoring convenience, <tag>p:inline</tag> may be omitted if one or more element
+          nodes, optionally preceded and/or followed by whitespace occurs where a
+            <tag>p:inline</tag> is allowed. Whitespace around each element is ignored and the
+          element is treated as if it was enclosed within a <tag>p:inline</tag> element (with no
+          attributes). Elements in the XProc namespace are forbidden except for
+            <tag>p:documentation</tag> and <tag>p:pipeinfo</tag> which are ignored. </para>
+
+        <para>The following example demonstrates this implicit behaviour:</para>
+
+        <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline1">
     <p:with-input port="source">
         <para xmlns="http://docbook.org/ns/docbook">Some text</para>
         <para xmlns="http://docbook.org/ns/docbook">Some other text</para>
     </p:with-input>
 </p:identity>]]></programlisting>
 
-<para>Is interpreted as follows:</para>
+        <para>Is interpreted as follows:</para>
 
-<programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline2">
+        <programlisting language="xml"><![CDATA[<p:identity name="identity" code="my:implicitinline2">
     <p:with-input port="source">
         <p:inline><para xmlns="http://docbook.org/ns/docbook">Some text</para></p:inline>
         <p:inline><para xmlns="http://docbook.org/ns/docbook">Some other text</para></p:inline>
     </p:with-input>
 </p:identity>]]></programlisting>
 
-<para>An explicit <tag>p:inline</tag> is required if the author
-wants to include top level comments, processing instructions, or whitespace,
-or if the document element is in the XProc namespace.</para>
+        <para>An explicit <tag>p:inline</tag> is required if the author wants to include top level
+          comments, processing instructions, or whitespace, or if the document element is in the
+          XProc namespace.</para>
 
-<para><error code="S0079">It is a <glossterm>static error</glossterm>
-if comments, non-whitespace text nodes, or processing instructions occur as siblings of an element node
-that would be treated as an implicit inline.</error>
-</para>
-</section>
-</section>
+        <para>
+          <error code="S0079">It is a <glossterm>static error</glossterm> if comments,
+            non-whitespace text nodes, or processing instructions occur as siblings of an element
+            node that would be treated as an implicit inline.</error>
+        </para>
+      </section>
+    </section>
 
-<section xml:id="p.document">
-<title>p:document</title>
+    <section xml:id="p.document">
+      <title>p:document</title>
 
-<para>A <tag>p:document</tag> reads a document from a URI.</para>
+      <para>A <tag>p:document</tag> reads a document from a URI.</para>
 
-<e:rng-pattern name="Document"/>
+      <e:rng-pattern name="Document"/>
 
-<para>The value of the <tag class="attribute">href</tag> attribute,
-after expanding any <glossterm baseform="attribute value
-template">attribute value templates</glossterm>, is a URI.
-<error code="D0064">It is a <glossterm>dynamic error</glossterm> if
-the URI is not a valid <type>xs:anyURI</type>.</error> The URI is
-interpreted as an IRI reference. If it is relative, it is made
-absolute against the base URI of the <tag>p:document</tag> element.
-</para>
+      <para>The value of the <tag class="attribute">href</tag> attribute, after expanding any
+          <glossterm baseform="attribute value
+template">attribute value templates</glossterm>, is a
+        URI. <error code="D0064">It is a <glossterm>dynamic error</glossterm> if the URI is not a
+          valid <type>xs:anyURI</type>.</error> The URI is interpreted as an IRI reference. If it is
+        relative, it is made absolute against the base URI of the <tag>p:document</tag> element. </para>
 
-<para>The semantics of <tag>p:document</tag> are the same as a the
-semantics of <tag>p:load</tag> where the <option>href</option> option
-is the URI, the
-<option>content-type</option> option comes from
-<tag class="attribute">content-type</tag> attribute, the
-<option>document-properties</option> option comes from the
-<tag class="attribute">document-properties</tag> attribute, and the
-<option>parameters</option> option comes from the
-<tag class="attribute">parameters</tag> attribute.
-</para>
+      <para>The semantics of <tag>p:document</tag> are the same as a the semantics of
+          <tag>p:load</tag> where the <option>href</option> option is the URI, the
+          <option>content-type</option> option comes from <tag class="attribute">content-type</tag>
+        attribute, the <option>document-properties</option> option comes from the <tag
+          class="attribute">document-properties</tag> attribute, and the <option>parameters</option>
+        option comes from the <tag class="attribute">parameters</tag> attribute. </para>
 
-<note xml:id="note-document"><para>A <tag>p:document</tag> always <emphasis>reads</emphasis> from
-the specified IRI. In the context of a <tag>p:input</tag> or <tag>p:with-input</tag>,
-this seems
-perfectly natural. In the context of a <tag>p:output</tag>, this may
-seem a little asymmetrical. Putting a <tag>p:document</tag> in a
-<tag>p:output</tag> causes the pipeline to <emphasis>read</emphasis>
-from the specified IRI and provide that document <emphasis>as an
-output</emphasis> on that port. </para><para>Use <tag>p:store</tag> to store the results that appear on a
-<tag>p:output</tag>.</para></note>
-</section>
+      <note xml:id="note-document">
+        <para>A <tag>p:document</tag> always <emphasis>reads</emphasis> from the specified IRI. In
+          the context of a <tag>p:input</tag> or <tag>p:with-input</tag>, this seems perfectly
+          natural. In the context of a <tag>p:output</tag>, this may seem a little asymmetrical.
+          Putting a <tag>p:document</tag> in a <tag>p:output</tag> causes the pipeline to
+            <emphasis>read</emphasis> from the specified IRI and provide that document <emphasis>as
+            an output</emphasis> on that port. </para>
+        <para>Use <tag>p:store</tag> to store the results that appear on a
+          <tag>p:output</tag>.</para>
+      </note>
+    </section>
 
-<section xml:id="p.empty">
-<title>p:empty</title>
-<para>A <tag>p:empty</tag> connects to an <glossterm>empty
-sequence</glossterm> of documents.</para>
+    <section xml:id="p.empty">
+      <title>p:empty</title>
+      <para>A <tag>p:empty</tag> connects to an <glossterm>empty sequence</glossterm> of
+        documents.</para>
 
-<e:rng-pattern name="Empty"/>
+      <e:rng-pattern name="Empty"/>
 
-<para>If an empty binding is used, it must be the only binding for the
-port. <error code="S0089">It is a <glossterm>static error</glossterm>
-if the <tag>p:empty</tag> binding appears as a sibling of any other binding,
-including itself.</error></para>
-</section>
+      <para>If an empty binding is used, it must be the only binding for the port. <error
+          code="S0089">It is a <glossterm>static error</glossterm> if the <tag>p:empty</tag> binding
+          appears as a sibling of any other binding, including itself.</error></para>
+    </section>
 
-    <section xml:id="p.documentation"><title>p:documentation</title><para>A
-          <tag>p:documentation</tag> contains human-readable documentation.</para>
+    <section xml:id="p.documentation">
+      <title>p:documentation</title>
+      <para>A <tag>p:documentation</tag> contains human-readable documentation.</para>
       <e:rng-pattern name="Documentation"/>
       <para>There are no constraints on the content of the <tag>p:documentation</tag> element.
         Documentation is ignored by pipeline processors. See <xref linkend="documentation"/>.
-      </para></section>
+      </para>
+    </section>
 
-    <section xml:id="p.pipeinfo"><title>p:pipeinfo</title><para>A <tag>p:pipeinfo</tag> contains
-        ancillary information for steps in the pipeline.</para>
+    <section xml:id="p.pipeinfo">
+      <title>p:pipeinfo</title>
+      <para>A <tag>p:pipeinfo</tag> contains ancillary information for steps in the pipeline.</para>
       <e:rng-pattern name="PipeInfo"/>
       <para>There are no constraints on the content of the <tag>p:pipeinfo</tag> element, see <link
-          linkend="annotations"/>.</para></section>
+          linkend="annotations"/>.</para>
     </section>
+  </section>
   <section xml:id="errors">
     <title>Errors</title>
     <para>Errors in a pipeline can be divided into two classes: static errors and dynamic
@@ -6361,59 +6197,48 @@ including itself.</error></para>
       <title>Static Errors</title>
       <para><termdef xml:id="dt-static-error">A <firstterm>static error</firstterm> is one which can
           be detected before pipeline evaluation is even attempted.</termdef> Examples of static
-        errors include cycles in the pipeline graph
-        and incorrect specification of inputs and outputs. </para>
+        errors include cycles in the pipeline graph and incorrect specification of inputs and
+        outputs. </para>
       <para>Static errors are fatal and must be detected before any steps are evaluated.</para>
       <para>For a complete list of static errors, see <xref linkend="app.static-errors"/>.</para>
     </section>
     <section xml:id="dynamic-errors">
       <title>Dynamic Errors</title>
 
-      <para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic
-      error</firstterm> is one which occurs while a pipeline is being
-      evaluated (and cannot be detected before evaluation begins).</termdef>
-      Examples of dynamic errors include
-      references to URIs that cannot be resolved, steps which fail,
-      and pipelines that exhaust the capacity of an implementation
-      (such as memory or disk space).</para>
+      <para><termdef xml:id="dt-dynamic-error">A <firstterm>dynamic error</firstterm> is one which
+          occurs while a pipeline is being evaluated (and cannot be detected before evaluation
+          begins).</termdef> Examples of dynamic errors include references to URIs that cannot be
+        resolved, steps which fail, and pipelines that exhaust the capacity of an implementation
+        (such as memory or disk space).</para>
 
-<para>Implementations are required to evaluate the pipeline graph
-according to the rules of this specification, but they may choose to
-optimize pipeline execution in different ways. This may cause steps to
-be evaluated in different orders which consequently has an impact on
-error detection.
-<impl>The detection of dynamic errors is somewhat
-<glossterm>implementation-dependent</glossterm> because the order of
-step execution may vary.</impl> In cases where an implementation
-is able to run a pipeline without evaluating a particular expression,
-or running a particular step, the implementation is never
-required evaluate the expression or run the step solely in order to determine
-whether doing so causes a dynamic error. For example, if a variable is
-declared but never referenced, an implementation may choose whether or
-not to evaluate the expression which initializes the variable, which means that if
-evaluating the variable’s initializer causes a dynamic error, some
-implementations will signal this error and others will not.</para>
+      <para>Implementations are required to evaluate the pipeline graph according to the rules of
+        this specification, but they may choose to optimize pipeline execution in different ways.
+        This may cause steps to be evaluated in different orders which consequently has an impact on
+        error detection. <impl>The detection of dynamic errors is somewhat
+            <glossterm>implementation-dependent</glossterm> because the order of step execution may
+          vary.</impl> In cases where an implementation is able to run a pipeline without evaluating
+        a particular expression, or running a particular step, the implementation is never required
+        evaluate the expression or run the step solely in order to determine whether doing so causes
+        a dynamic error. For example, if a variable is declared but never referenced, an
+        implementation may choose whether or not to evaluate the expression which initializes the
+        variable, which means that if evaluating the variable’s initializer causes a dynamic error,
+        some implementations will signal this error and others will not.</para>
 
-<para>There are some cases where this specification requires that
-steps must not be executed: for example, the content of a <tag>p:when</tag>
-<rfc2119>must not</rfc2119> be executed if the <tag class="attribute">test</tag>
-condition is false. This
-means that an implementation <rfc2119>must not</rfc2119> signal any dynamic errors that
-would arise if the contents of the <tag>p:when</tag> were executed.</para>
+      <para>There are some cases where this specification requires that steps must not be executed:
+        for example, the content of a <tag>p:when</tag>
+        <rfc2119>must not</rfc2119> be executed if the <tag class="attribute">test</tag> condition
+        is false. This means that an implementation <rfc2119>must not</rfc2119> signal any dynamic
+        errors that would arise if the contents of the <tag>p:when</tag> were executed.</para>
 
-<para>An implementation may signal a dynamic error before any source
-document is available, but only if it can determine that the error
-would be signaled for every possible source document and every
-possible set of parameter values.</para>
+      <para>An implementation may signal a dynamic error before any source document is available,
+        but only if it can determine that the error would be signaled for every possible source
+        document and every possible set of parameter values.</para>
 
-      <para>If a step fails due to a dynamic error, failure propagates
-      upwards until either a <tag>p:try</tag> is encountered or the
-      entire pipeline fails. In other words, outside of a
-      <tag>p:try</tag>, step failure causes the entire pipeline to
-      fail.</para>
+      <para>If a step fails due to a dynamic error, failure propagates upwards until either a
+          <tag>p:try</tag> is encountered or the entire pipeline fails. In other words, outside of a
+          <tag>p:try</tag>, step failure causes the entire pipeline to fail.</para>
 
-      <para>For a complete list of dynamic errors, see <xref
-      linkend="app.dynamic-errors"/>.</para>
+      <para>For a complete list of dynamic errors, see <xref linkend="app.dynamic-errors"/>.</para>
     </section>
     <section xml:id="step-errors">
       <title>Step Errors</title>
@@ -6424,64 +6249,65 @@ possible set of parameter values.</para>
     </section>
   </section>
 
-<xi:include href="conformance.xml"/>
-<xi:include href="xpath-context.xml"/>
-<xi:include href="references.xml"/>
-<xi:include href="../../../build/glossary.xml">
-  <xi:fallback>
-    <glossary xml:id="glossary">
-      <title>Glossary</title>
-      <para>Glossary needs to be generated</para>
-    </glossary>
-  </xi:fallback>
-</xi:include>
-<xi:include href="language-summary.xml"/>
-<xi:include href="error-codes.xml"/>
-<xi:include href="namespace-fixup.xml"/>
-<xi:include href="handle-imports.xml"/>
-<xi:include href="parallel.xml"/>
-<xi:include href="mediatype.xml"/>
-<xi:include href="ancillary.xml"/>
-<xi:include href="credits.xml"/>
+  <xi:include href="conformance.xml"/>
+  <xi:include href="xpath-context.xml"/>
+  <xi:include href="references.xml"/>
+  <xi:include href="../../../build/glossary.xml">
+    <xi:fallback>
+      <glossary xml:id="glossary">
+        <title>Glossary</title>
+        <para>Glossary needs to be generated</para>
+      </glossary>
+    </xi:fallback>
+  </xi:include>
+  <xi:include href="language-summary.xml"/>
+  <xi:include href="error-codes.xml"/>
+  <xi:include href="namespace-fixup.xml"/>
+  <xi:include href="handle-imports.xml"/>
+  <xi:include href="parallel.xml"/>
+  <xi:include href="mediatype.xml"/>
+  <xi:include href="ancillary.xml"/>
+  <xi:include href="credits.xml"/>
 
-<appendix xml:id="changelog">
-<title>Change Log</title>
-<para>This appendix catalogs non-editorial changes made after the
-February 2019
-“<link xlink:href="http://spec.xproc.org/lastcall-2019-02/head/xproc/">last call</link>”
-draft:</para>
+  <appendix xml:id="changelog">
+    <title>Change Log</title>
+    <para>This appendix catalogs non-editorial changes made after the February 2019 “<link
+        xlink:href="http://spec.xproc.org/lastcall-2019-02/head/xproc/">last call</link>”
+      draft:</para>
 
     <itemizedlist>
       <listitem>
-        <para>The semantics of <tag>p:if</tag> have been changed. If the test expression is false, <tag>p:if</tag>
-          behaves roughly like an identity step. Previously it produced no outputs.</para>
+        <para>The semantics of <tag>p:if</tag> have been changed. If the test expression is false,
+            <tag>p:if</tag> behaves roughly like an identity step. Previously it produced no
+          outputs.</para>
       </listitem>
       <listitem>
-        <para>It is no longer a static error (XS0093), if <tag>p:option</tag> or <tag>p:variable</tag> have an attribute
-            <literal>visibility</literal> and are not children of a <tag>p:library</tag>.</para>
+        <para>It is no longer a static error (XS0093), if <tag>p:option</tag> or
+            <tag>p:variable</tag> have an attribute <literal>visibility</literal> and are not
+          children of a <tag>p:library</tag>.</para>
       </listitem>
       <listitem>
-        <para>The semantics of <tag>p:choose</tag> have been changed. The default sub-pipeline for a missing
-            <tag>p:otherwise</tag> is a <tag>p:identity</tag> step (with the additional feature that it isn’t an error
-          if there’s no default readable port). A primary output port on the <tag>p:when</tag> branches for this is
-          required.</para>
+        <para>The semantics of <tag>p:choose</tag> have been changed. The default sub-pipeline for a
+          missing <tag>p:otherwise</tag> is a <tag>p:identity</tag> step (with the additional
+          feature that it isn’t an error if there’s no default readable port). A primary output port
+          on the <tag>p:when</tag> branches for this is required.</para>
       </listitem>
       <listitem>
-        <para>The way the context item for XPath expressions is provided has been changed. It is now provided if and only 
-        if the connection delivers exactly one document, otherwise the context item is undefined. A new error (XD0001) is
-        introduced. It is raised if an XPath expression makes use of the context item, but the context item is undefined.
-        Two dynamic errors (XD0005 and XD0008) were removed.</para>
+        <para>The way the context item for XPath expressions is provided has been changed. It is now
+          provided if and only if the connection delivers exactly one document, otherwise the
+          context item is undefined. A new error (XD0001) is introduced. It is raised if an XPath
+          expression makes use of the context item, but the context item is undefined. Two dynamic
+          errors (XD0005 and XD0008) were removed.</para>
       </listitem>
       <listitem>
-        <para>Content type shortcuts and the notion of forbidden content types have been added.
-        See <xref linkend="specified-content-types"/>.
-        </para>
+        <para>Content type shortcuts and the notion of forbidden content types have been added. See
+            <xref linkend="specified-content-types"/>. </para>
       </listitem>
       <listitem>
         <para>Introduction of the <code>serialization</code> document property. See <xref
             linkend="document-properties"/>.</para>
       </listitem>
     </itemizedlist>
-</appendix>
+  </appendix>
 
 </specification>


### PR DESCRIPTION
This is an attempt to resolve #788.

The whole prose for serialization was quite a historically grown jungle. I've tried to make it more clear but leave the important bits in. It does not handle the separate parameters any more (with the exception ot the method parameter, which is rather fundamental), it simply refers to [the serialization spec](https://www.w3.org/TR/xslt-xquery-serialization-31/).

Looking at the result I seem to have inadvertently changed indenting in other places. My apologies for that, that was not the intention but is now hard to roll back.

Anyway, This is one of the larger edits which are hard to judge without the final HTML at hand. Since I do not have any github pages setup, I will add my local copy of the HTML to the PR.