### PR TITLE
Attempt to clarify conversion of option shortcut values

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5655,9 +5655,8 @@ See <xref linkend="statics"/>.</para>
                 The context node for the attribute value template comes from the default readable port for the step on
                 which they occur. If there is no such port, the context node is undefined.</para>
        
-
 <para>As with other attribute value templates, the attribute’s string value,
-as an <code>xs:untypedAtomic</code>, is used as the value of the option. Normal
+as an <code>xs:untypedAtomic</code>, is used as the value of the option. Function
 conversion rules apply to convert this untyped atomic value to the
 option’s sequence type.</para>
       </listitem>

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5655,8 +5655,11 @@ See <xref linkend="statics"/>.</para>
                 The context node for the attribute value template comes from the default readable port for the step on
                 which they occur. If there is no such port, the context node is undefined.</para>
        
-            <para>The attribute&#x2019;s string value, after the attribute value template expansion, is used as
-              the value of the option. It must be possible to convert this string to the option&#x2019;s sequence type.</para>
+
+<para>As with other attribute value templates, the attribute’s string value,
+as an <code>xs:untypedAtomic</code>, is used as the value of the option. Normal
+conversion rules apply to convert this untyped atomic value to the
+option’s sequence type.</para>
       </listitem>
     </itemizedlist>
     


### PR DESCRIPTION
This PR attempts to resolve an issue raised in an email conversation where the rules for AVTs in option shortcuts appeared to contradict the rules for AVTs in attribute values generally.