### PR TITLE
Proposal of editorial fix

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5534,7 +5534,7 @@ XProc sequence type, see <xref linkend="varopt-types"/>.
 <tag class="attribute">select</tag> attribute <rfc2119>must</rfc2119> be
 specified. The value of the <tag class="attribute">select</tag>
 attribute is an XPath expression which will be evaluated to provide
-the value of the variable.</para>
+the value of the option.</para>
 </listitem>
 </varlistentry>
 <varlistentry><term><tag class="attribute">collection</tag></term>


### PR DESCRIPTION
Replaced 'variable' with 'option', which is imho right there. Might be a result from copy-and-paste.