### PR TITLE
sync select attribute of p:input with p:with-input 

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4581,18 +4581,14 @@ that more than one input port is the primary.</error></para>
 <tag class="attribute">select</tag> may be used to select a portion of the
 input identified by the <tag>p:empty</tag>, <tag>p:document</tag>,
 or <tag>p:inline</tag> elements in the
-<tag>p:input</tag>. This select expression <rfc2119>must</rfc2119> be an XPath
-expression.
-The selected nodes are returned as separate documents.
-If such a document consists exclusively of text nodes, then it has a content
-type of <literal>text/plain</literal>, otherwise it has a content type
-of <literal>application/xml</literal>. <error code="D0016">It is a
-<glossterm>dynamic error</glossterm> if the select expression on a p:input or
-p:with-input returns anything other than document nodes, element nodes,
-processing instruction nodes, comment nodes, text nodes or an empty sequence.</error></para>
+<tag>p:input</tag>.</para>
+
+<para>With the exception that <tag>p:input</tag> cannot establish a connection 
+to another step, what is said about the <tag class="attribute">select</tag> 
+attribute in <tag>p:with-input</tag> equally applies to <tag>p:input</tag>.</para>
 
 <para>The
-<tag class="attribute">select</tag> expression applies
+<tag class="attribute">select</tag> expression on <tag>p:input</tag> applies
 <emphasis>only</emphasis> if the default connection is used. If an
 explicit connection is provided by the caller, then the default select
 expression is ignored.</para>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6521,7 +6521,7 @@ draft:</para>
         <para>Identified the <port>error</port> port as the primary input port in <tag>p:catch</tag>.</para>
       </listitem>
       <listitem>
-        <para>Clarified that <tag>p:finally</tag> <rfc2119>must not</rfc2119> declare a pirmary output port.</para>
+        <para>Clarified that <tag>p:finally</tag> <rfc2119>must not</rfc2119> declare a primary output port.</para>
       </listitem>
       <listitem>
         <para>Clarified which functions are available during static analysis.</para>
@@ -6536,6 +6536,10 @@ draft:</para>
         <para>Clarified how sequences of XDM values (for
         example, from a <tag>p:xslt</tag> step) are converted into
         documents.</para>
+      </listitem>
+      <listitem>
+        <para>Updated the description of the <tag class="attribute">select</tag> attribute for <tag>p:input</tag>
+        so that it is in line with the more recent changes that have been applied to <tag>p:with-input</tag>.</para>
       </listitem>
     </itemizedlist>
 </appendix>


### PR DESCRIPTION
I didn’t want to replicate the whole `@select` prose from `p:with-input/@select`, therefore I followed the precedent of `p:input/@href` and just linked to `p:with-input`.

Thanks @martin-honnen for reading the spec so thoroughly and for being so attentive!

Fix #946 