### PR TITLE
Bump DB version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 docbookXsltBaseUri=https://cdn.docbook.org
-docbookXsltVersion=2.3.9
+docbookXsltVersion=2.3.12
 stepsBaseUri=http://spec.xproc.org/master/head/etc


### PR DESCRIPTION
New DocBook XSLT 2.0 Stylesheet release that avoids all those Saxon warnings about using value-of where you should be using sequence.
