### PR TITLE
Attempt to fix 877

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1161,7 +1161,9 @@ evaluation</firstterm> consists of tasks which, in general,
 cannot be performed out until a source document is available.</termdef></para>
 
 <para><error code="S0107">It is a <glossterm>static error</glossterm> in XProc
-if any XPath expression contains a static error (error in expression syntax,
+if any XPath expression or the XSLT <glossterm>selection pattern</glossterm> 
+in option <option>match</option>
+on <tag>p:viewport</tag> contains a static error (error in expression syntax,
 references to unknown variables or functions, etc.).</error>
 Type errors, even if they are determined during static
 analysis, <rfc2119>must not</rfc2119> be raised statically by


### PR DESCRIPTION
Attempt to fix #877 by expanding description of XS0107. It is not just for XPath but for the only processor evaluated selection pattern (p:viewport/@match) too.