### PR TITLE
index: Use relative paths

### DIFF
--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -41,18 +41,18 @@ available at this time.</p>
 <dd>
 <p>Two versions are available:</p>
 <dl>
-<dt><a href="/lastcall-2019-02/head/xproc/">February 2019 “last call” draft</a></dt>
+<dt><a href="lastcall-2019-02/head/xproc/">February 2019 “last call” draft</a></dt>
 <dd>
 <p>The editorial team believes that the core language specification is
 in “last call”. We are unaware (at the time of publication) of any
 substantive issues. This draft is stable and will not be updated.
 </p>
 </dd>
-<dt><a href="/master/head/xproc/">Current editorial draft</a></dt>
+<dt><a href="master/head/xproc/">Current editorial draft</a></dt>
 <dd>
 <p>The current editorial draft tracks changes made since the “last call” draft.
 For the most part, only editorial changes are expected. See the
-<a href="/master/head/xproc/#changelog">Change Log</a> appendix for a list
+<a href="master/head/xproc/#changelog">Change Log</a> appendix for a list
 of substantive changes. This draft is updated regularly as the editorial team
 address issues.
 </p>
@@ -62,7 +62,7 @@ address issues.
 that you’ve found an error or omission, please
 <a href="https://github.com/xproc/3.0-specification/issues">let us know</a>.</p>
 </dd>
-<dt><a href="/master/head/steps/">XProc 3.0:
+<dt><a href="master/head/steps/">XProc 3.0:
 Standard Step Library</a></dt>
 <dd>
 <p>The standard step library contains all of standard atomic steps, that is, the
@@ -84,25 +84,25 @@ separate specifications:
 </p>
 
 <dl>
-<dt><a href="/master/head/run/">Dynamic pipeline execution
+<dt><a href="master/head/run/">Dynamic pipeline execution
 (<code>p:run</code>)</a></dt>
 <dd>A step that runs pipelines constructed dynamically.</dd>
 
-<dt><a href="/master/head/file/">File steps</a></dt>
+<dt><a href="master/head/file/">File steps</a></dt>
 <dd>Steps related to accessing files on a filesystem
 (rename, move, delete, etc.).</dd>
 
-<dt><a href="/master/head/os/">Operating system steps</a></dt>
+<dt><a href="master/head/os/">Operating system steps</a></dt>
 <dd>Steps related to accessing aspects of the underlying operating system
 (information about the system and the ability to execute commands on it).</dd>
 
-<dt><a href="/master/head/paged-media/">Paged media steps</a></dt>
+<dt><a href="master/head/paged-media/">Paged media steps</a></dt>
 <dd>Steps related to producing paged media (e.g, PDF files).</dd>
 
-<dt><a href="/master/head/text/">Text steps</a></dt>
+<dt><a href="master/head/text/">Text steps</a></dt>
 <dd>Steps related to accessing text files (head, tail, etc.).</dd>
 
-<dt><a href="/master/head/validation/">Validation steps</a></dt>
+<dt><a href="master/head/validation/">Validation steps</a></dt>
 <dd>Steps related to validation (of XML, JSON, etc.).</dd>
 </dl>
 </dd>


### PR DESCRIPTION
Using relative paths instead of absolute paths turns the current invalid links

    https://xxx.github.io/master/head/xproc/

into

    https://xxx.github.io/3.0-specification/master/head/xproc/

These new links should work fine in `spec.xproc.org` as well.