### PR TITLE
Changed book reference into a reference to the new learning materials page

### DIFF
--- a/src/homepage/index.html
+++ b/src/homepage/index.html
@@ -23,7 +23,7 @@ with the request or
 us the changes as a pull request.</p>
 
 <p>►<a href="#specifications">Specifications</a>
-►<a href="#references">References</a>
+►<a href="#learning">Learning materials</a>
 ►<a href="#implementations">Implementations</a>
 ►<a href="#testsuite">Test suite</a>
 </p>
@@ -139,10 +139,10 @@ or if you think that an optional step should be required or vice versa.
 </p>
 </div>
 
-<div id="references">
-<h2>References</h2>
+<div id="learning">
+<h2>Learning materials</h2>
 
-<p>A programmer’s reference to XProc 3.0 will be available.</p>
+  <p>An overview of learning materials for XProc 3.0 is available <a href="https://xproc.org/learning.html">here</a>.</p>
 </div>
 
 <div id="implementations">


### PR DESCRIPTION
For https://spec.xproc.org/

There was still only an announcement to the book there. I changed it to a link to the learning materials page I just created.