### PR TITLE
Resolve the order of elements in p:library

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6510,7 +6510,13 @@ See <xref linkend="versioning-considerations"/>.</para>
           error to put a <tag>p:declare-step</tag> without a <tag
             class="attribute">type</tag> in a <tag>p:library</tag>, but there is no standard
           mechanism for instantiating it or referring to it. It is effectively invisible.</para>
-      </note><para>Libraries can import pipelines and/or other libraries.
+      </note>
+
+<para>Like <tag>p:declare-step</tag>, within a library, imports must
+precede the prologue (any static options), which must precede any
+declared steps.</para>
+
+<para>Libraries can import pipelines and/or other libraries.
 See also <xref linkend="handling-imports"
       />.</para></section>
 


### PR DESCRIPTION
Perhaps it wasn't technically necessary to change the prose, but it seemed reasonable to mention the order. We'll need to carefully summarize the changes for the next public draft anyway.