### PR TITLE
Add a distinct error code for an incorrect port name

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5278,6 +5278,10 @@ is no primary input port.</error>
 to specify a port name on <tag>p:with-input</tag> for <tag>p:for-each</tag>,
   <tag>p:viewport</tag>, <tag>p:choose</tag>, <tag>p:when</tag>, or <tag>p:if</tag>.</error>
 </para>
+<para><error code="S0114">It is a <glossterm>static error</glossterm>
+if a port name is specified and the step type being invoked does not have
+an input port declared with that name.</error>
+</para>
 <para><error code="S0086">It is a <glossterm>static error</glossterm>
 to provide more than one <tag>p:with-input</tag> for the same port.</error>
 </para>


### PR DESCRIPTION
If a pipeline author attempts to specify a value for an option that isn't declared on a step, there's a distinct error code for that case.

This PR adds a corresponding distinct error code for the case where a pipeline author attempts to make a connection to an input port that isn't declared.
