### PR TITLE
Updated status and change log

### DIFF
--- a/tools/xsl/docbook.xsl
+++ b/tools/xsl/docbook.xsl
@@ -129,7 +129,14 @@
 			 mode="m:titlepage-mode"/>
 
     <h2>
-      <xsl:text>Draft Community Group Report </xsl:text>
+      <xsl:choose>
+        <xsl:when test="$w3c-doctype='ed'">
+          <xsl:text>Draft Community Group Report </xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>Community Group Report </xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
 
       <time class="dt-published">
         <xsl:attribute name="datetime"

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6,13 +6,13 @@
                xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xml:id='xproc'
-               class="ed"
+               class="note"
                version="5.0-extension w3c-xproc">
 <info>
 <title>XProc 3.0: An XML Pipeline Language</title>
 <!-- defaults to date formatted <pubdate>2014-12-18</pubdate> -->
 
-<copyright><year>2018</year><year>2019</year><year>2020</year>
+<copyright><year>2018</year><year>2019</year><year>2020</year><year>2021</year><year>2022</year>
 <holder>the Contributors to the XProc 3.0 Specification</holder> 
 </copyright>
 
@@ -69,11 +69,10 @@ steps are executed.</para>
   </para>
 
 <note role="editorial">
-<para>This draft is the “editor’s working draft” and may include changes made
-after the “last call” draft. The
-<link xlink:href="http://spec.xproc.org/lastcall-2020-08/head/xproc/">last call draft</link>
-is stable and will not change.
-</para>
+<para>This is the final editorial review draft of the XProc 3.0 specification.
+The Community Group intends to publish this as the final, completed specification
+as soon as all of the related specifications are ready and the editorial review is
+completed.</para>
 </note>
 
 <para>This document is derived from
@@ -7137,6 +7136,55 @@ possible set of parameter values.</para>
 
 <appendix xml:id="changelog">
 <title>Change Log</title>
+
+  <para>This list contains the non-editorial changes made after the
+    August 2020
+    “<link xlink:href="https://spec.xproc.org/lastcall-2020-08/head/xproc/">last call</link>”
+    draft:</para>
+  
+  <itemizedlist>
+    <listitem>
+      <para>The <tag class="attribute">depends</tag> attribute is forbidden on
+      <tag>p:when</tag>, <tag>p:otherwise</tag>, <tag>p:catch</tag>, and
+      <tag>p:finally</tag>.</para>
+    </listitem>
+    <listitem>
+      <para>Processors may remove any implicit connections that they can determine
+      statically will never be used (issue
+      <link xlink:href="https://github.com/xproc/3.0-specification/issues/995">995</link>).
+      </para>
+    </listitem>
+    <listitem>
+      <para>Expanded and clarified the rules for implicit casting (issues
+      <link xlink:href="https://github.com/xproc/3.0-specification/issues/1001">1001</link>
+      and
+      <link xlink:href="https://github.com/xproc/3.0-specification/issues/1012">1012</link>).
+      </para>
+    </listitem>
+    <listitem>
+      <para>The semantics of the <function>p:urify</function> function were extensively
+      redrafted and clarified.</para>
+    </listitem>
+    <listitem>
+      <para>Text value templates are never expanded in the descendants of <tag>p:inline</tag> 
+      elements that specify an <tag class="attribute">encoding</tag>.</para>
+    </listitem>
+    <listitem>
+      <para>Clarified the semantics of <tag class="attribute">[p:]use-when</tag>
+      to address potential deadlock situations that can arise if
+      two or more expressions depend on each other.</para>
+    </listitem>
+    <listitem>
+      <para>Clarified that <function>p:step-available</function> cannot refer
+      to the step currently being declared (issue
+      <link xlink:href="https://github.com/xproc/3.0-specification/issues/1057">1057</link>).
+      </para>
+    </listitem>
+    <listitem>
+      <para>A number of error codes have been clarified and new error codes have been added.</para>
+    </listitem>
+  </itemizedlist>
+
   <para>This list contains the non-editorial changes made after the
     December 2019
     “<link xlink:href="https://spec.xproc.org/lastcall-2019-12/head/xproc/">last call</link>”


### PR DESCRIPTION
This is it folks, this is the big one. This is (at least intended to be) the final editorial draft of the XProc 3.0 specification.

1. I made a pass through the commits and updated the changelog. If you think I've missed any non-editorial changes, please let me know.
2. I removed "Draft" from the document title, updated the status, and updated the copyright years.

Next, I'll work on getting the standard step library into its final editorial draft state. When we have both specs in final form, I think we can push the "we're done" button at will.