### PR TITLE
Attempt to resolve issues 1030 and 1029

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5558,10 +5558,9 @@ parameters</link>.
 </varlistentry>
 </variablelist>
 
-
 <para><error code="S0029">It is a <glossterm>static error</glossterm>
 to specify a connection for a <tag>p:output</tag> inside a
-<tag>p:declare-step</tag> for an atomic step.</error></para>
+<tag>p:declare-step</tag> for an <glossterm>external step</glossterm>.</error></para>
 
 <para>If a connection is provided for a <tag>p:output</tag>, documents
 are <emphasis>read from</emphasis> that connection and those documents
@@ -6195,10 +6194,20 @@ specify a value for an option that is declared static.</error>
 
 <para>A <tag>p:declare-step</tag> provides the type and
 <glossterm>signature</glossterm> of a pipeline or
-an <glossterm>atomic step</glossterm>.
+an <glossterm>external step</glossterm>.
 Pipelines contain a subpipeline which defines what the declared
-step does. Atomic steps have an implementation defined elsewhere in some
-other way.</para>
+step does.
+<termdef xml:id="dt-external-step">An <firstterm>external step</firstterm>
+is one supported by the implementation, but which has no exposed description
+of what it does.</termdef> 
+</para>
+
+<para>The standard XProc atomic steps (<tag>p:add-attribute</tag>,
+<tag>p:add-xml-base</tag> …) are all external steps.
+<impl>Whether or not an implementation allows users to provide thier own
+external steps is <glossterm>implementation-dependent</glossterm>.</impl>
+A <tag>p:declare-step</tag> must be provided for every pipeline and external step
+that is used in a pipeline.</para>
 
 <para><impl>When a declared step is evaluated directly by the XProc
 processor (as opposed to occurring as an atomic step in some
@@ -6378,16 +6387,16 @@ subpipeline does not have a primary output port.</error></para>
 </section>
 
 <section xml:id="declare-atomic-steps">
-<title>Declaring atomic steps</title>
+<title>Declaring external steps</title>
 
-<para>The distinction between an atomic step declaration and a
-pipeline declaration hinges on the presence or absence of a
-subpipeline. An atomic step declaration does not have a subpipeline.
-</para>
+<para>The distinction between a pipeline declaration and an external
+step declaration hinges on the presence or absence of a subpipeline.
+A step declaration that does not contain a subpipeline is, by definition,
+declaring an <glossterm>external step</glossterm>.</para>
 
-<para>Atomic step declarations may not import other pipelines or
+<para>External step declarations may not import other pipelines or
 functions, may not declare static options, and may not declare
-additional steps. In other words, the content of an atomic step
+additional steps. In other words, the content of an external step
 declaration consists exclusively of <tag>p:input</tag>,
 <tag>p:output</tag>, and <tag>p:option</tag> elements.</para>
 
@@ -6405,6 +6414,11 @@ steps that a particular processor does not know how to implement. It
 is, of course, an error to attempt to evaluate such steps. 
 The function <function>p:step-available</function> will return <literal>false</literal>
 when called with the type name of such a step.</para>
+
+<para><error code="S0115">It is a <glossterm>static error</glossterm>
+to attempt to invoke an external step that is not available.
+</error></para>
+
 </section>
 </section>
 

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6204,7 +6204,7 @@ of what it does.</termdef>
 
 <para>The standard XProc atomic steps (<tag>p:add-attribute</tag>,
 <tag>p:add-xml-base</tag> …) are all external steps.
-<impl>Whether or not an implementation allows users to provide thier own
+<impl>Whether or not an implementation allows users to provide their own
 external steps is <glossterm>implementation-dependent</glossterm>.</impl>
 A <tag>p:declare-step</tag> must be provided for every pipeline and external step
 that is used in a pipeline.</para>


### PR DESCRIPTION
I took on board @gimsieke 's suggestion that the spec would be clearer if it distinguished between two different meanings of "atomic step", as he outlines in #1030. I decided to define a new term "external step" for steps that do not contain a subpipeline.

I've redrafted 16.5 accordingly and I do think it's an improvement. I think it also clarifies `err:XS0029`.

In #1029 there was a proposal to remove `err:XS0042`. That's already been done by some other PR. I assume that was accidental, but I think it's clearly what we needed to do so I'm just going to let it stand.

Close #1029 
Close #1030 
