### PR TITLE
Listing more xml attributes

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -3125,6 +3125,14 @@ For convenience, they are all summarized here.</para>
   <para>An <tag class="attribute">xml:base</tag> attribute is allowed on any element. It has
   the semantics of <biblioref linkend="xml-base"/>.</para>
 </listitem>
+<listitem>
+  <para>An <tag class="attribute">xml:lang</tag> attribute is allowed on any element. It has
+  the semantics of <biblioref linkend="xml10"/>.</para>
+</listitem>
+<listitem>
+  <para>An <tag class="attribute">xml:space</tag> attribute is allowed on any element. It has
+    the semantics of <biblioref linkend="xml10"/>.</para>
+</listitem>
 </itemizedlist>
 
 <para>The remaining attributes are sometimes in no namespace and sometimes


### PR DESCRIPTION
As the spec already says "Attributes from the XML namespace are allowed anywhere. " calling out `xml:lang` and `xml:space` does not seem necessary, but it also does no harm. 
The key problem seems to be not the specs, but the grammar which does not reflect the prose in a correct way.
issue #983 
 