### PR TITLE
Defined err:XD0083, expression fell down, went boom!

### DIFF
--- a/xproc/src/main/xml/specification.xml
+++ b/xproc/src/main/xml/specification.xml
@@ -4242,6 +4242,14 @@ attribute">extension attributes</glossterm>.</error>
           in some way not identified more precisely in this specification.
           </para>
         </listitem>
+        <listitem>
+          <para><error code="D0083">It is a <glossterm>dynamic error</glossterm> if an expression
+          in the pipeline is cannot be evaluated (because of errors in expression syntax,
+          references to unbound namespace prefixes, references to unknown variables or functions,
+          etc.).</error>
+          This is a general error code indicating that dynamic expression evaluation failed for
+          some reason not identified more precisely in this specification.</para>
+        </listitem>
       </itemizedlist>
       <para>If an XProc processor can determine statically that a dynamic error will
           <emphasis>always</emphasis> occur, it <rfc2119>may</rfc2119> report that error statically


### PR DESCRIPTION
Fix #1117 