### PR TITLE
Resolves the textual part of issue #949

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5199,20 +5199,6 @@ default collection within <tag class="attribute">select</tag> expression.</para>
 </listitem>
 </varlistentry>
 
-<varlistentry><term><tag class="attribute">visibility</tag></term>
-<listitem>
-<para>If the <tag>p:variable</tag> is a child of a <tag>p:library</tag>,
-the <tag class="attribute">visibility</tag> attribute controls whether
-the variable is visible to an importing pipeline. If
-<tag class="attribute">visibility</tag> is set to “<literal>private</literal>”,
-the variable is visible inside the <tag>p:library</tag> but not visible to
-any pipeline importing the <tag>p:library</tag>. If the visibility attribute is
-missing, “<literal>public</literal>” is assumed. If the <tag>p:variable</tag> is not a child 
-of <tag>a p:library</tag> the attribute has no effect and is ignored.
-</para>
-</listitem>
-</varlistentry>
-
 <varlistentry><term><tag class="attribute">href</tag></term>
 <listitem>
 <para>As described in <tag>p:with-input</tag>.</para>
@@ -6455,7 +6441,19 @@ possible set of parameter values.</para>
 
 <appendix xml:id="changelog">
 <title>Change Log</title>
-<para>This appendix catalogs non-editorial changes made after the
+  <para>This list contains the non-editorial changes made after the
+    December 2019
+    “<link xlink:href="https://spec.xproc.org/lastcall-2019-12/head/xproc/">last call</link>”
+    draft:</para>
+  
+  <itemizedlist>
+    <listitem>
+      <para>The <code>visibility</code> attribute of <tag>p:variable</tag> was removed.</para>
+    </listitem>
+    
+  </itemizedlist>
+  
+<para>This list contains the non-editorial changes made after the
 February 2019
 “<link xlink:href="http://spec.xproc.org/lastcall-2019-02/head/xproc/">last call</link>”
 draft:</para>


### PR DESCRIPTION
These are only the textual changes necessary for #949. Someone must change the schema and remove  `p:variable/@visibility`, which I don't know how to do.

I created a new list in the change log appendix to record this change.