### PR TITLE
Editorial proposal: Remove left-over para

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5700,9 +5700,6 @@ steps cannot refer to the inputs or outputs of a
 <tag>p:declare-step</tag> using <tag>p:pipe</tag>; only instances of
 the type can be referenced.</para>
 
-<para>Most pipeline authors use the <tag>p:declare-step</tag> element
-to declare a pipeline.</para>
-
 <section xml:id="declare-pipelines">
 <title>Declaring pipelines</title>
 


### PR DESCRIPTION
I think the deleted para is a left-over from the times there were 'p:pipeline' and 'p:declare-step'.