### PR TITLE
Fix the build so that it gets the correct grammar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,16 +122,23 @@ task spec_sch(type: Copy) {
 // ======================================================================
 // XProc schemas (just make sure they're downloaded early)
 
-def schemaList = ["core30.rng",
-                  "xproc.rnc", "xproc.rng",
+task download_core30_rng(type: Download) {
+  src "$grammarBaseUri/lib/core30.rng"
+  dest "$buildDir/"
+  doFirst { mkdir "$buildDir" }
+}
+download_core30_rng.onlyIf { ! file("$buildDir/core30.rng".toString()).exists() }
+spec_schemas.dependsOn download_core30_rng
+
+def schemaList = ["xproc.rnc", "xproc.rng",
                   "xproc10.rnc", "xproc10.rng",
                   "xproc30.rnc", "xproc30.rng"]
 
 schemaList.each { schema ->
   def taskname = "download_" + schema.replace(".", "_")
   Task t = task "${taskname}"(type: Download) {
-    src "$grammarBaseUri/$schema"
-    dest "$buildDir/$schema"
+    src "$grammarBaseUri/relax-ng/$schema"
+    dest "$buildDir/"
     doFirst { mkdir "$buildDir" }
   }
   t.onlyIf { ! file("$buildDir/$schema".toString()).exists() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 docbookXsltBaseUri=https://cdn.docbook.org
 docbookXsltVersion=2.4.3
 stepsBaseUri=http://spec.xproc.org/master/head/etc
-grammarBaseUri=http://spec.xproc.org/master/head/etc
+grammarBaseUri=https://grammar.xproc.org
+


### PR DESCRIPTION
This PR gets the grammar files from github.com/xproc/3.0-grammar

I don't expect this change to be controversial, so I'm just going to merge it after the build passes. Unfortunately, travis-ci is down now (21 March, 10:45 UTC) so it may be a while.