### PR TITLE
Attempt to resolve issue #998

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -2526,6 +2526,15 @@ the features of the path (or the features of the path as resolved against the
 <listitem>
 <para>If there is an authority, append “//” followed by the
 authority.</para>
+  <itemizedlist>
+  <listitem>
+  <para>On a Windows system, if the scheme is known to be <code>file</code>
+and the processor determines that the
+authority component is accessible via the universal naming convention (UNC),
+an additional “//” <rfc2119>may</rfc2119> be added before the authority. (In other words,
+<code>file:////uncserver</code> is allowed.)</para>
+  </listitem>
+  </itemizedlist>
 </listitem>
 <listitem>
 <para>If there is <emphasis>not</emphasis> an authority, but the scheme is “file”

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -1938,8 +1938,8 @@ resources in archive files.</para>
 <para>The <function>p:urify</function> function attempts to
 transform file system paths into file URIs (<biblioref
 linkend="rfc3986"/>). If a presumptive yet not fully compliant URI is
-given as an argument, <function>p:urify</function> employs a series
-of heuristics to resolve the string into a URI.</para>
+given as an argument, <function>p:urify</function> attempts to
+resolve the string into a URI.</para>
 
 <para>The <function>p:urify</function> function resolves a string into
 a URI by employing a series of heuristics. These have been selected so


### PR DESCRIPTION
This change allows the `p:urify()` function in a processor to return `file:////uncserver` if it's on Windows and determines that the authority component is a UNC server.

Fix #998 