### PR TITLE
Attempt to resolve the select question in issue 1040

### DIFF
--- a/xproc/src/main/examples/input-port.xml
+++ b/xproc/src/main/examples/input-port.xml
@@ -7,7 +7,8 @@
 </p:identity>
 <p:identity name="irrelevant">
 
-<p:with-input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
+<p:with-input xmlns:html="http://www.w3.org/1999/xhtml"
+              port="source" select="//html:div">
   <p:pipe step="origin" port="result"/>
 </p:with-input>
 

--- a/xproc/src/main/examples/input-select.xml
+++ b/xproc/src/main/examples/input-select.xml
@@ -2,7 +2,8 @@
 <p:output port="result"/>
 <p:identity>
 
-<p:with-input port="source" select="//html:div" xmlns:html="http://www.w3.org/1999/xhtml">
+<p:with-input xmlns:html="http://www.w3.org/1999/xhtml"
+              port="source" select="//html:div">
   <p:document href="http://example.org/input.html"/>
 </p:with-input>
 

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5292,25 +5292,22 @@ undefined.</error></para>
 </varlistentry>
 <varlistentry><term><tag class="attribute">select</tag></term>
 <listitem>
-<para>A <tag class="attribute">select</tag> expression
-<rfc2119>may</rfc2119> be provided with a connection.
-If a <tag class="attribute">select</tag> expression is specified,
-it will be applied to each item that appears on the connection. That is,
-for each item received, the
-<tag class="attribute">select</tag> expression will be evaluated with that
-item as the context item.
-If no items are received on the connection, the select
-expression will be evaluated once with an empty sequence as the
-context item.
-The sequence of items returned (the accumulated sequence of items, in the case where
-more than one item appears on the connection)
-by the expression is the input to the step.</para>
+<para>If a <tag class="attribute">select</tag> expression is
+specified, it is effectively a filter on the input. The expression
+will be evaluated once for each document that appears on the port,
+using that document as the context item. The result of evaluating the
+expression (on each document that appears, in the order they arrive)
+will be the sequence of items that the step receives on the
+port.</para>
 
 <para>The rules as stated in <xref
 linkend="creating-documents-from-xdm-step-results"/> will be applied to the members
 of this sequence and will turn these into separate documents. <error code="D0016">It is a
 <glossterm>dynamic error</glossterm> if the select expression on a <tag>p:input</tag> or
 <tag>p:with-input</tag> returns attribute nodes or function items.</error></para>
+
+<para>If no documents are received, the expression is not evaluated and the
+step receives no input on the port.</para>
 
 <para>For example:</para>
 

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5300,7 +5300,7 @@ for each item received, the
 <tag class="attribute">select</tag> expression will be evaluated with that
 item as the context item.
 If no items are received on the connection, the select
-expression will be evaluated once with an empty document node as the
+expression will be evaluated once with an empty sequence as the
 context item.
 The sequence of items returned (the accumulated sequence of items, in the case where
 more than one item appears on the connection)

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5292,17 +5292,27 @@ undefined.</error></para>
 </varlistentry>
 <varlistentry><term><tag class="attribute">select</tag></term>
 <listitem>
-            <para>A <tag class="attribute">select</tag> expression <rfc2119>may</rfc2119> also be
-              provided with a connection. The <tag class="attribute">select</tag> expression, if
-              specified, applies the specified XPath select expression to the document(s) that are
-              read. </para>
-            <para>The result of this is a sequence of items. The rules as stated in <xref
-                linkend="creating-documents-from-xdm-step-results"/> will be applied to the members
-              of this sequence and will turn these into separate documents. <error code="D0016">It is a
-                <glossterm>dynamic error</glossterm> if the select expression on a <tag>p:input</tag> or
-                <tag>p:with-input</tag> returns attribute nodes or function items.</error></para>
+<para>A <tag class="attribute">select</tag> expression
+<rfc2119>may</rfc2119> be provided with a connection.
+If a <tag class="attribute">select</tag> expression is specified,
+it will be applied to each item that appears on the connection. That is,
+for each item received, the
+<tag class="attribute">select</tag> expression will be evaluated with that
+item as the context item.
+If no items are received on the connection, the select
+expression will be evaluated once with an empty document node as the
+context item.
+The sequence of items returned (the accumulated sequence of items, in the case where
+more than one item appears on the connection)
+by the expression is the input to the step.</para>
 
-  <para>For example:</para>
+<para>The rules as stated in <xref
+linkend="creating-documents-from-xdm-step-results"/> will be applied to the members
+of this sequence and will turn these into separate documents. <error code="D0016">It is a
+<glossterm>dynamic error</glossterm> if the select expression on a <tag>p:input</tag> or
+<tag>p:with-input</tag> returns attribute nodes or function items.</error></para>
+
+<para>For example:</para>
 
 <programlisting language="xml"><xi:include href="../../../build/examples/input-doc.txt" parse="text"/></programlisting>
 
@@ -5317,9 +5327,13 @@ will result in the same content being returned in several
 documents.)</para>
 
 <para>A select expression can equally be applied to input read from
-another step. This input:</para><programlisting
+another step. This input:</para>
+
+<programlisting
 language="xml"><xi:include href="../../../build/examples/input-port.txt"
-parse="text"/></programlisting><para>provides a sequence of zero or
+parse="text"/></programlisting>
+
+<para>provides a sequence of zero or
 more documents, one for each <code>html:div</code> in the document (or
 each of the documents) that is read from the <literal>result</literal>
 port of the step named <literal>origin</literal>.</para>


### PR DESCRIPTION
Close #1040 

This PR resolves the behavior of a `select` expression on `p:with-input` when the expression does not refer to the context item. (For example, if the `select` expression returns a static map or array).

On the surface, it introduces the slightly strange semantic that if a `select` expression is provided, but *nothing* appears on the input port, the expression is still evaluated once, against an empty document node.

Note that the context has to be an empty document or there will be all sorts of spurious errors. Consider:

```xml
<p:with-input port="source" select="//div"/>
```

If the expression was evaluated without a context item, that would raise an error which is surely not what the user expects.

Conversely, if we don't evaluate the expression at all when no documents appear on the input port, then this example:

```xml
<p:with-input port="source" select="map { 'a': 1 }"/>
```

produces no inputs to the step. And we've established (in #1040) that we *do* want the map to be sent to the step once.



