### PR TITLE
Clarify that @select on p:option can never refer to the context item

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -5962,7 +5962,11 @@ Consequently, if it contains option references, these can only be
 references to preceding non-static options on the step or to in-scope static options.
 <error code="D0001">It is a <glossterm>dynamic error</glossterm> if an
 XPath expression makes reference to the context item, size, or position when
-the context item is undefined.</error></para>
+the context item is undefined.</error>
+This error will always arise if the <tag class="attribute">select</tag> expression
+refers to the context item because there can never be a context item for
+<tag>p:option</tag> default values.
+</para>
 
 <para><impl>The precise details about what XPath expressions are allowed
 (for example, can the expression declare a function) is


### PR DESCRIPTION
The description of `err:XD0001` in the discussion of `select` might be misleading. The spec tries to use the same error text when errors are repeated, in order to avoid introducing confusion. However, because the context here is a little different, the use of the phrase "when the context item is undefined" can lead a reader to believe that this is conditional, which it isn't in this case.

I've added a clarification. 