### PR TITLE
Attempt to resolve #1036

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6691,7 +6691,11 @@ class="attribute">encoding</tag> attribute.</error>
 
 <para>If an <tag class="attribute">encoding</tag> attribute is present,
 value templates are never expanded. The value of
-<tag class="attribute">[p:]expand-text</tag> is irrelevant and always ignored.</para>
+<tag class="attribute">[p:]expand-text</tag> is irrelevant and always ignored.
+Otherwise, the text content of <tag>p:inline</tag> is subject to text value
+template expansion irrespective of its content type. (Attribute value template
+expansion only applies to XML and HTML media types.)
+</para>
 
 <para>The interpretation of the (possibly decoded) content
 depends on the document’s content type.


### PR DESCRIPTION
Make it explicit that text value template expansion applies irrespective of the content type.