### PR TITLE
Update for post-3.0 work

### DIFF
--- a/tools/xpl/formatspec.xpl
+++ b/tools/xpl/formatspec.xpl
@@ -110,7 +110,7 @@
     -->
     <p:load>
       <p:with-option name="href"
-                     select="concat('https://spec.xproc.org/lastcall-2020-08/head/', $specid)"/>
+                     select="'https://spec.xproc.org/3.0/xproc/index.html'"/>
     </p:load>
     <p:delete match="html:p[//html:code]/@id"/>
     <p:store name="fix1">

--- a/tools/xsl/docbook.xsl
+++ b/tools/xsl/docbook.xsl
@@ -276,7 +276,7 @@
         <dt>Changes:</dt>
         <xsl:if test="/*/@xml:id = 'xproc'">
           <dd>
-            <a href="lcdiff.html">Diff against the “last call” draft</a>
+            <a href="lcdiff.html">Diff against the 3.0 specification</a>
           </dd>
         </xsl:if>
         <xsl:if test="$auto-diff">

--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -6,12 +6,12 @@
                xmlns:e="http://www.w3.org/1999/XSL/Spec/ElementSyntax"
                xmlns:xi="http://www.w3.org/2001/XInclude"
                xml:id='xproc'
-               class="note"
-               version="5.0-extension w3c-xproc final">
+               class="ed"
+               version="5.0-extension w3c-xproc">
 <info>
-<title>XProc 3.0: An XML Pipeline Language</title>
-<pubdate>2022-09-12</pubdate>
-<bibliomisc role="final-uri">https://spec.xproc.org/3.0/xproc/</bibliomisc>
+<title>XProc 3.0+: An XML Pipeline Language</title>
+<!--<pubdate>2022-09-12</pubdate>-->
+<!--<bibliomisc role="final-uri">https://spec.xproc.org/3.0/xproc/</bibliomisc>-->
 <copyright><year>2018</year><year>2019</year><year>2020</year><year>2021</year><year>2022</year>
 <holder>the Contributors to the XProc 3.0 Specification</holder> 
 </copyright>
@@ -21,8 +21,10 @@
             xlink:href="https://www.w3.org/community/xproc-next/">XProc Next</bibliomisc>
 
 <bibliorelation type="isformatof" xlink:href="specification.xml">XML</bibliorelation>
+<!--
 <bibliorelation type="isformatof" xlink:href="xproc_a4.pdf">PDF (A4)</bibliorelation>
 <bibliorelation type="isformatof" xlink:href="xproc_letter.pdf">PDF (US Letter)</bibliorelation>
+-->
 <authorgroup>
   <author>
     <personname>Norman Walsh</personname>
@@ -69,6 +71,12 @@ steps are executed.</para>
   (<link xlink:href="mailto:xproc-dev-request@w3.org?subject=subscribe">subscribe</link>,
   <link xlink:href="https://lists.w3.org/Archives/Public/xproc-dev/">archives</link>).
   </para>
+
+<note role="editorial">
+<para>This draft is the “editor’s working draft” and includes changes made
+after the XProc 3.0 specification was released.
+</para>
+</note>
 
 <para>This document is derived from
 <link xlink:href="https://www.w3.org/TR/2010/REC-xproc-20100511/">XProc:


### PR DESCRIPTION
This just takes out some of the "final" markup, restores the note about the fact that it's an editorial draft, and makes diffs against the 3.0 spec instead of the last call draft.