### PR TITLE
Attempt to fix-966

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6546,7 +6546,7 @@ draft:</para>
         so that it is in line with the more recent changes that have been applied to <tag>p:with-input</tag>.</para>
       </listitem>
       <listitem>
-        <para>Changed description of <tag>p:viewport</tag> stating that the base URI of every matched note is the
+        <para>Changed description of <tag>p:viewport</tag> stating that the base URI of every matched node is the
         document's base URI, not just for document and element nodes.</para>
       </listitem>
     </itemizedlist>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3712,8 +3712,8 @@ the source document is wrapped in a document node, as necessary, and
 provided, one at a time, to the viewport&#x2019;s
 <glossterm>subpipeline</glossterm> on a port named
 <port>current</port>. The base URI of the resulting document that is
-passed to the subpipeline is the base URI of the matched element or
-document. <error code="D0010">It is a <glossterm>dynamic
+passed to the subpipeline is the base URI of the matched node.
+<error code="D0010">It is a <glossterm>dynamic
 error</glossterm> if the <tag class="attribute">match</tag> expression
 on <tag>p:viewport</tag> matches an attribute or a namespace node.</error></para>
 
@@ -6544,6 +6544,10 @@ draft:</para>
       <listitem>
         <para>Updated the description of the <tag class="attribute">select</tag> attribute for <tag>p:input</tag>
         so that it is in line with the more recent changes that have been applied to <tag>p:with-input</tag>.</para>
+      </listitem>
+      <listitem>
+        <para>Changed description of <tag>p:viewport</tag> stating that the base URI of every matched note is the
+        document's base URI, not just for document and element nodes.</para>
       </listitem>
     </itemizedlist>
 </appendix>


### PR DESCRIPTION
Attempt to fix #966 : Every document can have a base URI, not just the ones created from matched documents and elements.