### PR TITLE
Use ext: prefix for extension elements

### DIFF
--- a/tools/xsl/rngsyntax.xsl
+++ b/tools/xsl/rngsyntax.xsl
@@ -87,6 +87,10 @@
 	<xsl:when test="not($rngpat/rng:element/@name)">
 	  <!-- special case -->
 	  <xsl:choose>
+	    <xsl:when test="ancestor::db:section[@xml:id='p.extension']"
+		      xmlns:db="http://docbook.org/ns/docbook">
+	      <xsl:attribute name="prefix" select="'ext'"/>
+            </xsl:when>
 	    <xsl:when test="ancestor::db:section[@xml:id='p.atomic']"
 		      xmlns:db="http://docbook.org/ns/docbook">
 	      <xsl:attribute name="prefix" select="'p'"/>


### PR DESCRIPTION
Fix #1011 

The prefix generated for `rng:element` markup is controlled by the stylesheet that processes them. I expect this used to work and broke when we made editorial changes. I've just (re-?)established that in the case where the syntax pattern occurs in the section with the id `p.extension`, the prefix `ext` should be used instead of `p`.
