### PR TITLE
Fixing typos

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5248,7 +5248,7 @@ the name of a static option.</error>
 <listitem>
 <para>The type of the value may be specified in the
 <tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
+XPath sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5380,7 +5380,7 @@ the name of a static option.</error>
 <listitem>
 <para>The type of the value may be specified in the
 <tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
+XPath sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>
@@ -5523,7 +5523,7 @@ name as part of the same step invocation.</error></para>
 <listitem>
 <para>The type of the value may be specified in the
 <tag class="attribute">as</tag> attribute using an
-XProc sequence type, see <xref linkend="varopt-types"/>.
+XPath sequence type, see <xref linkend="varopt-types"/>.
 </para>
 </listitem>
 </varlistentry>


### PR DESCRIPTION
Replacing "XProc sequence type" with "XPath sequence type"